### PR TITLE
Fire mining auto-start on mobile / mining-only launches

### DIFF
--- a/web-wallet/src/app/app.component.ts
+++ b/web-wallet/src/app/app.component.ts
@@ -181,6 +181,12 @@ export class AppComponent implements OnInit, OnDestroy {
    */
   private async initNodeService(): Promise<void> {
     if (!this.electronService.isDesktop) {
+      // Mobile / mining-only: no managed node to start, but still honour the
+      // mining auto-start preference. The desktop branch runs autoStartMining
+      // later in this method after the managed node is ready.
+      this.miningService
+        .autoStartMining()
+        .catch(err => console.error('Mining auto-start failed:', err));
       return;
     }
 


### PR DESCRIPTION
## Summary

Since rc8 the mining auto-start call has lived inside `initNodeService()`, past the early return for non-desktop platforms:

\`\`\`typescript
private async initNodeService(): Promise<void> {
  if (!this.electronService.isDesktop) {
    return;  // ← Android / mining-only exit here
  }
  // ... desktop-only node startup ...
  this.miningService.autoStartMining().catch(...);  // unreachable on mobile
}
\`\`\`

Result: the "auto-start mining" toggle persisted correctly, but the handler was never invoked on Android or mining-only launches. Manual start still worked, which masked the bug until tested on mobile. Existing bug, not a regression.

## Fix

Call `autoStartMining()` in the mobile branch before the early return. Desktop flow is untouched.

`autoStartMining()` is already guarded against missing config / empty chains or drives / miner already running, so it no-ops safely when preconditions aren't met.

## Test plan

- [ ] Android: launch with auto-start toggle enabled + chains + drives configured → mining starts automatically, activity log shows "Mining auto-started".
- [ ] Android: launch with auto-start toggle disabled → mining doesn't start.
- [ ] Desktop managed mode: unchanged — mining still auto-starts after node is ready.
- [ ] Desktop external mode: unchanged — mining still auto-starts after the init path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)