### PR TITLE
feat: Add Android mining-only mode support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,3 +191,75 @@ jobs:
               gh release upload ${{ github.ref_name }} "artifacts/$NEW_NAME" --repo ${{ github.repository }} --clobber
             fi
           done
+
+  build-android:
+    name: Build (Android)
+    needs: create-release
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Android build is experimental - don't fail the whole release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: web-wallet/package-lock.json
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK
+        run: |
+          sdkmanager --install "ndk;27.0.11718014"
+          echo "NDK_HOME=$ANDROID_HOME/ndk/27.0.11718014" >> $GITHUB_ENV
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './web-wallet/src-tauri -> target'
+
+      - name: Install web-wallet dependencies
+        working-directory: web-wallet
+        run: npm ci
+
+      - name: Initialize Android project
+        working-directory: web-wallet
+        run: npx tauri android init
+
+      - name: Build Android APK
+        working-directory: web-wallet
+        run: npx tauri android build --apk
+
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Upload Android APK
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          APK_DIR="web-wallet/src-tauri/gen/android/app/build/outputs/apk/universal/release"
+          mkdir -p artifacts
+
+          # Find and rename APK
+          for f in "$APK_DIR/"*.apk; do
+            if [ -f "$f" ]; then
+              NEW_NAME="Phoenix-PoCX-Miner-${VERSION}-Android.apk"
+              cp "$f" "artifacts/$NEW_NAME"
+              gh release upload ${{ github.ref_name }} "artifacts/$NEW_NAME" --repo ${{ github.repository }} --clobber
+            fi
+          done

--- a/web-wallet/package-lock.json
+++ b/web-wallet/package-lock.json
@@ -34,6 +34,7 @@
         "@tauri-apps/plugin-updater": "^2.5.1",
         "angularx-qrcode": "^21.0.4",
         "rxjs": "~7.8.2",
+        "tauri-plugin-android-fs-api": "^24.1.0",
         "tslib": "^2.8.1",
         "zone.js": "^0.16.0"
       },
@@ -15309,6 +15310,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tauri-plugin-android-fs-api": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/tauri-plugin-android-fs-api/-/tauri-plugin-android-fs-api-24.1.0.tgz",
+      "integrity": "sha512-wcSlKxcU9fUuwp+7kKQhm7drTAAh6bnHM602FWdfH9IUZptoJ9EmeI9eirncXchF876SroCpOLWny8XrYevwQA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@tauri-apps/api": "^2.0.0"
       }
     },
     "node_modules/terser": {

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -24,6 +24,7 @@
     "@tauri-apps/plugin-notification": "^2.2.2",
     "@tauri-apps/plugin-opener": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.5.1",
+    "tauri-plugin-android-fs-api": "^24.1.0",
     "@angular/animations": "^21.0.8",
     "@angular/cdk": "^21.0.5",
     "@angular/common": "^21.0.8",

--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -3673,6 +3673,7 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tauri-plugin-android-fs",
  "tauri-plugin-dialog",
  "tauri-plugin-http",
  "tauri-plugin-notification",
@@ -5325,6 +5326,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_async"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b815ef8e053247ad785b136d233ee9c9872eeda5319f2719d57cac88270c3dd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5589,6 +5601,25 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.10+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-android-fs"
+version = "24.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "932123b6e889f68bc01b61b72b67f5226314c3f7227d3669baacc4b7f160d860"
+dependencies = [
+ "base64 0.22.1",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sync_async",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -76,6 +76,9 @@ windows-sys = { version = "0.59", features = [
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
 
+[target.'cfg(target_os = "android")'.dependencies]
+tauri-plugin-android-fs = "24"
+
 [profile.release]
 panic = "abort"
 codegen-units = 1

--- a/web-wallet/src-tauri/nsis/hooks.nsi
+++ b/web-wallet/src-tauri/nsis/hooks.nsi
@@ -1,0 +1,26 @@
+; Custom NSIS hooks for Phoenix PoCX Wallet
+; This script adds a "Phoenix PoCX Miner" shortcut alongside the main wallet shortcut
+
+!macro NSIS_HOOK_POSTINSTALL
+  ; Create Mining-only mode shortcuts
+  ; Start Menu shortcut (in same folder as main app)
+  StrCmp $AppStartMenuFolder "" create_miner_shortcut_root create_miner_shortcut_folder
+
+  create_miner_shortcut_folder:
+    CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\Phoenix PoCX Miner.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "--mining-only"
+    Goto create_miner_desktop
+
+  create_miner_shortcut_root:
+    CreateShortcut "$SMPROGRAMS\Phoenix PoCX Miner.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "--mining-only"
+
+  create_miner_desktop:
+    ; Desktop shortcut for mining mode
+    CreateShortcut "$DESKTOP\Phoenix PoCX Miner.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "--mining-only"
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  ; Remove Mining-only mode shortcuts during uninstall
+  Delete "$SMPROGRAMS\$AppStartMenuFolder\Phoenix PoCX Miner.lnk"
+  Delete "$SMPROGRAMS\Phoenix PoCX Miner.lnk"
+  Delete "$DESKTOP\Phoenix PoCX Miner.lnk"
+!macroend

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -55,8 +55,12 @@
     },
     "windows": {
       "nsis": {
-        "installMode": "currentUser"
+        "installMode": "currentUser",
+        "installerHooks": "nsis/hooks.nsi"
       }
+    },
+    "android": {
+      "minSdkVersion": 24
     }
   },
   "plugins": {

--- a/web-wallet/src/app/app.config.ts
+++ b/web-wallet/src/app/app.config.ts
@@ -18,8 +18,19 @@ import { reducers, metaReducers, effects } from './store';
 import { CookieAuthService } from './core/auth/cookie-auth.service';
 import { I18nService, CustomPaginatorIntl } from './core/i18n';
 import { PlatformService } from './core/services/platform.service';
+import { AppModeService } from './core/services/app-mode.service';
 import { SettingsActions, selectNodeConfig } from './store/settings';
 import { NodeService } from './node';
+
+/**
+ * Initialize app mode from launch arguments (--mining-only flag).
+ * Must run early to determine routing behavior.
+ */
+function initializeAppMode(appMode: AppModeService): () => Promise<void> {
+  return async () => {
+    await appMode.initializeMode();
+  };
+}
 
 /**
  * Initialize platform and settings at app startup.
@@ -88,6 +99,14 @@ export const appConfig: ApplicationConfig = {
       provide: APP_INITIALIZER,
       useFactory: initializeI18n,
       deps: [I18nService, HttpClient],
+      multi: true,
+    },
+
+    // App mode initialization (detect --mining-only flag)
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeAppMode,
+      deps: [AppModeService],
       multi: true,
     },
 

--- a/web-wallet/src/app/core/guards/index.ts
+++ b/web-wallet/src/app/core/guards/index.ts
@@ -1,2 +1,3 @@
 export { authGuard, noAuthGuard } from './auth.guard';
 export { nodeSetupGuard } from './node-setup.guard';
+export { miningOnlyGuard, notMiningOnlyGuard } from './mining-only.guard';

--- a/web-wallet/src/app/core/guards/mining-only.guard.ts
+++ b/web-wallet/src/app/core/guards/mining-only.guard.ts
@@ -1,0 +1,35 @@
+import { inject } from '@angular/core';
+import { Router, CanActivateFn } from '@angular/router';
+import { AppModeService } from '../services/app-mode.service';
+
+/**
+ * MiningOnlyGuard allows access only when the app is in mining-only mode.
+ * Used to protect routes that should only be accessible in mining-only mode.
+ */
+export const miningOnlyGuard: CanActivateFn = () => {
+  const appMode = inject(AppModeService);
+  const router = inject(Router);
+
+  if (appMode.isMiningOnly()) {
+    return true;
+  }
+
+  // Redirect to normal auth flow if not in mining-only mode
+  return router.createUrlTree(['/auth']);
+};
+
+/**
+ * NotMiningOnlyGuard allows access only when the app is NOT in mining-only mode.
+ * Used to protect wallet routes from being accessed in mining-only mode.
+ */
+export const notMiningOnlyGuard: CanActivateFn = () => {
+  const appMode = inject(AppModeService);
+  const router = inject(Router);
+
+  if (!appMode.isMiningOnly()) {
+    return true;
+  }
+
+  // Redirect to miner route if in mining-only mode
+  return router.createUrlTree(['/miner']);
+};

--- a/web-wallet/src/app/core/services/app-mode.service.ts
+++ b/web-wallet/src/app/core/services/app-mode.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { ElectronService } from './electron.service';
+
+/**
+ * AppModeService manages the application launch mode.
+ *
+ * The app can be launched in two modes:
+ * - 'wallet' (default): Full wallet functionality with sidenav
+ * - 'mining': Mining-only mode with simplified UI
+ *
+ * Mining-only mode is activated by:
+ * - Passing --mining-only or -m flag when launching the desktop application
+ * - Running on Android (always mining-only, no local node support)
+ */
+@Injectable({ providedIn: 'root' })
+export class AppModeService {
+  private readonly electronService = inject(ElectronService);
+
+  /** Whether the app is in mining-only mode */
+  readonly isMiningOnly = signal(false);
+
+  /** Whether running on a mobile platform (Android) - no local node support */
+  readonly isMobile = signal(false);
+
+  /** Whether the mode has been initialized (internal guard) */
+  private readonly _isInitialized = signal(false);
+
+  /**
+   * Initialize the app mode from launch arguments.
+   * Should be called during app initialization (APP_INITIALIZER).
+   */
+  async initializeMode(): Promise<void> {
+    if (this._isInitialized()) {
+      return;
+    }
+
+    if (this.electronService.isDesktop) {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+
+        // Check platform first to detect mobile
+        const platform = await invoke<string>('get_platform');
+        if (platform === 'android') {
+          this.isMobile.set(true);
+        }
+
+        // Get launch mode (always 'mining' on Android)
+        const mode = await invoke<string>('get_launch_mode');
+        if (mode === 'mining') {
+          this.isMiningOnly.set(true);
+        }
+      } catch (error) {
+        console.error('Failed to get launch mode:', error);
+        // Default to wallet mode on error
+      }
+    }
+
+    this._isInitialized.set(true);
+  }
+}

--- a/web-wallet/src/app/core/services/index.ts
+++ b/web-wallet/src/app/core/services/index.ts
@@ -2,3 +2,4 @@
 export { ElectronService } from './electron.service';
 export { PlatformService } from './platform.service';
 export type { Platform } from './platform.service';
+export { AppModeService } from './app-mode.service';

--- a/web-wallet/src/app/core/services/platform.service.ts
+++ b/web-wallet/src/app/core/services/platform.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { ElectronService } from './electron.service';
 
-export type Platform = 'win32' | 'darwin' | 'linux' | 'browser';
+export type Platform = 'win32' | 'darwin' | 'linux' | 'android' | 'browser';
 
 /**
  * PlatformService provides platform detection and environment information.
@@ -61,6 +61,13 @@ export class PlatformService {
    */
   get isLinux(): boolean {
     return this._platform === 'linux';
+  }
+
+  /**
+   * Check if running on Android
+   */
+  get isAndroid(): boolean {
+    return this._platform === 'android';
   }
 
   /**

--- a/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
+++ b/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
@@ -1,0 +1,327 @@
+import { Component, inject } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { I18nPipe, I18nService, LANGUAGES, Language } from '../../core/i18n';
+import { MiningService } from '../../mining/services';
+
+/**
+ * MiningLayoutComponent provides a simplified layout for mining-only mode.
+ *
+ * Features:
+ * - Minimal header with app name and status indicators
+ * - No sidenav (no wallet navigation)
+ * - Full-width content area for mining dashboard
+ * - Language selector and exit button
+ */
+@Component({
+  selector: 'app-mining-layout',
+  standalone: true,
+  imports: [
+    RouterModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule,
+    MatMenuModule,
+    MatTooltipModule,
+    I18nPipe,
+  ],
+  template: `
+    <div class="mining-layout">
+      <!-- Simplified Header -->
+      <mat-toolbar class="mining-toolbar">
+        <div class="toolbar-content">
+          <!-- Left: Logo and App Name -->
+          <div class="toolbar-left">
+            <img src="assets/images/logos/phoenix_v.svg" alt="Phoenix PoCX" class="logo" />
+            <span class="app-name">Phoenix PoCX Miner</span>
+
+            <div class="toolbar-separator"></div>
+
+            <!-- Status Indicators -->
+            <div class="status-indicators">
+              <!-- Miner Indicator -->
+              @if (miningService.isConfigured()) {
+                <div
+                  class="status-indicator"
+                  [matTooltip]="
+                    miningService.minerRunning()
+                      ? ('miner_running' | i18n)
+                      : ('miner_stopped' | i18n)
+                  "
+                >
+                  <mat-icon [class.active]="miningService.minerRunning()">hardware</mat-icon>
+                </div>
+              }
+
+              <!-- Plotter Indicator -->
+              @if (miningService.plotterUIState() !== 'complete') {
+                <div
+                  class="status-indicator"
+                  [matTooltip]="
+                    miningService.plotterUIState() === 'plotting' ||
+                    miningService.plotterUIState() === 'stopping'
+                      ? ('plotting_active' | i18n)
+                      : ('plotting_pending' | i18n)
+                  "
+                >
+                  <mat-icon
+                    [class.active]="
+                      miningService.plotterUIState() === 'plotting' ||
+                      miningService.plotterUIState() === 'stopping'
+                    "
+                    >storage</mat-icon
+                  >
+                </div>
+              }
+            </div>
+          </div>
+
+          <!-- Right: Language and Exit -->
+          <div class="toolbar-right">
+            <!-- Mining Setup Button -->
+            <button
+              mat-button
+              class="action-button icon-button"
+              [routerLink]="['/miner/setup']"
+              [matTooltip]="'mining_setup' | i18n"
+            >
+              <mat-icon class="secondary-text">settings</mat-icon>
+            </button>
+
+            <div class="toolbar-separator"></div>
+
+            <!-- Language Selector -->
+            <button mat-button [matMenuTriggerFor]="langMenu" class="action-button lang-button">
+              <span class="lang-name-text">{{ i18n.currentLanguageName() }}</span>
+              <mat-icon class="lang-icon secondary-text">language</mat-icon>
+            </button>
+
+            <mat-menu #langMenu="matMenu">
+              @for (lang of languages; track lang.code) {
+                <button mat-menu-item (click)="setLanguage(lang)">
+                  {{ lang.nativeName }}
+                </button>
+              }
+            </mat-menu>
+          </div>
+        </div>
+      </mat-toolbar>
+
+      <!-- Content Area -->
+      <div class="mining-content">
+        <router-outlet></router-outlet>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .mining-layout {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        background: #eaf0f6;
+      }
+
+      .mining-toolbar {
+        position: relative;
+        background-color: white !important;
+        color: rgba(0, 0, 0, 0.87) !important;
+        padding: 0;
+        height: 64px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        flex-shrink: 0;
+      }
+
+      .toolbar-content {
+        display: flex;
+        width: 100%;
+        height: 100%;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .toolbar-left {
+        display: flex;
+        align-items: center;
+        height: 100%;
+        padding-left: 16px;
+        gap: 12px;
+      }
+
+      .logo {
+        width: 32px;
+        height: 32px;
+      }
+
+      .app-name {
+        font-size: 16px;
+        font-weight: 500;
+        color: rgba(0, 0, 0, 0.87);
+      }
+
+      .toolbar-right {
+        display: flex;
+        align-items: center;
+        height: 100%;
+      }
+
+      .toolbar-separator {
+        height: 64px;
+        width: 1px;
+        background: rgba(0, 0, 0, 0.12);
+      }
+
+      .action-button {
+        min-width: 64px;
+        height: 64px;
+        border-radius: 0;
+      }
+
+      .icon-button {
+        min-width: 56px;
+        width: 56px;
+        padding: 0 !important;
+        justify-content: center !important;
+
+        mat-icon {
+          font-size: 24px;
+          width: 24px;
+          height: 24px;
+          margin: 0 !important;
+        }
+      }
+
+      .secondary-text {
+        color: rgba(0, 0, 0, 0.54);
+      }
+
+      .status-indicators {
+        display: flex;
+        align-items: center;
+        height: 64px;
+        padding: 0 12px;
+        gap: 8px;
+      }
+
+      .status-indicator {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        mat-icon {
+          font-size: 22px;
+          width: 22px;
+          height: 22px;
+          color: rgba(0, 0, 0, 0.25);
+          transition: color 0.2s ease;
+
+          &.active {
+            color: #4caf50;
+          }
+        }
+      }
+
+      .lang-button {
+        .lang-name-text {
+          color: rgba(0, 0, 0, 0.87);
+          display: inline;
+        }
+
+        .lang-icon {
+          display: none;
+          font-size: 24px;
+          width: 24px;
+          height: 24px;
+        }
+
+        @media (max-width: 600px) {
+          .lang-name-text {
+            display: none;
+          }
+
+          .lang-icon {
+            display: inline;
+          }
+        }
+      }
+
+      .mining-content {
+        flex: 1;
+        overflow: auto;
+        display: flex;
+        flex-direction: column;
+      }
+
+      :host-context(.dark-theme) {
+        .mining-layout {
+          background: #303030;
+        }
+
+        .mining-toolbar {
+          background-color: #424242 !important;
+          color: white !important;
+        }
+
+        .app-name {
+          color: white;
+        }
+
+        .secondary-text {
+          color: rgba(255, 255, 255, 0.7);
+        }
+
+        .toolbar-separator {
+          background: rgba(255, 255, 255, 0.12);
+        }
+      }
+
+      @media (max-width: 600px) {
+        .mining-toolbar {
+          height: 56px;
+        }
+
+        .action-button {
+          min-width: 48px;
+          height: 56px;
+        }
+
+        .icon-button {
+          min-width: 48px;
+          width: 48px;
+
+          mat-icon {
+            font-size: 22px;
+            width: 22px;
+            height: 22px;
+          }
+        }
+
+        .toolbar-separator {
+          height: 56px;
+        }
+
+        .app-name {
+          display: none;
+        }
+
+        .status-indicators {
+          height: 56px;
+        }
+      }
+    `,
+  ],
+})
+export class MiningLayoutComponent {
+  readonly i18n = inject(I18nService);
+  readonly miningService = inject(MiningService);
+
+  languages: Language[] = LANGUAGES;
+
+  setLanguage(lang: Language): void {
+    this.i18n.setLanguageByCode(lang.code);
+  }
+}

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -117,20 +117,6 @@ import { MiningService } from '../../mining/services';
             }
           </div>
 
-          <div class="toolbar-separator"></div>
-
-          <!-- Settings Button (gear icon) -->
-          <button
-            mat-button
-            class="action-button icon-button"
-            [routerLink]="['/settings']"
-            [matTooltip]="'settings' | i18n"
-          >
-            <mat-icon class="secondary-text">settings</mat-icon>
-          </button>
-
-          <div class="toolbar-separator"></div>
-
           <div class="logo">
             <img
               class="logo-icon"
@@ -214,6 +200,18 @@ import { MiningService } from '../../mining/services';
 
             <div class="toolbar-separator"></div>
           }
+
+          <!-- Settings Button (gear icon) -->
+          <button
+            mat-button
+            class="action-button icon-button"
+            [routerLink]="['/settings']"
+            [matTooltip]="'settings' | i18n"
+          >
+            <mat-icon class="secondary-text">settings</mat-icon>
+          </button>
+
+          <div class="toolbar-separator"></div>
 
           <!-- Language Selector -->
           <button mat-button [matMenuTriggerFor]="langMenu" class="action-button lang-button">

--- a/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
+++ b/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
@@ -7,6 +7,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { I18nPipe, I18nService } from '../../../core/i18n';
+import { AppModeService } from '../../../core/services/app-mode.service';
 import { MiningService } from '../../services';
 import {
   MiningStatus,
@@ -555,7 +556,7 @@ import { PlanViewerDialogComponent } from '../../components/plan-viewer-dialog/p
             <div class="first-run-card">
               <h2>{{ 'mining_welcome' | i18n }}</h2>
               <p>{{ 'mining_welcome_message' | i18n }}</p>
-              <button class="btn btn-primary" routerLink="/mining/setup">
+              <button class="btn btn-primary" [routerLink]="setupRoute()">
                 {{ 'mining_get_started' | i18n }}
               </button>
             </div>
@@ -1513,6 +1514,12 @@ export class MiningDashboardComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly dialog = inject(MatDialog);
   private readonly i18n = inject(I18nService);
+  private readonly appMode = inject(AppModeService);
+
+  /** Setup route path - differs between wallet mode and mining-only mode */
+  readonly setupRoute = computed(() =>
+    this.appMode.isMiningOnly() ? '/miner/setup' : '/mining/setup'
+  );
 
   readonly miningStatus = signal<MiningStatus | null>(null);
   readonly plottingStatus = signal<PlottingStatus | null>(null);
@@ -2195,7 +2202,7 @@ export class MiningDashboardComponent implements OnInit, OnDestroy {
     await Promise.all(loadPromises);
 
     // Navigate to setup with step parameter
-    this.router.navigate(['/mining/setup'], { queryParams: { step } });
+    this.router.navigate([this.setupRoute()], { queryParams: { step } });
   }
 
   // Plotter methods


### PR DESCRIPTION
## Summary

- Add mining-only mode variant with `--mining-only` or `-m` flag for desktop
- Android always runs in mining-only mode (no local node support)
- Simplified UI layout for mining-only interface (MiningLayoutComponent)
- Native Android folder picker via `tauri-plugin-android-fs`
- Android APK build added to release workflow

## Changes

### New Files
- `MiningLayoutComponent` - Minimal header layout for mining mode
- `AppModeService` - Launch mode detection service
- `miningOnlyGuard` / `notMiningOnlyGuard` - Route protection guards
- `nsis/hooks.nsi` - Creates "Phoenix PoCX Miner" shortcut with `-m` flag

### Modified
- `lib.rs` - Conditional plugin loading, Android platform detection
- `release.yml` - Added Android build job
- `setup-wizard.component.ts` - Android folder picker support
- `toolbar.component.ts` - Moved settings button, removed separator

## Test plan

- [ ] Desktop: Run with `--mining-only` flag, verify simplified UI
- [ ] Desktop: Run normally, verify full wallet UI
- [ ] Windows installer: Verify both shortcuts created
- [ ] CI: Android build job runs (experimental, may fail first time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)