### PR TITLE
Unblock mainnet selection in node setup and settings

### DIFF
--- a/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
+++ b/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
@@ -202,11 +202,9 @@ interface ConnectionTestResult {
                   @if (nodeService.isInstalled()) {
                     <div class="config-section">
                       <h3 class="section-title">{{ 'network' | i18n }}</h3>
-                      <!-- #POCXTODO: mainnet blocker — network selector disabled until mainnet launch -->
                       <mat-radio-group
                         [(ngModel)]="activeConfig.network"
                         (change)="onManagedNetworkChange()"
-                        [disabled]="true"
                         class="horizontal-radio-group"
                       >
                         <mat-radio-button value="mainnet">{{ 'mainnet' | i18n }}</mat-radio-button>
@@ -285,11 +283,9 @@ interface ConnectionTestResult {
                   <!-- Network Section -->
                   <div class="config-section">
                     <h3 class="section-title">{{ 'network' | i18n }}</h3>
-                    <!-- #POCXTODO: mainnet blocker — network selector disabled until mainnet launch -->
                     <mat-radio-group
                       [(ngModel)]="activeConfig.network"
                       (change)="onNetworkChange()"
-                      [disabled]="true"
                       class="horizontal-radio-group"
                     >
                       <mat-radio-button value="mainnet">{{ 'mainnet' | i18n }}</mat-radio-button>

--- a/web-wallet/src/app/node/pages/node-setup/node-setup.component.ts
+++ b/web-wallet/src/app/node/pages/node-setup/node-setup.component.ts
@@ -86,11 +86,7 @@ import { getDefaultRpcPort } from '../../../store/settings/settings.state';
             </div>
 
             <label class="testnet-toggle">
-              <input
-                type="checkbox"
-                [checked]="testnetMode()"
-                (change)="toggleTestnetMode()"
-              />
+              <input type="checkbox" [checked]="testnetMode()" (change)="toggleTestnetMode()" />
               <span>{{ 'node_setup_testnet_mode' | i18n }}</span>
             </label>
           </div>

--- a/web-wallet/src/app/node/pages/node-setup/node-setup.component.ts
+++ b/web-wallet/src/app/node/pages/node-setup/node-setup.component.ts
@@ -85,13 +85,11 @@ import { getDefaultRpcPort } from '../../../store/settings/settings.state';
               </div>
             </div>
 
-            <!-- #POCXTODO: mainnet blocker — testnet forced on and disabled until mainnet launch -->
             <label class="testnet-toggle">
               <input
                 type="checkbox"
                 [checked]="testnetMode()"
                 (change)="toggleTestnetMode()"
-                disabled
               />
               <span>{{ 'node_setup_testnet_mode' | i18n }}</span>
             </label>
@@ -661,7 +659,7 @@ export class NodeSetupComponent implements OnInit, OnDestroy {
   // State
   readonly currentStep = signal(0);
   readonly selectedMode = signal<NodeMode>('managed');
-  readonly testnetMode = signal(true); // #POCXTODO: mainnet blocker — default to testnet until mainnet launch
+  readonly testnetMode = signal(false);
   readonly releaseInfo = signal<ReleaseInfo | null>(null);
   readonly isFetchingRelease = signal(false);
   readonly platformArch = signal<string>('unknown');


### PR DESCRIPTION
## Summary
- Drops the four `#POCXTODO: mainnet blocker` gates introduced for the testnet-only window: the disabled testnet toggle in the setup wizard and the two `[disabled]="true"` network radio groups in settings (managed + external).
- Flips the setup wizard's `testnetMode` default from `true` to `false` so mainnet is the default and testnet becomes opt-in.

## Test plan
- [ ] First-launch setup wizard: testnet checkbox is interactive; toggles between mainnet (default) and testnet without page error.
- [ ] Settings → managed mode: network radio group is enabled; switching mainnet ↔ testnet stops the node, persists, and restarts on the new network.
- [ ] Settings → external mode: network radio group is enabled; switching mainnet/testnet/regtest persists and the RPC host/port defaults follow.
- [ ] Existing testnet users on this build: their stored network preference is preserved (no forced flip on upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)