### PR TITLE
Align @tauri-apps/api with Rust tauri 2.11.x

### DIFF
--- a/web-wallet/package-lock.json
+++ b/web-wallet/package-lock.json
@@ -29,7 +29,7 @@
         "@scure/base": "^2.0.0",
         "@scure/bip32": "^2.0.1",
         "@scure/bip39": "^2.0.1",
-        "@tauri-apps/api": "^2.5.0",
+        "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "^2.2.1",
         "@tauri-apps/plugin-http": "^2.3.1",
         "@tauri-apps/plugin-notification": "^2.2.2",
@@ -6483,9 +6483,9 @@
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -39,7 +39,7 @@
     "@scure/base": "^2.0.0",
     "@scure/bip32": "^2.0.1",
     "@scure/bip39": "^2.0.1",
-    "@tauri-apps/api": "^2.5.0",
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.2.1",
     "@tauri-apps/plugin-http": "^2.3.1",
     "@tauri-apps/plugin-notification": "^2.2.2",


### PR DESCRIPTION
## Summary
- Bumps `@tauri-apps/api` semver from `^2.5.0` to `^2.11.0` in `package.json` so the lockfile resolves to 2.11.0.
- Brings the npm side in line with the Rust `tauri` crate at 2.11.2, which Cargo picked up during the dep refresh in #71.

## Why
After #71, `npm run tauri:dev` printed:

```
Error Found version mismatched Tauri packages. Make sure the NPM package and Rust crate versions are on the same major/minor releases:
tauri (v2.11.2) : @tauri-apps/api (v2.10.1)
```

Warning only — didn't block the build — but it shows up every startup. This clears it.

## Test plan
- [x] `npm run build` — clean, only the pre-existing CSS budget warnings on mining components.
- [ ] `npm run tauri:dev` after merge to confirm the mismatch warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)