### PR TITLE
Actually fire mining auto-start on Android (take 2)

### DIFF
--- a/web-wallet/src/app/app.component.ts
+++ b/web-wallet/src/app/app.component.ts
@@ -181,31 +181,30 @@ export class AppComponent implements OnInit, OnDestroy {
    */
   private async initNodeService(): Promise<void> {
     if (!this.electronService.isDesktop) {
-      // Mobile / mining-only: no managed node to start, but still honour the
-      // mining auto-start preference. The desktop branch runs autoStartMining
-      // later in this method after the managed node is ready.
-      this.miningService
-        .autoStartMining()
-        .catch(err => console.error('Mining auto-start failed:', err));
+      // Pure web / non-Tauri environments: no mining or aggregator backend.
       return;
     }
 
     try {
       const { invoke } = await import('@tauri-apps/api/core');
       const configExists = await invoke<boolean>('is_first_launch_complete');
-      if (!configExists) {
-        return;
-      }
 
-      const shouldStartManagedNode =
-        this.nodeService.isManaged() &&
-        this.nodeService.isInstalled() &&
-        !this.appModeService.isMiningOnly();
+      // Node setup only applies to full-wallet launches where the user
+      // configured a managed node. Mining-only (including Android) has no
+      // node_config.json by design, so `configExists` is false there — we
+      // skip the managed-node start but still reach the auto-start calls
+      // below.
+      if (configExists) {
+        const shouldStartManagedNode =
+          this.nodeService.isManaged() &&
+          this.nodeService.isInstalled() &&
+          !this.appModeService.isMiningOnly();
 
-      if (shouldStartManagedNode) {
-        await this.nodeService.ensureNodeReadyAndAuthenticated(() =>
-          this.cookieAuth.refreshCredentials()
-        );
+        if (shouldStartManagedNode) {
+          await this.nodeService.ensureNodeReadyAndAuthenticated(() =>
+            this.cookieAuth.refreshCredentials()
+          );
+        }
       }
     } catch (err) {
       console.error('Error during node startup:', err);
@@ -213,12 +212,14 @@ export class AppComponent implements OnInit, OnDestroy {
       this.isStartingNode.set(false);
     }
 
-    // Auto-start aggregator if enabled in config (after node is ready)
+    // Auto-start runs on every Tauri launch (desktop wallet, desktop
+    // mining-only, Android mining-only). Each service has its own guards
+    // — missing config, missing chains/drives, node-not-ready — so these
+    // calls no-op safely when preconditions aren't met.
     this.aggregatorService
       .autoStart()
       .catch(err => console.error('Aggregator auto-start failed:', err));
 
-    // Auto-start mining if enabled in config (after node is ready)
     this.miningService
       .autoStartMining()
       .catch(err => console.error('Mining auto-start failed:', err));


### PR DESCRIPTION
## Summary

PR #47 targeted the wrong branch. \`ElectronService.isDesktop\` returns \`true\` on Android because the check is really "is Tauri/Electron running" — the method name is misleading. Android runs Tauri, so \`!isDesktop\` never fires there, and the mobile branch I added was dead code.

The actual blocker was the \`configExists\` early return:

\`\`\`typescript
const configExists = await invoke<boolean>('is_first_launch_complete');
if (!configExists) {
  return;  // ← Android mining-only has no node_config.json, returns here
}
\`\`\`

On Android mining-only there's no \`node_config.json\` by design, so this return exited before the auto-start calls at the end of the function.

## Fix

Restructure so \`configExists\` gates only the managed-node startup, not the whole function. Auto-start calls at the end now run on every Tauri launch:

- Desktop wallet mode: node starts → auto-start fires (same as before).
- Desktop mining-only: node start skipped → auto-start fires.
- Android mining-only: no node config → managed-start skipped → auto-start fires. **This is the fix.**

Each auto-start service has its own guards (missing config, empty chains/drives, node-not-ready), so these calls no-op safely when preconditions aren't met.

Also removes the dead mobile branch from #47.

## Test plan

- [ ] Android: auto-start toggle enabled + chains + drives configured → mining actually starts on launch, activity log shows "Mining auto-started".
- [ ] Android: auto-start toggle disabled → mining doesn't start.
- [ ] Desktop wallet: unchanged behaviour.
- [ ] Desktop mining-only: auto-start works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)