### PR TITLE
Fix node-setup redirect race on cold start in release builds

### DIFF
--- a/web-wallet/src/app/node/services/node.service.ts
+++ b/web-wallet/src/app/node/services/node.service.ts
@@ -437,7 +437,17 @@ export class NodeService {
   async startNode(): Promise<number | null> {
     try {
       this._error.set(null);
-      this._status.set(createDefaultNodeStatus());
+      this._status.update(s => ({
+        ...s,
+        running: false,
+        blocks: 0,
+        headers: 0,
+        peers: 0,
+        synced: false,
+        syncProgress: 0,
+        pid: null,
+        error: null,
+      }));
       this._nodeStarting.next();
       const pid = await invoke<number>('start_managed_node');
       console.log('NodeService: Started node with PID:', pid);
@@ -490,7 +500,17 @@ export class NodeService {
   async restartNode(): Promise<number | null> {
     try {
       this._error.set(null);
-      this._status.set(createDefaultNodeStatus());
+      this._status.update(s => ({
+        ...s,
+        running: false,
+        blocks: 0,
+        headers: 0,
+        peers: 0,
+        synced: false,
+        syncProgress: 0,
+        pid: null,
+        error: null,
+      }));
       this._nodeStarting.next();
       const pid = await invoke<number>('restart_managed_node');
       console.log('NodeService: Restarted node with PID:', pid);


### PR DESCRIPTION
## Summary
- Fixes a release-only bug where, after a full shutdown (phoenix + node) and cold restart, the app briefly showed "Starting node..." then landed on `/node/setup` instead of the wallet selector. Manual nav to Select Wallet → Manage Wallets worked.
- Root cause: `startNode()` / `restartNode()` called `_status.set(createDefaultNodeStatus())` which reset `installed → false` and `network → mainnet`. In release, this reset could race `nodeSetupGuard`'s `await nodeService.initialize()`, so the guard read `isInstalled() === false` during the `invoke('start_managed_node')` round-trip and redirected to setup. In dev, webpack-dev-server startup slack hid the race.
- Fix: clear only transient runtime fields (`running`, `blocks`, `headers`, `peers`, `synced`, `syncProgress`, `pid`, `error`) and preserve config-derived fields (`mode`, `installed`, `network`, `version`).

## Test plan
- [x] Release build: fresh start with managed node + testnet → lands on wallet selector, not `/node/setup`
- [ ] Dev build: no regression in startup flow
- [ ] Restart node via settings → status fields repopulate correctly, no redirect
- [ ] External node mode: no regression (startNode/restartNode not called)
- [ ] Mining-only mode: no regression (guard skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)