### PR TITLE
Seed-keyed Resume tasks (fix silent-fail on duplicate .tmps)

### DIFF
--- a/web-wallet/src-tauri/src/mining/drives.rs
+++ b/web-wallet/src-tauri/src/mining/drives.rs
@@ -15,10 +15,11 @@ pub struct DriveInfo {
     pub total_gib: f64,
     pub free_gib: f64,
     pub is_system_drive: bool,
-    pub complete_files: u32,           // .pocx files (ready for mining)
-    pub complete_size_gib: f64,        // Size of complete files
-    pub incomplete_files: u32,         // Resumable .tmp files (matching current config)
-    pub incomplete_size_gib: f64,      // Size of resumable .tmp files
+    pub complete_files: u32,    // .pocx files (ready for mining)
+    pub complete_size_gib: f64, // Size of complete files
+    pub incomplete_files: u32,  // Count of resumable .tmp files (== incomplete_details.len())
+    pub incomplete_size_gib: f64, // Total size of resumable .tmp files
+    pub incomplete_details: Vec<IncompleteFile>, // Per-file resume metadata (seed, warps)
     pub volume_id: Option<String>, // Volume GUID for same-drive detection (handles mount points)
     pub orphan_files: Vec<OrphanFile>, // .tmp files that can't be resumed under current config
 }
@@ -29,6 +30,9 @@ pub struct DriveInfo {
 pub enum OrphanReason {
     AddressMismatch,
     CompressionMismatch,
+    /// Two or more parseable .tmp files in one dir share the same seed —
+    /// only one can resume cleanly, so the user must pick which to keep.
+    DuplicateSeed,
 }
 
 /// A .tmp file that can't be resumed under the current config.
@@ -41,6 +45,18 @@ pub struct OrphanFile {
     pub reason: OrphanReason,
     pub expected: String, // current config value
     pub actual: String,   // value embedded in .tmp filename
+}
+
+/// A .tmp file that can be resumed under the current config.
+/// Carries the seed (from the filename) so the plotter can target it directly,
+/// without re-scanning the directory at execute time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncompleteFile {
+    pub filename: String,
+    pub seed_hex: String, // 64-char uppercase hex
+    pub warps: u64,
+    pub size_gib: f64,
 }
 
 /// Parsed components of a `{addr}_{seed}_{warps}_X{compress}.tmp` filename.
@@ -119,8 +135,7 @@ impl ScanConfig {
 struct PlotFileScan {
     complete_count: u32,
     complete_bytes: u64,
-    incomplete_count: u32,
-    incomplete_bytes: u64,
+    incomplete: Vec<IncompleteFile>,
     orphan_files: Vec<OrphanFile>,
 }
 
@@ -224,8 +239,12 @@ fn is_plot_filename(filename: &str) -> bool {
 /// Scan directory for plot files (.pocx and .tmp).
 ///
 /// When `scan_config` is `Some`, .tmp files are classified against the current
-/// config: matches go into `incomplete_*`, mismatches go into `orphan_files`.
-/// When `None`, every .tmp counts as incomplete (used before any config is set).
+/// config: parseable matches go into `incomplete`, mismatches go into `orphan_files`.
+/// Unparseable .tmp files are skipped silently — they are not Phoenix-managed plots.
+///
+/// As a final pass, parseable matches are grouped by seed: any group with 2+ files
+/// is reclassified as `DuplicateSeed` orphans (the plotter can only resume one .tmp
+/// per seed; the user must delete duplicates).
 fn scan_plot_files(path: &str, scan_config: Option<&ScanConfig>) -> PlotFileScan {
     let gib = 1024.0 * 1024.0 * 1024.0;
     let dir = Path::new(path);
@@ -234,6 +253,9 @@ fn scan_plot_files(path: &str, scan_config: Option<&ScanConfig>) -> PlotFileScan
     }
 
     let mut result = PlotFileScan::default();
+    // Buffer parseable matches until we've seen all entries — we can only flag
+    // DuplicateSeed once we know whether another file shares the same seed.
+    let mut candidates: Vec<IncompleteFile> = Vec::new();
 
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
@@ -247,58 +269,87 @@ fn scan_plot_files(path: &str, scan_config: Option<&ScanConfig>) -> PlotFileScan
                 None => continue,
             };
 
-            // Check if it matches plot file pattern
             if !is_plot_filename(filename) {
                 continue;
             }
 
             let file_size = std::fs::metadata(&file_path).map(|m| m.len()).unwrap_or(0);
 
-            if let Some(ext) = file_path.extension().and_then(|e| e.to_str()) {
-                match ext {
-                    "pocx" => {
-                        result.complete_count += 1;
-                        result.complete_bytes += file_size;
-                    }
-                    "tmp" => {
-                        // Classify against current config if provided.
-                        let orphan = match (scan_config, parse_tmp_filename(filename)) {
-                            (Some(cfg), Some(parsed)) => {
-                                if parsed.addr_hex != cfg.address_hex_upper {
-                                    Some(OrphanFile {
-                                        filename: filename.to_string(),
-                                        size_gib: file_size as f64 / gib,
-                                        reason: OrphanReason::AddressMismatch,
-                                        expected: cfg.address_hex_upper.clone(),
-                                        actual: parsed.addr_hex,
-                                    })
-                                } else if parsed.compression != cfg.compression {
-                                    Some(OrphanFile {
-                                        filename: filename.to_string(),
-                                        size_gib: file_size as f64 / gib,
-                                        reason: OrphanReason::CompressionMismatch,
-                                        expected: format!("X{}", cfg.compression),
-                                        actual: format!("X{}", parsed.compression),
-                                    })
-                                } else {
-                                    None
-                                }
-                            }
-                            // No config or unparseable filename → treat as resumable
-                            // (legacy behaviour; the resume code will surface its own
-                            // error if the file is genuinely unusable).
-                            _ => None,
-                        };
+            let ext = match file_path.extension().and_then(|e| e.to_str()) {
+                Some(e) => e,
+                None => continue,
+            };
 
-                        if let Some(orphan_file) = orphan {
-                            result.orphan_files.push(orphan_file);
-                        } else {
-                            result.incomplete_count += 1;
-                            result.incomplete_bytes += file_size;
+            match ext {
+                "pocx" => {
+                    result.complete_count += 1;
+                    result.complete_bytes += file_size;
+                }
+                "tmp" => {
+                    let parsed = match parse_tmp_filename(filename) {
+                        Some(p) => p,
+                        // Unparseable .tmp — not Phoenix-managed, skip silently.
+                        None => continue,
+                    };
+
+                    // Address/compression classification only applies when we have
+                    // a config to compare against. Without one, every parseable
+                    // .tmp is a potential candidate (used before any config is set).
+                    if let Some(cfg) = scan_config {
+                        if parsed.addr_hex != cfg.address_hex_upper {
+                            result.orphan_files.push(OrphanFile {
+                                filename: filename.to_string(),
+                                size_gib: file_size as f64 / gib,
+                                reason: OrphanReason::AddressMismatch,
+                                expected: cfg.address_hex_upper.clone(),
+                                actual: parsed.addr_hex,
+                            });
+                            continue;
+                        }
+                        if parsed.compression != cfg.compression {
+                            result.orphan_files.push(OrphanFile {
+                                filename: filename.to_string(),
+                                size_gib: file_size as f64 / gib,
+                                reason: OrphanReason::CompressionMismatch,
+                                expected: format!("X{}", cfg.compression),
+                                actual: format!("X{}", parsed.compression),
+                            });
+                            continue;
                         }
                     }
-                    _ => {}
+
+                    candidates.push(IncompleteFile {
+                        filename: filename.to_string(),
+                        seed_hex: hex::encode_upper(parsed.seed),
+                        warps: parsed.warps,
+                        size_gib: file_size as f64 / gib,
+                    });
                 }
+                _ => {}
+            }
+        }
+    }
+
+    // Group candidates by seed. Singletons are real Resume targets; any group
+    // with 2+ files indicates a duplicate (manual copy / corruption) and gets
+    // surfaced through the orphan dialog rather than silently picked.
+    let mut by_seed: std::collections::HashMap<String, Vec<IncompleteFile>> =
+        std::collections::HashMap::new();
+    for c in candidates {
+        by_seed.entry(c.seed_hex.clone()).or_default().push(c);
+    }
+    for (seed, group) in by_seed {
+        if group.len() == 1 {
+            result.incomplete.extend(group);
+        } else {
+            for f in group {
+                result.orphan_files.push(OrphanFile {
+                    filename: f.filename,
+                    size_gib: f.size_gib,
+                    reason: OrphanReason::DuplicateSeed,
+                    expected: seed.clone(), // the shared seed — for display
+                    actual: seed.clone(),
+                });
             }
         }
     }
@@ -336,8 +387,9 @@ pub fn list_drives(scan_config: Option<&ScanConfig>) -> Vec<DriveInfo> {
                 is_system_drive: is_system,
                 complete_files: scan.complete_count,
                 complete_size_gib: scan.complete_bytes as f64 / gib,
-                incomplete_files: scan.incomplete_count,
-                incomplete_size_gib: scan.incomplete_bytes as f64 / gib,
+                incomplete_files: scan.incomplete.len() as u32,
+                incomplete_size_gib: scan.incomplete.iter().map(|f| f.size_gib).sum(),
+                incomplete_details: scan.incomplete,
                 volume_id: get_volume_guid(&mount_point),
                 orphan_files: scan.orphan_files,
             }
@@ -401,8 +453,9 @@ pub fn get_drive_info(path: &str, scan_config: Option<&ScanConfig>) -> Option<Dr
                 is_system_drive: is_system,
                 complete_files: scan.complete_count,
                 complete_size_gib: scan.complete_bytes as f64 / gib,
-                incomplete_files: scan.incomplete_count,
-                incomplete_size_gib: scan.incomplete_bytes as f64 / gib,
+                incomplete_files: scan.incomplete.len() as u32,
+                incomplete_size_gib: scan.incomplete.iter().map(|f| f.size_gib).sum(),
+                incomplete_details: scan.incomplete,
                 volume_id: get_volume_guid(path),
                 orphan_files: scan.orphan_files,
             }
@@ -506,8 +559,9 @@ fn get_drive_info_android(path: &str, scan_config: Option<&ScanConfig>) -> Optio
         is_system_drive: false, // Android app storage is never system drive
         complete_files: scan.complete_count,
         complete_size_gib: scan.complete_bytes as f64 / gib,
-        incomplete_files: scan.incomplete_count,
-        incomplete_size_gib: scan.incomplete_bytes as f64 / gib,
+        incomplete_files: scan.incomplete.len() as u32,
+        incomplete_size_gib: scan.incomplete.iter().map(|f| f.size_gib).sum(),
+        incomplete_details: scan.incomplete,
         volume_id: get_volume_guid(path),
         orphan_files: scan.orphan_files,
     })
@@ -563,8 +617,9 @@ fn get_drive_info_fallback(path: &str, scan_config: Option<&ScanConfig>) -> Opti
         is_system_drive: false,
         complete_files: scan.complete_count,
         complete_size_gib: scan.complete_bytes as f64 / gib,
-        incomplete_files: scan.incomplete_count,
-        incomplete_size_gib: scan.incomplete_bytes as f64 / gib,
+        incomplete_files: scan.incomplete.len() as u32,
+        incomplete_size_gib: scan.incomplete.iter().map(|f| f.size_gib).sum(),
+        incomplete_details: scan.incomplete,
         volume_id: get_volume_guid(path),
         orphan_files: scan.orphan_files,
     })
@@ -622,8 +677,9 @@ fn get_drive_info_fallback(path: &str, scan_config: Option<&ScanConfig>) -> Opti
         is_system_drive: false,
         complete_files: scan.complete_count,
         complete_size_gib: scan.complete_bytes as f64 / gib,
-        incomplete_files: scan.incomplete_count,
-        incomplete_size_gib: scan.incomplete_bytes as f64 / gib,
+        incomplete_files: scan.incomplete.len() as u32,
+        incomplete_size_gib: scan.incomplete.iter().map(|f| f.size_gib).sum(),
+        incomplete_details: scan.incomplete,
         volume_id: get_volume_guid(path),
         orphan_files: scan.orphan_files,
     })

--- a/web-wallet/src-tauri/src/mining/drives.rs
+++ b/web-wallet/src-tauri/src/mining/drives.rs
@@ -15,9 +15,9 @@ pub struct DriveInfo {
     pub total_gib: f64,
     pub free_gib: f64,
     pub is_system_drive: bool,
-    pub complete_files: u32,    // .pocx files (ready for mining)
-    pub complete_size_gib: f64, // Size of complete files
-    pub incomplete_files: u32,  // Count of resumable .tmp files (== incomplete_details.len())
+    pub complete_files: u32,      // .pocx files (ready for mining)
+    pub complete_size_gib: f64,   // Size of complete files
+    pub incomplete_files: u32,    // Count of resumable .tmp files (== incomplete_details.len())
     pub incomplete_size_gib: f64, // Total size of resumable .tmp files
     pub incomplete_details: Vec<IncompleteFile>, // Per-file resume metadata (seed, warps)
     pub volume_id: Option<String>, // Volume GUID for same-drive detection (handles mount points)

--- a/web-wallet/src-tauri/src/mining/plotter.rs
+++ b/web-wallet/src-tauri/src/mining/plotter.rs
@@ -408,12 +408,7 @@ pub async fn execute_plot_batch<R: Runtime>(
                 ..
             } => {
                 let seed = decode_seed_hex(seed_hex)?;
-                log::info!(
-                    "Resume for {}: warps={}, seed={}",
-                    path,
-                    warps,
-                    seed_hex
-                );
+                log::info!("Resume for {}: warps={}, seed={}", path, warps, seed_hex);
                 outputs.push(BatchPlotOutput {
                     path: path.clone(),
                     warps: *warps,

--- a/web-wallet/src-tauri/src/mining/plotter.rs
+++ b/web-wallet/src-tauri/src/mining/plotter.rs
@@ -13,13 +13,11 @@
 //! This can be done by right-clicking the app and selecting "Run as administrator".
 
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Runtime};
 
 use super::callback::TauriPlotterCallback;
-use super::drives::{parse_tmp_filename, ScanConfig};
 use super::state::{MiningConfig, PlotPlanItem, PlottingStatus, SharedMiningState};
 
 // ============================================================================
@@ -381,16 +379,10 @@ pub async fn execute_plot_batch<R: Runtime>(
         return Err("No plotting address configured".to_string());
     }
 
-    // Build a ScanConfig once so we can match Resume items to their .tmp files.
-    // Plan-time orphan checking should mean every Resume here has a matching .tmp,
-    // but we re-verify defensively and bail with a clear error otherwise.
-    let scan_cfg =
-        ScanConfig::from_mining_config(&config.plotting_address, config.compression_level);
-
     // Single pass: collect outputs + per-output resume seeds.
-    // For Resume items, both `warps` and `seed` come from the .tmp filename
-    // (the source of truth — preallocation can be partial on disk-full / non-elevated
-    // Windows / network mounts, so trusting the on-disk size is unsafe).
+    // Resume items carry their own `warps` and `seed_hex` (populated by the
+    // scanner from the .tmp filename at plan time), so the plotter doesn't
+    // need to rescan the directory at execute time.
     let mut outputs: Vec<BatchPlotOutput> = Vec::new();
     let mut paths: Vec<String> = Vec::new();
     let mut seeds: Vec<Option<[u8; 32]>> = Vec::new();
@@ -409,29 +401,25 @@ pub async fn execute_plot_batch<R: Runtime>(
                 paths.push(path.clone());
                 seeds.push(None); // New plots get random seeds
             }
-            PlotPlanItem::Resume { path, .. } => {
-                let parsed = match find_resumable_tmp(path, scan_cfg.as_ref()) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        return Err(format!(
-                            "Resume aborted for {}: {}. Delete orphan .tmp files or restore matching settings.",
-                            path, e
-                        ));
-                    }
-                };
+            PlotPlanItem::Resume {
+                path,
+                warps,
+                seed_hex,
+                ..
+            } => {
+                let seed = decode_seed_hex(seed_hex)?;
                 log::info!(
-                    "Resume for {}: warps={}, compression=X{}, seed={}",
+                    "Resume for {}: warps={}, seed={}",
                     path,
-                    parsed.warps,
-                    parsed.compression,
-                    hex::encode(parsed.seed)
+                    warps,
+                    seed_hex
                 );
                 outputs.push(BatchPlotOutput {
                     path: path.clone(),
-                    warps: parsed.warps,
+                    warps: *warps,
                 });
                 paths.push(path.clone());
-                seeds.push(Some(parsed.seed));
+                seeds.push(Some(seed));
             }
             PlotPlanItem::AddToMiner => {
                 // Skip add_to_miner items in batch - they're executed separately
@@ -559,14 +547,14 @@ pub async fn execute_plot_batch<R: Runtime>(
                                     }),
                                 );
                             }
-                            PlotPlanItem::Resume { path, size_gib, .. } => {
+                            PlotPlanItem::Resume { path, warps, .. } => {
                                 let _ = app_handle_clone.emit(
                                     "plotter:item-complete",
                                     serde_json::json!({
                                         "type": "resume",
                                         "path": path,
                                         "success": true,
-                                        "warpsPlotted": size_gib,
+                                        "warpsPlotted": warps,
                                         "durationMs": duration.as_millis() as u64,
                                         "batchSize": items_clone.len(),
                                     }),
@@ -665,11 +653,18 @@ pub async fn execute_plot_item<R: Runtime>(
     plotter_runtime.clear_stop();
 
     match item {
-        PlotPlanItem::Resume { path, size_gib, .. } => {
+        PlotPlanItem::Resume {
+            path,
+            warps,
+            seed_hex,
+            ..
+        } => {
+            let seed = decode_seed_hex(&seed_hex)?;
             execute_resume(
                 app_handle,
                 path,
-                size_gib,
+                warps,
+                seed,
                 config,
                 mining_state,
                 plotter_runtime,
@@ -714,98 +709,41 @@ pub async fn execute_plot_item<R: Runtime>(
     }
 }
 
-/// Find the single .tmp file in `dir_path` that matches the current scan config.
-///
-/// Returns the parsed components (seed, warps from filename) so the caller can
-/// build a resume task without needing to re-scan or trust on-disk file size.
-///
-/// Errors if no matching .tmp exists, or if multiple do (which would indicate
-/// the orphan check was bypassed — keep this strict so we never silently pick
-/// the wrong file).
-fn find_resumable_tmp(
-    dir_path: &str,
-    scan_config: Option<&ScanConfig>,
-) -> Result<super::drives::ParsedTmpFilename, String> {
-    let dir = Path::new(dir_path);
-    if !dir.exists() || !dir.is_dir() {
-        return Err(format!("Directory does not exist: {}", dir_path));
-    }
-
-    let entries = std::fs::read_dir(dir).map_err(|e| format!("Failed to read directory: {}", e))?;
-
-    let mut matches: Vec<super::drives::ParsedTmpFilename> = Vec::new();
-    for entry in entries.flatten() {
-        let file_path = entry.path();
-        if file_path.extension().and_then(|e| e.to_str()) != Some("tmp") {
-            continue;
-        }
-        let filename = match file_path.file_name().and_then(|n| n.to_str()) {
-            Some(n) => n,
-            None => continue,
-        };
-        let parsed = match parse_tmp_filename(filename) {
-            Some(p) => p,
-            None => continue, // unparseable filename — skip silently
-        };
-        // Filter to the current config when one is available; otherwise accept any
-        // parseable .tmp (legacy / pre-config code paths).
-        if let Some(cfg) = scan_config {
-            if parsed.addr_hex != cfg.address_hex_upper || parsed.compression != cfg.compression {
-                continue;
-            }
-        }
-        matches.push(parsed);
-    }
-
-    match matches.len() {
-        0 => Err(format!("No matching .tmp file found in {}", dir_path)),
-        1 => Ok(matches.into_iter().next().unwrap()),
-        n => Err(format!(
-            "Found {} resumable .tmp files in {} — expected exactly 1. Delete extras manually.",
-            n, dir_path
-        )),
-    }
+/// Decode a 64-char hex seed string into the 32-byte array the plotter expects.
+fn decode_seed_hex(seed_hex: &str) -> Result<[u8; 32], String> {
+    let bytes = hex::decode(seed_hex).map_err(|e| format!("Invalid seed hex: {}", e))?;
+    <[u8; 32]>::try_from(bytes.as_slice())
+        .map_err(|_| format!("Seed hex must decode to 32 bytes, got {}", bytes.len()))
 }
 
-/// Execute a resume task (resume incomplete .tmp file)
+/// Execute a resume task. Seed and warps come from the plan item — the plotter
+/// targets `{addr}_{seed}_{warps}_X{compression}.tmp` directly.
 async fn execute_resume<R: Runtime>(
     app_handle: AppHandle<R>,
     drive_path: String,
-    _size_gib: u64, // ignored — warps come from the .tmp filename, not the plan
+    warps: u64,
+    seed: [u8; 32],
     config: &MiningConfig,
     mining_state: SharedMiningState,
     plotter_runtime: SharedPlotterRuntime,
 ) -> Result<PlotExecutionResult, String> {
     log::info!(
-        "[RESUME] Looking for resumable .tmp file in: {}",
-        drive_path
-    );
-
-    let scan_cfg =
-        ScanConfig::from_mining_config(&config.plotting_address, config.compression_level);
-    let parsed = find_resumable_tmp(&drive_path, scan_cfg.as_ref()).map_err(|e| {
-        format!(
-            "{}. Delete orphan .tmp files or restore matching settings.",
-            e
-        )
-    })?;
-
-    log::info!(
-        "[RESUME] Resuming: warps={}, compression=X{}, seed={}",
-        parsed.warps,
-        parsed.compression,
-        hex::encode(parsed.seed)
+        "[RESUME] Resuming: path={}, warps={}, compression=X{}, seed={}",
+        drive_path,
+        warps,
+        config.compression_level,
+        hex::encode(seed)
     );
 
     execute_plot_internal(
         app_handle,
         "resume",
         drive_path,
-        parsed.warps, // ← from filename, not plan
+        warps,
         config,
         mining_state,
         plotter_runtime,
-        Some(parsed.seed),
+        Some(seed),
     )
     .await
 }

--- a/web-wallet/src-tauri/src/mining/state.rs
+++ b/web-wallet/src-tauri/src/mining/state.rs
@@ -141,13 +141,14 @@ pub struct PlotterDeviceConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PlotPlanItem {
-    /// Resume an incomplete .tmp file
+    /// Resume an incomplete .tmp file. The `seed_hex` (uppercase, 64 chars)
+    /// uniquely identifies which `.tmp` to target — multiple resumable files
+    /// can coexist in the same directory as long as their seeds differ.
     Resume {
         path: String,
-        #[serde(rename = "fileIndex")]
-        file_index: u32,
-        #[serde(rename = "sizeGib")]
-        size_gib: u64,
+        warps: u64,
+        #[serde(rename = "seedHex")]
+        seed_hex: String,
         #[serde(rename = "batchId")]
         batch_id: u32,
     },

--- a/web-wallet/src/app/mining/components/orphan-resolution-dialog/orphan-resolution-dialog.component.ts
+++ b/web-wallet/src/app/mining/components/orphan-resolution-dialog/orphan-resolution-dialog.component.ts
@@ -188,13 +188,13 @@ export class OrphanResolutionDialogComponent {
   readonly orphanDrives = computed(() => this.miningService.orphanBlocker() ?? []);
 
   formatReason(orphan: OrphanFile): string {
-    const expected = orphan.expected;
-    const actual = orphan.actual;
-    const key: Record<OrphanReason, string> =
-      orphan.reason === 'address_mismatch'
-        ? { address_mismatch: 'orphan_reason_address', compression_mismatch: '' }
-        : { compression_mismatch: 'orphan_reason_compression', address_mismatch: '' };
-    return this.i18n.get(key[orphan.reason], { expected, actual });
+    const params = { expected: orphan.expected, actual: orphan.actual };
+    const keyMap: Record<OrphanReason, string> = {
+      address_mismatch: 'orphan_reason_address',
+      compression_mismatch: 'orphan_reason_compression',
+      duplicate_seed: 'orphan_reason_duplicate_seed',
+    };
+    return this.i18n.get(keyMap[orphan.reason], params);
   }
 
   async deleteOrphan(dirPath: string, orphan: OrphanFile): Promise<void> {

--- a/web-wallet/src/app/mining/components/plan-viewer-dialog/plan-viewer-dialog.component.ts
+++ b/web-wallet/src/app/mining/components/plan-viewer-dialog/plan-viewer-dialog.component.ts
@@ -89,7 +89,7 @@ import { I18nPipe, I18nService } from '../../../core/i18n';
                     @case ('resume') {
                       <span class="badge resume">{{ 'plan_resume' | i18n }}</span>
                       <span class="item-path">{{ formatPath(item.path) }}</span>
-                      <span class="item-detail">{{ item.sizeGib }} GiB</span>
+                      <span class="item-detail">{{ item.warps }} GiB</span>
                       <span class="item-batch" [matTooltip]="getParallelBatchTooltip(item.batchId)">
                         B{{ item.batchId + 1 }}
                       </span>

--- a/web-wallet/src/app/mining/models/mining.models.ts
+++ b/web-wallet/src/app/mining/models/mining.models.ts
@@ -46,13 +46,26 @@ export interface DriveInfo {
   isSystemDrive: boolean;
   completeFiles: number; // .pocx files (ready for mining)
   completeSizeGib: number; // Size of complete files
-  incompleteFiles: number; // Resumable .tmp files (matching current config)
-  incompleteSizeGib: number; // Size of resumable .tmp files
+  incompleteFiles: number; // Count of resumable .tmp files (== incompleteDetails.length)
+  incompleteSizeGib: number; // Total size of resumable .tmp files
+  incompleteDetails: IncompleteFile[]; // Per-file resume metadata (seed, warps)
   volumeId?: string; // Volume GUID for same-drive detection (handles mount points)
   orphanFiles: OrphanFile[]; // .tmp files that can't be resumed under current config
 }
 
-export type OrphanReason = 'address_mismatch' | 'compression_mismatch';
+/**
+ * A resumable .tmp file. The seed (parsed from the filename) is the unique key
+ * — the plan generator emits one Resume task per file, carrying its seed so the
+ * plotter targets the right .tmp directly.
+ */
+export interface IncompleteFile {
+  filename: string;
+  seedHex: string; // 64-char uppercase hex
+  warps: number;
+  sizeGib: number;
+}
+
+export type OrphanReason = 'address_mismatch' | 'compression_mismatch' | 'duplicate_seed';
 
 export interface OrphanFile {
   filename: string;
@@ -307,7 +320,7 @@ export type PlotterUIState = 'plotting' | 'stopping' | 'ready' | 'complete';
 // ============================================================================
 
 export type PlotPlanItem =
-  | { type: 'resume'; path: string; fileIndex: number; sizeGib: number; batchId: number }
+  | { type: 'resume'; path: string; warps: number; seedHex: string; batchId: number }
   | { type: 'plot'; path: string; warps: number; batchId: number }
   | { type: 'add_to_miner' };
 

--- a/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
+++ b/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
@@ -2413,7 +2413,7 @@ export class MiningDashboardComponent implements OnInit, OnDestroy {
       if (item.type === 'plot') {
         remaining += item.warps;
       } else if (item.type === 'resume') {
-        remaining += item.sizeGib;
+        remaining += item.warps;
       }
     }
     if (remaining >= 1024) {

--- a/web-wallet/src/app/mining/services/mining.service.ts
+++ b/web-wallet/src/app/mining/services/mining.service.ts
@@ -1361,7 +1361,7 @@ export class MiningService {
           break;
         }
         batchItems.push(item);
-        totalBatchWarps += item.sizeGib;
+        totalBatchWarps += item.warps;
       }
 
       console.log(

--- a/web-wallet/src/app/mining/services/plot-plan.service.ts
+++ b/web-wallet/src/app/mining/services/plot-plan.service.ts
@@ -1,5 +1,12 @@
 import { Injectable } from '@angular/core';
-import { DriveInfo, DriveConfig, PlotPlan, PlotPlanItem, PlotPlanStats } from '../models';
+import {
+  DriveInfo,
+  DriveConfig,
+  IncompleteFile,
+  PlotPlan,
+  PlotPlanItem,
+  PlotPlanStats,
+} from '../models';
 
 const BATCH_SIZE = 1024; // 1024 warps = 1 TiB
 
@@ -12,6 +19,7 @@ interface DriveState {
   completeSizeGib: number;
   incompleteSizeGib: number;
   incompleteFiles: number;
+  incompleteDetails: IncompleteFile[];
   allocatedGib: number;
 }
 
@@ -33,6 +41,7 @@ export class PlotPlanService {
         completeSizeGib: drive.completeSizeGib,
         incompleteSizeGib: drive.incompleteSizeGib,
         incompleteFiles: drive.incompleteFiles,
+        incompleteDetails: drive.incompleteDetails ?? [],
         allocatedGib: cfg?.allocatedGib ?? 0,
       };
     });
@@ -97,31 +106,35 @@ export class PlotPlanService {
     };
 
     // Step 3: Generate resume tasks (highest priority)
-    // v2 plotter supports parallel resume with per-path seeds,
-    // so we group resume items across different drives into batches.
-    const resumeItems: Array<{ path: string; fileIndex: number; sizeGib: number }> = [];
+    // v2 plotter supports parallel resume with per-path seeds, so we group
+    // resume items across different drives into batches. Each Resume item
+    // carries its own seed (parsed from the .tmp filename by the scanner),
+    // so two .tmps in the same dir with different seeds can each be resumed.
+    interface ResumeCandidate {
+      path: string;
+      seedHex: string;
+      warps: number;
+    }
+    const resumeItems: ResumeCandidate[] = [];
     for (const drive of driveStates) {
-      if (drive.incompleteFiles > 0) {
-        const sizePerFile = drive.incompleteSizeGib / drive.incompleteFiles;
-        for (let i = 0; i < drive.incompleteFiles; i++) {
-          resumeItems.push({
-            path: drive.path,
-            fileIndex: i,
-            sizeGib: Math.round(sizePerFile),
-          });
-        }
+      for (const file of drive.incompleteDetails) {
+        resumeItems.push({
+          path: drive.path,
+          seedHex: file.seedHex,
+          warps: file.warps,
+        });
       }
     }
 
-    // Group resume items into parallel batches (up to parallelDrives, one per drive per batch)
-    // This leverages v2 plotter's per-path seed support for parallel resume
+    // Group resume items into parallel batches (up to parallelDrives, one per
+    // drive per batch — multiple resumables on the same drive run sequentially
+    // across batches).
     const remaining = [...resumeItems];
     while (remaining.length > 0) {
-      const batch: typeof resumeItems = [];
+      const batch: ResumeCandidate[] = [];
       const usedPaths = new Set<string>();
       const consumed = new Set<number>();
 
-      // Fill batch with items from different drives
       for (let i = 0; i < remaining.length && batch.length < config.parallelDrives; i++) {
         if (!usedPaths.has(remaining[i].path)) {
           batch.push(remaining[i]);
@@ -132,25 +145,22 @@ export class PlotPlanService {
 
       if (batch.length === 0) break; // Safety
 
-      // Add batch items to plan
       for (const item of batch) {
         plan.push({
           type: 'resume',
           path: item.path,
-          fileIndex: item.fileIndex,
-          sizeGib: item.sizeGib,
+          warps: item.warps,
+          seedHex: item.seedHex,
           batchId,
         });
         markTaskComplete(item.path);
       }
       batchId++;
 
-      // Check for completed drives after batch
       for (const item of batch) {
         checkAndAddMiner(item.path);
       }
 
-      // Remove consumed items (reverse order to preserve indices)
       const indices = [...consumed].sort((a, b) => b - a);
       for (const idx of indices) {
         remaining.splice(idx, 1);
@@ -427,9 +437,9 @@ export class PlotPlanService {
           completedTasks++;
         }
       } else if (item.type === 'resume') {
-        totalWarps += item.sizeGib;
+        totalWarps += item.warps;
         if (i < currentIndex) {
-          completedWarps += item.sizeGib;
+          completedWarps += item.warps;
         }
 
         // Count unique resume batches

--- a/web-wallet/src/assets/locales/bg.json
+++ b/web-wallet/src/assets/locales/bg.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Всички осиротели файлове са разрешени. Можете да затворите този диалог и да започнете плотването.",
   "orphan_reason_address": "Несъответствие на адреса за плотване (файл: {actual}, текущ: {expected})",
   "orphan_reason_compression": "Несъответствие на компресията (файл: {actual}, текуща: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Текуща версия",
   "custom": "Персонализиран",
   "danger_zone": "Опасна зона",

--- a/web-wallet/src/assets/locales/ca.json
+++ b/web-wallet/src/assets/locales/ca.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Tots els fitxers orfes resolts. Podeu tancar aquest diàleg i començar el plotting.",
   "orphan_reason_address": "Adreça de plotting no coincident (fitxer: {actual}, actual: {expected})",
   "orphan_reason_compression": "Compressió no coincident (fitxer: {actual}, actual: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Versió actual",
   "custom": "Personalitzat",
   "danger_zone": "Zona perillosa",

--- a/web-wallet/src/assets/locales/cs.json
+++ b/web-wallet/src/assets/locales/cs.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Vsechny osirele soubory vyreseny. Muzete zavrit tento dialog a zacit s plotovanim.",
   "orphan_reason_address": "Neshoda plotovaci adresy (soubor: {actual}, aktualni: {expected})",
   "orphan_reason_compression": "Neshoda komprese (soubor: {actual}, aktualni: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Aktuální verze",
   "custom": "Vlastni",
   "danger_zone": "Nebezpecna zona",

--- a/web-wallet/src/assets/locales/de-de.json
+++ b/web-wallet/src/assets/locales/de-de.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Alle verwaisten Dateien behoben. Sie koennen diesen Dialog schliessen und mit dem Plotten beginnen.",
   "orphan_reason_address": "Plot-Adresse stimmt nicht ueberein (Datei: {actual}, aktuell: {expected})",
   "orphan_reason_compression": "Kompression stimmt nicht ueberein (Datei: {actual}, aktuell: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Aktuelle Version",
   "custom": "Benutzerdefiniert",
   "danger_zone": "Gefahrenzone",

--- a/web-wallet/src/assets/locales/el.json
+++ b/web-wallet/src/assets/locales/el.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Όλα τα ορφανά αρχεία επιλύθηκαν. Μπορείτε να κλείσετε αυτό το παράθυρο και να ξεκινήσετε το plotting.",
   "orphan_reason_address": "Ασυμφωνία διεύθυνσης plotting (αρχείο: {actual}, τρέχουσα: {expected})",
   "orphan_reason_compression": "Ασυμφωνία συμπίεσης (αρχείο: {actual}, τρέχουσα: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Τρέχουσα έκδοση",
   "custom": "Προσαρμοσμένο",
   "danger_zone": "Επικίνδυνη ζώνη",

--- a/web-wallet/src/assets/locales/en.json
+++ b/web-wallet/src/assets/locales/en.json
@@ -481,6 +481,7 @@
   "orphan_all_resolved": "All orphan files resolved. You can close this dialog and start plotting.",
   "orphan_reason_address": "Plotting address mismatch (file: {actual}, current: {expected})",
   "orphan_reason_compression": "Compression mismatch (file: {actual}, current: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "exit_confirm_title": "Confirm Exit",
   "exit_confirm_message": "These processes will be stopped when you exit.",
   "exit_anyway": "Exit",

--- a/web-wallet/src/assets/locales/es-es.json
+++ b/web-wallet/src/assets/locales/es-es.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Todos los archivos huérfanos resueltos. Puede cerrar este diálogo e iniciar el plotting.",
   "orphan_reason_address": "Dirección de plotting diferente (archivo: {actual}, actual: {expected})",
   "orphan_reason_compression": "Compresión diferente (archivo: {actual}, actual: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Versión actual",
   "custom": "Personalizado",
   "danger_zone": "Zona peligrosa",

--- a/web-wallet/src/assets/locales/fi.json
+++ b/web-wallet/src/assets/locales/fi.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Kaikki orpotiedostot ratkaistu. Voit sulkea tämän valintaikkunan ja aloittaa plotin.",
   "orphan_reason_address": "Plot-osoite ei täsmää (tiedosto: {actual}, nykyinen: {expected})",
   "orphan_reason_compression": "Pakkaus ei täsmää (tiedosto: {actual}, nykyinen: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Nykyinen versio",
   "custom": "Mukautettu",
   "danger_zone": "Vaaravyohyke",

--- a/web-wallet/src/assets/locales/fr.json
+++ b/web-wallet/src/assets/locales/fr.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Tous les fichiers orphelins resolus. Vous pouvez fermer cette boite de dialogue et lancer le plotting.",
   "orphan_reason_address": "Adresse de plotting differente (fichier : {actual}, actuelle : {expected})",
   "orphan_reason_compression": "Compression differente (fichier : {actual}, actuelle : {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Version actuelle",
   "custom": "Personnalise",
   "danger_zone": "Zone dangereuse",

--- a/web-wallet/src/assets/locales/gl.json
+++ b/web-wallet/src/assets/locales/gl.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Todos os ficheiros orfos resoltos. Pode pechar este diálogo e iniciar o plotting.",
   "orphan_reason_address": "Enderezo de plotting non coincidente (ficheiro: {actual}, actual: {expected})",
   "orphan_reason_compression": "Compresión non coincidente (ficheiro: {actual}, actual: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Versión actual",
   "custom": "Personalizado",
   "danger_zone": "Zona de perigo",

--- a/web-wallet/src/assets/locales/hi.json
+++ b/web-wallet/src/assets/locales/hi.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "सभी अनाथ फ़ाइलें हल हो गईं. आप इस संवाद को बंद कर सकते हैं और प्लॉटिंग शुरू कर सकते हैं.",
   "orphan_reason_address": "प्लॉटिंग पता मेल नहीं खाता (फ़ाइल: {actual}, वर्तमान: {expected})",
   "orphan_reason_compression": "कम्प्रेशन मेल नहीं खाता (फ़ाइल: {actual}, वर्तमान: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "वर्तमान संस्करण",
   "custom": "कस्टम",
   "danger_zone": "खतरा क्षेत्र",

--- a/web-wallet/src/assets/locales/hr.json
+++ b/web-wallet/src/assets/locales/hr.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Sve siroce datoteke su rijesene. Mozete zatvoriti ovaj dijalog i zapoceti plottanje.",
   "orphan_reason_address": "Nepodudaranje plot adrese (datoteka: {actual}, trenutno: {expected})",
   "orphan_reason_compression": "Nepodudaranje kompresije (datoteka: {actual}, trenutno: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Trenutna verzija",
   "custom": "Prilagodeno",
   "danger_zone": "Opasna zona",

--- a/web-wallet/src/assets/locales/id.json
+++ b/web-wallet/src/assets/locales/id.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Semua file yatim telah diselesaikan. Anda dapat menutup dialog ini dan mulai plotting.",
   "orphan_reason_address": "Alamat plotting tidak cocok (file: {actual}, saat ini: {expected})",
   "orphan_reason_compression": "Kompresi tidak cocok (file: {actual}, saat ini: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Versi Saat Ini",
   "custom": "Kustom",
   "danger_zone": "Zona Bahaya",

--- a/web-wallet/src/assets/locales/it.json
+++ b/web-wallet/src/assets/locales/it.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Tutti i file orfani risolti. Puoi chiudere questo dialogo e avviare il plotting.",
   "orphan_reason_address": "Indirizzo di plotting diverso (file: {actual}, attuale: {expected})",
   "orphan_reason_compression": "Compressione diversa (file: {actual}, attuale: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Versione attuale",
   "custom": "Personalizzato",
   "danger_zone": "Zona pericolosa",

--- a/web-wallet/src/assets/locales/ja.json
+++ b/web-wallet/src/assets/locales/ja.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "すべての孤立ファイルが解決されました。このダイアログを閉じてプロットを開始できます。",
   "orphan_reason_address": "プロットアドレスが一致しません (ファイル: {actual}、現在: {expected})",
   "orphan_reason_compression": "圧縮が一致しません (ファイル: {actual}、現在: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "現在のバージョン",
   "custom": "カスタム",
   "danger_zone": "危険ゾーン",

--- a/web-wallet/src/assets/locales/lt.json
+++ b/web-wallet/src/assets/locales/lt.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Visi naslaiciu failai issprestos. Galite uzdaryti si dialoga ir pradeti plottinga.",
   "orphan_reason_address": "Plottingo adreso neatitikimas (failas: {actual}, esamas: {expected})",
   "orphan_reason_compression": "Suspaudimo neatitikimas (failas: {actual}, esamas: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Dabartinė versija",
   "custom": "Pasirinktinis",
   "danger_zone": "Pavojaus zona",

--- a/web-wallet/src/assets/locales/nl.json
+++ b/web-wallet/src/assets/locales/nl.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Alle weesbestanden opgelost. U kunt dit dialoogvenster sluiten en beginnen met plotten.",
   "orphan_reason_address": "Plot-adres komt niet overeen (bestand: {actual}, huidig: {expected})",
   "orphan_reason_compression": "Compressie komt niet overeen (bestand: {actual}, huidig: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Huidige versie",
   "custom": "Aangepast",
   "danger_zone": "Gevarenzone",

--- a/web-wallet/src/assets/locales/pl.json
+++ b/web-wallet/src/assets/locales/pl.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Wszystkie osierocone pliki rozwiazane. Mozesz zamknac ten dialog i rozpoczac plotting.",
   "orphan_reason_address": "Niezgodny adres plottingu (plik: {actual}, aktualny: {expected})",
   "orphan_reason_compression": "Niezgodna kompresja (plik: {actual}, aktualna: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Aktualna wersja",
   "custom": "Wlasne",
   "danger_zone": "Strefa niebezpieczenstwa",

--- a/web-wallet/src/assets/locales/pt-br.json
+++ b/web-wallet/src/assets/locales/pt-br.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Todos os arquivos órfãos resolvidos. Você pode fechar este diálogo e iniciar o plotting.",
   "orphan_reason_address": "Endereço de plotting diferente (arquivo: {actual}, atual: {expected})",
   "orphan_reason_compression": "Compressão diferente (arquivo: {actual}, atual: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Versão atual",
   "custom": "Personalizado",
   "danger_zone": "Zona de perigo",

--- a/web-wallet/src/assets/locales/ro.json
+++ b/web-wallet/src/assets/locales/ro.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Toate fișierele orfane rezolvate. Puteți închide acest dialog și începe plottingul.",
   "orphan_reason_address": "Adresa de plotting nu corespunde (fișier: {actual}, actual: {expected})",
   "orphan_reason_compression": "Compresia nu corespunde (fișier: {actual}, actual: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Versiunea curentă",
   "custom": "Personalizat",
   "danger_zone": "Zonă periculoasă",

--- a/web-wallet/src/assets/locales/ru.json
+++ b/web-wallet/src/assets/locales/ru.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Все потерянные файлы устранены. Вы можете закрыть этот диалог и начать плоттинг.",
   "orphan_reason_address": "Адрес плоттинга не совпадает (файл: {actual}, текущий: {expected})",
   "orphan_reason_compression": "Сжатие не совпадает (файл: {actual}, текущее: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Текущая версия",
   "custom": "Пользовательский",
   "danger_zone": "Опасная зона",

--- a/web-wallet/src/assets/locales/sk.json
+++ b/web-wallet/src/assets/locales/sk.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Vsetky osirote subory vyriesene. Mozete zavriet tento dialog a zacat s plotovanim.",
   "orphan_reason_address": "Nezhoda plotovacej adresy (subor: {actual}, aktualna: {expected})",
   "orphan_reason_compression": "Nezhoda kompresie (subor: {actual}, aktualna: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Aktuálna verzia",
   "custom": "Vlastne",
   "danger_zone": "Nebezpecna zona",

--- a/web-wallet/src/assets/locales/sr.json
+++ b/web-wallet/src/assets/locales/sr.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Све сирочадне датотеке су решене. Можете затворити овај дијалог и почети плотовање.",
   "orphan_reason_address": "Неподударање плот адресе (датотека: {actual}, тренутно: {expected})",
   "orphan_reason_compression": "Неподударање компресије (датотека: {actual}, тренутно: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Тренутна верзија",
   "custom": "Прилагођено",
   "danger_zone": "Опасна зона",

--- a/web-wallet/src/assets/locales/tr.json
+++ b/web-wallet/src/assets/locales/tr.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Tüm yetim dosyalar çözüldü. Bu iletişim kutusunu kapatabilir ve plotlamaya başlayabilirsiniz.",
   "orphan_reason_address": "Plotlama adresi uyuşmazlığı (dosya: {actual}, mevcut: {expected})",
   "orphan_reason_compression": "Sıkıştırma uyuşmazlığı (dosya: {actual}, mevcut: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Mevcut Sürüm",
   "custom": "Özel",
   "danger_zone": "Tehlikeli Bölge",

--- a/web-wallet/src/assets/locales/uk.json
+++ b/web-wallet/src/assets/locales/uk.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "Усі загублені файли вирішено. Ви можете закрити цей діалог і почати плотинг.",
   "orphan_reason_address": "Невідповідність адреси плотингу (файл: {actual}, поточна: {expected})",
   "orphan_reason_compression": "Невідповідність стиснення (файл: {actual}, поточне: {expected})",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "Поточна версія",
   "custom": "Користувацький",
   "danger_zone": "Небезпечна зона",

--- a/web-wallet/src/assets/locales/zh-cn.json
+++ b/web-wallet/src/assets/locales/zh-cn.json
@@ -150,6 +150,7 @@
   "orphan_all_resolved": "所有孤立文件已解决。您可以关闭此对话框并开始绘图。",
   "orphan_reason_address": "绘图地址不匹配（文件：{actual}，当前：{expected}）",
   "orphan_reason_compression": "压缩不匹配（文件：{actual}，当前：{expected}）",
+  "orphan_reason_duplicate_seed": "Duplicate of another .tmp with the same seed — only one can be resumed",
   "current_version": "当前版本",
   "custom": "自定义",
   "danger_zone": "危险区",


### PR DESCRIPTION
## Summary

- **Resume plan items now carry `seed_hex` + `warps`**, parsed at scan time from the `.tmp` filename. The plotter targets each file directly by seed instead of "find the single matching `.tmp` in this dir", so two resumable `.tmp`s in the same drive (different seeds) each get their own Resume row and run sequentially.
- **New `OrphanReason::DuplicateSeed`** for the seed-collision edge case (two parseable `.tmp`s sharing a seed — e.g. byte-for-byte copy). The orphan dialog surfaces it instead of silently picking one file at random.
- **Removed the strict "exactly 1 `.tmp` per dir" check** in `find_resumable_tmp` (which is now gone entirely). That check was the source of the silent-fail in https://github.com/PoC-Consortium/phoenix-pocx/issues — when two resumable `.tmp`s existed, plan generation succeeded but execute-time errored with "Found 2 resumable .tmp files" and the failure never reached the UI.

## Background

User report: two resumable `.tmp` files on a single drive caused plotting to silently fail. Plan generation didn't trip the orphan dialog (orphan classifier only flagged address/compression mismatches), so the plan happily emitted two Resume rows pointing at the same drive path. At execute time, the plotter rejected the ambiguous state ("Found 2 resumable .tmp files in <dir> — expected exactly 1") and the error landed in `_error.set(...)` only — no dialog, no toast.

Root cause: `PlotPlanItem::Resume` carried only `path` + `size_gib`, with no per-file identity. The plotter inferred which `.tmp` to resume from `(addr, compression)` alone, which was non-unique.

## Approach

Resume tasks are now keyed by seed:

- `IncompleteFile { filename, seed_hex, warps, size_gib }` returned per-file by the scanner.
- `PlotPlanItem::Resume { path, warps, seed_hex, batch_id }` (was `{ path, file_index, size_gib, batch_id }`).
- `find_resumable_tmp` deleted — both `execute_resume` and the batch path take seed/warps straight from the plan item and feed them to `pocx_plotter_v2::PlotterTaskBuilder::seed(i, seed)`. No execute-time directory rescan.
- Scanner groups parseable matches by seed before deciding incomplete vs orphan: any seed shared by 2+ files becomes a `DuplicateSeed` orphan group, all surfaced together in the dialog.

## Upstream bug surfaced (not fixed by this PR)

Removing the strict-1 check exposed an edge case in `pocx_plotter_v2`: resuming a `.tmp` whose embedded marker reports `progress == number_of_warps` panics with `WriteExceedsEof` (CPU mode) or hangs (GPU mode). This is reachable in normal operation via a hard-kill in the narrow window between the final `write_resume_info` and the `.tmp → .pocx` rename. Filed upstream: PoC-Consortium/pocx#48. Once that lands and Phoenix bumps the dep, the case auto-recovers (rename completes on next plan execution).

## Test plan

- [x] `cargo check` clean
- [x] `npm run build` clean (only pre-existing style-budget warnings)
- [x] `node check-keys.js` passes — `orphan_reason_duplicate_seed` added to all 26 locales (English placeholder, ready for translation)
- [x] Manual test (Tauri dev, Windows): two `.tmp` files with distinct seeds in one drive → plan emits two Resume items with correct `seed_hex` per file → first item executes against the right `.tmp` → after panic, plan correctly advances `current_index 0 → 1` and runs the second
- [ ] Re-test after PoC-Consortium/pocx#48 lands: a `.tmp` carrying a "fully complete" marker should rename itself to `.pocx` instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)