### PR TITLE
Label the derived plotting address so wallet surfaces see it

### DIFF
--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -2920,7 +2920,20 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
         // Derive address at index 0 (first receive address)
         const addresses = await this.walletRpc.deriveAddresses(bip84Descriptor.desc, [0, 0]);
         if (addresses.length > 0) {
-          this.walletAddress.set(addresses[0]);
+          const addr = addresses[0];
+          this.walletAddress.set(addr);
+
+          // `deriveaddresses` is pure descriptor math and bypasses Core's label
+          // registry. Without a label the address won't appear in
+          // getaddressesbylabel(""), which the forging-assignment dropdown
+          // uses to list wallet addresses. Set an empty label (matching what
+          // getnewaddress would produce) so the plotting address is a
+          // first-class wallet address everywhere. The address is ismine via
+          // the active descriptor, so setlabel is guaranteed to succeed.
+          const info = await this.walletRpc.getAddressInfo(walletName, addr);
+          if (info.labels.length === 0) {
+            await this.walletRpc.setLabel(walletName, addr, '');
+          }
           return;
         }
       }


### PR DESCRIPTION
## Summary

The setup wizard derives the first receive address via `deriveaddresses(desc, [0, 0])` (pure descriptor math — bypasses Core's label registry). When a user plots to that address and opens the forging-assignment page, their address is missing from the dropdown (`getaddressesbylabel("")` only returns labeled addresses), and clicking "Generate new address" returns a **different** address because index 0 now counts as used.

Fix: after deriving, call `setlabel(addr, "")` if the address isn't already labeled. The derived address belongs to the wallet's active descriptor, so `setlabel` is guaranteed to succeed.

## Test plan

- [ ] Fresh wallet → setup wizard → confirm the displayed plotting address has `labels: [""]` after save (check via `getaddressinfo` RPC or directly in a Core console).
- [ ] Receive coins to the plotting address → open forging-assignment → plotting address **is** listed in the dropdown.
- [ ] Open setup wizard a second time → no duplicate `setlabel` call (idempotent guard via `labels.length === 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)