### PR TITLE
Move aggregator default port off Bitcoin's P2P 8333

### DIFF
--- a/web-wallet/src-tauri/src/aggregator/commands.rs
+++ b/web-wallet/src-tauri/src/aggregator/commands.rs
@@ -112,7 +112,7 @@ pub async fn start_aggregator(
     };
     let listen_address =
         if config.listen_address.ends_with(":0") || config.listen_address.ends_with(":1") {
-            format!("0.0.0.0:{}", effective_port + 1)
+            format!("0.0.0.0:{}", effective_port + 7)
         } else {
             config.listen_address.clone()
         };

--- a/web-wallet/src-tauri/src/aggregator/state.rs
+++ b/web-wallet/src-tauri/src/aggregator/state.rs
@@ -32,7 +32,7 @@ impl Default for AggregatorConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            listen_address: "0.0.0.0:8333".to_string(),
+            listen_address: "0.0.0.0:8339".to_string(),
             upstream_name: "local".to_string(),
             upstream_rpc_host: "127.0.0.1".to_string(),
             upstream_rpc_port: 8332,

--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -3187,7 +3187,7 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
       const nodeConfig = this.nodeService.config();
       const walletRpcHost = nodeConfig.rpcHost || '127.0.0.1';
       const walletRpcPort = nodeConfig.rpcPort || (nodeConfig.network === 'mainnet' ? 8332 : 18332);
-      const aggregatorPort = walletRpcPort + 1;
+      const aggregatorPort = walletRpcPort + 7;
       const useAggregator = data.aggregatorEnabled;
 
       // Build auth based on node config: aggregator needs no auth (local),
@@ -3303,11 +3303,12 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
    * The config is persisted in saveAndStart() after the mining config is saved.
    */
   private updateAggregatorFromSoloChain(chain: ChainConfig, enabled: boolean): void {
-    // Aggregator listens on upstream RPC port + 1, forwards to wallet RPC node
+    // Aggregator listens on upstream RPC port + 7 (e.g. mainnet 8332 → 8339,
+    // adjacent to PoCX P2P 8338; avoids Bitcoin's mainnet P2P port 8333).
     const nodeConfig = this.nodeService.config();
     const walletRpcHost = nodeConfig.rpcHost || '127.0.0.1';
     const walletRpcPort = nodeConfig.rpcPort || (nodeConfig.network === 'mainnet' ? 8332 : 18332);
-    const aggregatorPort = walletRpcPort + 1;
+    const aggregatorPort = walletRpcPort + 7;
     const config: AggregatorConfig = {
       enabled,
       listenAddress: `0.0.0.0:${aggregatorPort}`,


### PR DESCRIPTION
## Summary

- Aggregator's default `listen_address` was `0.0.0.0:8333` — that's **Bitcoin Core mainnet P2P**. The auto-fallback (`effective_rpc_port + 1`) similarly squatted on Bitcoin testnet3 P2P (18333) and regtest P2P (18444).
- Switched the default to `0.0.0.0:8339` and the offset to `+ 7`, landing the aggregator adjacent to PoCX P2P (8338) — `8332 RPC / 8338 P2P / 8339 aggregator` reads as one coherent cluster.
- 4 LOC + 1 comment across `state.rs`, `commands.rs`, and `setup-wizard.component.ts`. Existing user configs are unaffected (defaults only).

## Test plan

- [ ] Fresh install on mainnet — verify aggregator binds 8339, miner can connect through it
- [ ] Fresh install on testnet — verify aggregator binds 18339
- [ ] Existing install with persisted `aggregator-config.json` still using `:8333` — confirm migration story (no-op; existing config is honored)
- [ ] Setup wizard solo flow: aggregator-enabled chain config has `rpcPort: 8339`

🤖 Generated with [Claude Code](https://claude.com/claude-code)