### PR TITLE
Fix locked wallet: prompt passphrase before send/assign

### DIFF
--- a/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
+++ b/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
@@ -13,10 +13,12 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { takeUntil, skip } from 'rxjs/operators';
 import { I18nPipe, I18nService } from '../../../../core/i18n';
+import { PassphraseDialogComponent } from '../../../../shared';
+import type { PassphraseDialogResult } from '../../../../shared';
 import { NotificationService } from '../../../../shared/services';
 import { WalletManagerService } from '../../../../bitcoin/services/wallet/wallet-manager.service';
 import { WalletService } from '../../../../bitcoin/services/wallet/wallet.service';
@@ -1153,6 +1155,7 @@ export class ForgingAssignmentComponent implements OnInit, OnDestroy {
   private readonly blockchainRpc = inject(BlockchainRpcService);
   private readonly blockchainState = inject(BlockchainStateService);
   private readonly miningRpc = inject(MiningRpcService);
+  private readonly dialog = inject(MatDialog);
   private readonly destroy$ = new Subject<void>();
 
   // Tab selection
@@ -1402,6 +1405,21 @@ export class ForgingAssignmentComponent implements OnInit, OnDestroy {
     }
   }
 
+  private async ensureWalletUnlocked(walletName: string): Promise<boolean> {
+    const info = await this.walletRpc.getWalletInfo(walletName);
+    if (info.unlocked_until === undefined || info.unlocked_until > 0) {
+      return true; // not encrypted, or already unlocked
+    }
+    const dialogRef = this.dialog.open(PassphraseDialogComponent, {
+      width: '400px',
+      data: { walletName, timeout: 60 },
+    });
+    const result: PassphraseDialogResult | null = await dialogRef.afterClosed().toPromise();
+    if (!result) return false; // user cancelled
+    await this.walletRpc.walletPassphrase(walletName, result.passphrase, result.timeout);
+    return true;
+  }
+
   async onSubmit(): Promise<void> {
     if (!this.canSubmit()) return;
 
@@ -1442,6 +1460,11 @@ export class ForgingAssignmentComponent implements OnInit, OnDestroy {
     this.isSubmitting.set(true);
 
     try {
+      if (!(await this.ensureWalletUnlocked(walletName))) {
+        this.isSubmitting.set(false);
+        return;
+      }
+
       const feeRate = this.getSelectedFeeRate();
 
       if (this.currentMode === 'create') {

--- a/web-wallet/src/app/features/send/pages/send/send.component.ts
+++ b/web-wallet/src/app/features/send/pages/send/send.component.ts
@@ -25,7 +25,8 @@ interface Contact {
   notes?: string;
   createdAt: number;
 }
-import { AddressDisplayComponent } from '../../../../shared';
+import { AddressDisplayComponent, PassphraseDialogComponent } from '../../../../shared';
+import type { PassphraseDialogResult } from '../../../../shared';
 import { NotificationService } from '../../../../shared/services';
 import { WalletManagerService } from '../../../../bitcoin/services/wallet/wallet-manager.service';
 import { WalletService } from '../../../../bitcoin/services/wallet/wallet.service';
@@ -1271,6 +1272,21 @@ export class SendComponent implements OnInit, OnDestroy {
     }
   }
 
+  private async ensureWalletUnlocked(walletName: string): Promise<boolean> {
+    const info = await this.walletRpc.getWalletInfo(walletName);
+    if (info.unlocked_until === undefined || info.unlocked_until > 0) {
+      return true; // not encrypted, or already unlocked
+    }
+    const dialogRef = this.dialog.open(PassphraseDialogComponent, {
+      width: '400px',
+      data: { walletName, timeout: 60 },
+    });
+    const result: PassphraseDialogResult | null = await dialogRef.afterClosed().toPromise();
+    if (!result) return false; // user cancelled
+    await this.walletRpc.walletPassphrase(walletName, result.passphrase, result.timeout);
+    return true;
+  }
+
   async sendTransaction(): Promise<void> {
     const walletName = this.walletManager.activeWallet;
     if (!walletName || !this.amount) return;
@@ -1279,6 +1295,10 @@ export class SendComponent implements OnInit, OnDestroy {
     this.sendError.set(null);
 
     try {
+      if (!(await this.ensureWalletUnlocked(walletName))) {
+        this.sending.set(false);
+        return;
+      }
       // Use explicit fee_rate when available (custom or estimated), conf_target as fallback
       const feeRate =
         this.selectedFeeOption?.label === 'fee_custom'


### PR DESCRIPTION
## Summary
- Sending BTC or creating/revoking forging assignments on a locked encrypted wallet showed a raw `RPC Error -13` instead of prompting for the passphrase
- Both flows now check `getwalletinfo.unlocked_until` before the operation and open the existing `PassphraseDialogComponent` when the wallet is locked
- If the user cancels the dialog, the operation is aborted gracefully

## Test plan
- [ ] Encrypt a wallet, lock it, attempt to send — passphrase dialog should appear
- [ ] Enter correct passphrase → transaction proceeds normally
- [ ] Cancel the dialog → operation aborts, no error shown
- [ ] Repeat for forging assignment create and revoke
- [ ] Verify unencrypted wallets are unaffected (no dialog shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)