### PR TITLE
Fix GPU-only plotting regression after pocx 1.0.2 bump

### DIFF
--- a/web-wallet/src-tauri/src/mining/commands.rs
+++ b/web-wallet/src-tauri/src/mining/commands.rs
@@ -729,11 +729,12 @@ pub async fn run_device_benchmark(
             device_id.clone()
         };
 
+        // GPU-only: don't call .cpu_threads() — pocx_plotter_v2 1.0.2 rejects
+        // explicit .cpu_threads(0); leaving it at default disables CPU.
         pocx_plotter_v2::PlotterTaskBuilder::new()
             .address(&address)
             .map(|b| {
                 b.add_output(temp_dir.to_string_lossy().to_string(), warps, 1)
-                    .cpu_threads(0) // Disable CPU
                     .gpu(gpu_id_with_threads)
                     .compression(1)
                     .escalate(escalation)

--- a/web-wallet/src-tauri/src/mining/plotter.rs
+++ b/web-wallet/src-tauri/src/mining/plotter.rs
@@ -1078,16 +1078,21 @@ fn build_plotter_task_batch(
     log::info!("  Simulation mode: {}", config.simulation_mode);
     log::info!("========================================");
 
-    // Build the task
+    // Build the task. Only call .cpu_threads() when CPU is actually enabled;
+    // pocx_plotter_v2 1.0.2 rejects explicit .cpu_threads(0), so GPU-only
+    // configs must leave it at its default.
     let mut builder = pocx_plotter_v2::PlotterTaskBuilder::new()
         .address(address)
         .map_err(|e| format!("Invalid address: {}", e))?
-        .cpu_threads(cpu_threads)
         .compression(config.compression_level)
         .escalate(config.escalation)
         .direct_io(config.direct_io)
         .async_write(config.async_write)
         .quiet(false); // Allow plotter to log
+
+    if cpu_threads > 0 {
+        builder = builder.cpu_threads(cpu_threads);
+    }
 
     // Add all outputs
     for output in outputs {


### PR DESCRIPTION
## Summary
- Regression from #41: \`pocx_plotter_v2\` 1.0.2 tightened validation so that \`.cpu_threads(0)\` is now explicitly rejected with \`"cpu_threads must be greater than 0 when CPU participation is requested"\`. Per [pocx#47](https://github.com/PoC-Consortium/pocx/pull/47), GPU-only configs must **leave \`cpu_threads\` at its default** rather than passing 0.
- Phoenix was passing 0 in two places:
  - \`mining/plotter.rs:1085\` — called \`.cpu_threads(cpu_threads)\` unconditionally; \`cpu_threads\` resolves to 0 when the CPU device isn't enabled.
  - \`mining/commands.rs:736\` — explicit \`.cpu_threads(0) // Disable CPU\` in the GPU benchmark path.
- Fix: in \`plotter.rs\`, only call \`.cpu_threads()\` when \`cpu_threads > 0\`. In \`commands.rs\`, drop the explicit \`.cpu_threads(0)\` line from the GPU branch.

## Test plan
- [x] \`cargo check\` clean
- [ ] GPU-only plot: completes without the \`cpu_threads must be greater than 0\` error
- [ ] CPU-only plot: unchanged behavior (cpu_threads passed through as before)
- [ ] CPU + GPU combined plot: unchanged behavior
- [ ] Benchmark on GPU device: builds and runs without validation error
- [ ] Benchmark on CPU device: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)