### PR TITLE
Fix mainnet block explorer base URL

### DIFF
--- a/web-wallet/src/app/shared/services/block-explorer.service.ts
+++ b/web-wallet/src/app/shared/services/block-explorer.service.ts
@@ -9,7 +9,7 @@ import { ElectronService } from '../../core/services/electron.service';
  *
  * URLs are network-aware:
  * - Testnet: https://explorer.testnet.bitcoin-pocx.org/testnet
- * - Mainnet: https://explorer.bitcoin-pocx.org/mainnet
+ * - Mainnet: https://explorer.bitcoin-pocx.org
  *
  * Navigation is routed through ElectronService.openExternal so the OS browser
  * opens in the Tauri desktop build (plain window.open is blocked by the
@@ -29,7 +29,7 @@ export class BlockExplorerService {
   private getBaseUrl(): string {
     const net = this.network();
     if (net === 'mainnet') {
-      return 'https://explorer.bitcoin-pocx.org/mainnet';
+      return 'https://explorer.bitcoin-pocx.org';
     }
     // Default to testnet for both testnet and regtest
     return 'https://explorer.testnet.bitcoin-pocx.org/testnet';


### PR DESCRIPTION
## Summary
- Drop the `/mainnet` path segment from the mainnet block explorer base URL
- The live explorer at `explorer.bitcoin-pocx.org` serves `/tx/<txid>`, `/block/<hash>`, `/address/<addr>` directly from the host root, so the old base produced 404s

Closes #55

## Test plan
- [ ] On mainnet, click a transaction link and confirm it opens the correct tx page on the live explorer
- [ ] On mainnet, click a block link and confirm it opens the correct block page
- [ ] On mainnet, click an address link and confirm it opens the correct address page
- [ ] On testnet, confirm the existing testnet explorer links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)