### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-wallet",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-pocx"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-pocx"
-version = "2.0.0"
+version = "2.0.1"
 description = "Phoenix PoCX Wallet - Bitcoin-PoCX Desktop Wallet"
 authors = ["The Proof of Capacity Consortium <development@pocx.io>"]
 license = "GPL-3.0"

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phoenix PoCX Wallet",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "identifier": "org.pocx.phoenix",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Summary
Bumps the project version from 2.0.0 → 2.0.1 in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)