### PR TITLE
Bump pocx crates to 1.0.3

### DIFF
--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -3942,9 +3942,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_address"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404339b8d5421577e8f597381e5a5df93716d31cc38c420224f4d433e8ab12e9"
+checksum = "9efd34855bc245e79801a0b440c4b780d4ffdde7913fe61a3974037fb56df9e3"
 dependencies = [
  "bech32",
  "bs58",
@@ -3952,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_aggregator"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdceb1c140c68c464729c19972e584c986e6338bb18c6394a77365a7d87fb1e4"
+checksum = "db764a91b9720a16382cb4f527889db26aaf00c6c5d60cc16f5347aa64298187"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3980,9 +3980,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_hashlib"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7121d441afb089154bca5d00c7fbf20612f37b72ef2a6d2a3baa581b491894"
+checksum = "6c293a820e79455ea60e3b7c1643e32f4e34a74a35fdf1de31a788879d2d4c5c"
 dependencies = [
  "hex",
  "page_size",
@@ -3990,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_miner"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6781650df63ceec77713827a41068d21816fe1fd337063feff15e481e76c7b22"
+checksum = "b10101c31c79546b4d792db3b746781c204c95408f4393fd3bc2d9e3c25b01f1"
 dependencies = [
  "bytesize",
  "cfg-if",
@@ -4026,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_plotfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb853529dd3a420e3cba1ed94bf9e1b6f8b131d92ec5007667c7f9ab2c557312"
+checksum = "95848f4b1ed25e4e613926254413d41548052ea81ca697a6211bddc40ea3a885"
 dependencies = [
  "cfg-if",
  "filetime",
@@ -4044,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_plotter_v2"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e4b86cc0980de94f0518d3894392834bc2d2342f409b8e8d415a93b61bb2fb"
+checksum = "a76d49e1eb6d1b00da44944332724c148c14f2e61c1f9ccec7c0c1767dc04fcc"
 dependencies = [
  "cfg-if",
  "clap",
@@ -4068,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_protocol"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafc2c16a0cb896fa5a9d75ccfd0f9b553bd72e717aa62ee4e4c4ceb9a5ebf25"
+checksum = "c444a16f647c97aec49901e52759e058c360be792967cbba229f9f3f921061a0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -46,10 +46,10 @@ num_cpus = "1.16"
 tokio = { version = "1", features = ["full"] }
 
 # PoCX mining libraries
-pocx_miner = "1.0.2"
-pocx_plotter_v2 = { version = "1.0.2", features = ["opencl"] }
-pocx_address = "1.0.2"
-pocx_aggregator = "1.0.2"
+pocx_miner = "1.0.3"
+pocx_plotter_v2 = { version = "1.0.3", features = ["opencl"] }
+pocx_address = "1.0.3"
+pocx_aggregator = "1.0.3"
 
 
 # SHA256 hashing for node binary verification


### PR DESCRIPTION
## Summary
- Bumps `pocx_miner`, `pocx_plotter_v2`, `pocx_address`, and `pocx_aggregator` from 1.0.2 to 1.0.3.
- Cargo.lock regenerated — transitive `pocx_hashlib`, `pocx_plotfile`, and `pocx_protocol` also move to 1.0.3.

## Test plan
- [x] `cargo check` from `web-wallet/src-tauri/` resolves and compiles cleanly against 1.0.3.
- [ ] Smoke-test mining and plotting on desktop (CPU + GPU paths) to confirm no behavioural regressions from the upstream bump.
- [ ] Smoke-test aggregator pool path (assignment + deadline submission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)