### PR TITLE
Move CryptoGuru Mainnet to top of pool preset list

### DIFF
--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -1011,14 +1011,14 @@ interface ChainModalData {
                   (ngModelChange)="updateChainModal('poolUrl', $event)"
                 >
                   <option value="">{{ 'setup_select_pool_placeholder' | i18n }}</option>
+                  <option value="https://btcx-pool.cryptoguru.org:443">
+                    CryptoGuru Mainnet (btcx-pool.cryptoguru.org)
+                  </option>
                   <option value="https://pool.bitcoin-pocx.org:443">
                     Nogrod Mainnet (pool.bitcoin-pocx.org)
                   </option>
                   <option value="https://pool.testnet.bitcoin-pocx.org:443">
                     Nogrod Testnet (pool.testnet.bitcoin-pocx.org)
-                  </option>
-                  <option value="https://btcx-pool.cryptoguru.org:443">
-                    CryptoGuru Mainnet (btcx-pool.cryptoguru.org)
                   </option>
                 </select>
               </div>


### PR DESCRIPTION
## Summary
Reorders the pool preset dropdown in the mining setup wizard so CryptoGuru Mainnet appears first, before the Nogrod Mainnet/Testnet entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)