### PR TITLE
Show both Nogrod pools regardless of active network

### DIFF
--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -1011,16 +1011,12 @@ interface ChainModalData {
                   (ngModelChange)="updateChainModal('poolUrl', $event)"
                 >
                   <option value="">{{ 'setup_select_pool_placeholder' | i18n }}</option>
-                  @if (walletNetwork() === 'mainnet') {
-                    <option value="https://pool.bitcoin-pocx.org:443">
-                      Nogrod PoCX (pool.bitcoin-pocx.org)
-                    </option>
-                  }
-                  @if (walletNetwork() === 'testnet') {
-                    <option value="https://pool.testnet.bitcoin-pocx.org:443">
-                      Nogrod PoCX Testnet (pool.testnet.bitcoin-pocx.org)
-                    </option>
-                  }
+                  <option value="https://pool.bitcoin-pocx.org:443">
+                    Nogrod Mainnet (pool.bitcoin-pocx.org)
+                  </option>
+                  <option value="https://pool.testnet.bitcoin-pocx.org:443">
+                    Nogrod Testnet (pool.testnet.bitcoin-pocx.org)
+                  </option>
                 </select>
               </div>
               <ng-container *ngTemplateOutlet="authInputs"></ng-container>
@@ -3202,11 +3198,17 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
         priority: editing?.priority ?? this.chainConfigs().length + 1,
       };
     } else if (data.mode === 'pool') {
-      const poolName = data.poolUrl.includes('pool.bitcoin-pocx.org')
-        ? data.poolUrl.includes('testnet')
-          ? 'Nogrod PoCX Testnet'
-          : 'Nogrod PoCX'
-        : data.chainName || 'Pool';
+      // Match the known Nogrod endpoints so the chain shows up with a
+      // friendly name. The testnet URL contains `pool.testnet.bitcoin-pocx.org`
+      // (not `pool.bitcoin-pocx.org`), so test for the testnet variant first.
+      let poolName: string;
+      if (data.poolUrl.includes('pool.testnet.bitcoin-pocx.org')) {
+        poolName = 'Nogrod Testnet';
+      } else if (data.poolUrl.includes('pool.bitcoin-pocx.org')) {
+        poolName = 'Nogrod Mainnet';
+      } else {
+        poolName = data.chainName || 'Pool';
+      }
 
       // Parse pool URL to extract host and port
       const { transport, host, port } = this.parseUrl(data.poolUrl);


### PR DESCRIPTION
## Summary

Mining setup's chain modal was gating the Nogrod pool dropdown by `walletNetwork()` — a mainnet wallet only saw the mainnet pool and vice-versa. The network should not restrict what pools the user can *pick*; it should only affect which one actually works.

## Changes

- **Drop the network conditionals.** Both Nogrod options are always visible.
- **Rename dropdown labels** to `Nogrod Mainnet` / `Nogrod Testnet` (from `Nogrod PoCX` / `Nogrod PoCX Testnet`).
- **Fix pre-existing auto-naming bug.** The chain-name detection used `includes('pool.bitcoin-pocx.org')` as the outer match; because the testnet URL is `pool.testnet.bitcoin-pocx.org` (the `.testnet.` segment breaks that substring), picking the testnet pool fell through to the generic "Pool" label instead of "Nogrod Testnet". Restructured so testnet is tested first.

## Test plan

- [ ] Mainnet wallet → open chain modal → both Nogrod pools listed.
- [ ] Testnet wallet → open chain modal → both Nogrod pools listed.
- [ ] Select Nogrod Mainnet → chain saves with name "Nogrod Mainnet".
- [ ] Select Nogrod Testnet → chain saves with name "Nogrod Testnet" (previously fell through to "Pool").

🤖 Generated with [Claude Code](https://claude.com/claude-code)