### PR TITLE
Label send confirm row as "Estimated Fee"

### DIFF
--- a/web-wallet/src/app/features/send/pages/send/send.component.ts
+++ b/web-wallet/src/app/features/send/pages/send/send.component.ts
@@ -301,7 +301,7 @@ interface FeeOption {
                   >
                 </div>
                 <div class="summary-row">
-                  <span class="summary-label">{{ 'fee' | i18n }}:</span>
+                  <span class="summary-label">{{ 'estimated_fee' | i18n }}:</span>
                   <span class="summary-value"
                     >{{ selectedFeeOption?.estimatedFee ?? 0 | number: '1.8-8' }}
                     {{ currencySymbol() }}</span


### PR DESCRIPTION
## Summary
- The confirm summary row previously read **"Fee:"** next to the fee value, implying an exact amount. The number is actually `feeRate × 170 vB` (hardcoded P2WPKH 1-in-2-out assumption), so the real fee the node computes via coin selection can differ.
- Swap the label to the existing `estimated_fee` i18n key to make the approximation visible. Already translated in all 26 locales — zero string work.
- "Total:" is left unchanged since it's the amount leaving the wallet regardless of how the exact fee splits.

Follow-up (tracked separately, post-genesis): replace the 170 vB shortcut with a `walletcreatefundedpsbt` call so the displayed fee matches the transaction that will actually be broadcast, matching Bitcoin-Qt behaviour.

## Test plan
- [ ] Open the send dialog, fill in amount + address, reach the confirm summary.
- [ ] Verify the row label reads "Estimated Fee:" (EN) and localizes correctly in at least one non-EN locale.
- [ ] Verify the fee section above still reads "Estimated Fee" (unchanged).
- [ ] Verify "Total:" is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)