### PR TITLE
Address CodeQL findings: exact pool host match + ignore dist/

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           languages: javascript-typescript
           queries: security-and-quality
+          # Skip generated build artifacts — the quality query suite flags
+          # minified/tree-shaken output with rules that don't apply to source.
+          paths-ignore: |
+            web-wallet/dist
+            web-wallet/node_modules
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -3214,22 +3214,21 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
         priority: editing?.priority ?? this.chainConfigs().length + 1,
       };
     } else if (data.mode === 'pool') {
-      // Match the known pool endpoints so the chain shows up with a
-      // friendly name. The testnet URL contains `pool.testnet.bitcoin-pocx.org`
-      // (not `pool.bitcoin-pocx.org`), so test for the testnet variant first.
+      // Parse pool URL to extract host and port
+      const { transport, host, port } = this.parseUrl(data.poolUrl);
+
+      // Match known pool hosts (exact equality, not substring) so the chain
+      // shows up with a friendly name.
       let poolName: string;
-      if (data.poolUrl.includes('pool.testnet.bitcoin-pocx.org')) {
+      if (host === 'pool.testnet.bitcoin-pocx.org') {
         poolName = 'Nogrod Testnet';
-      } else if (data.poolUrl.includes('pool.bitcoin-pocx.org')) {
+      } else if (host === 'pool.bitcoin-pocx.org') {
         poolName = 'Nogrod Mainnet';
-      } else if (data.poolUrl.includes('btcx-pool.cryptoguru.org')) {
+      } else if (host === 'btcx-pool.cryptoguru.org') {
         poolName = 'CryptoGuru Mainnet';
       } else {
         poolName = data.chainName || 'Pool';
       }
-
-      // Parse pool URL to extract host and port
-      const { transport, host, port } = this.parseUrl(data.poolUrl);
 
       chain = {
         id,


### PR DESCRIPTION
## Summary

Cleans up the open findings on https://github.com/PoC-Consortium/phoenix-pocx/security/code-scanning (89 open alerts, 86 of which are noise from scanning built bundles).

### 1. Pool-name resolution → exact hostname match

`web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts:3221-3225` previously picked the friendly chain name with `data.poolUrl.includes('pool.bitcoin-pocx.org')` etc. CodeQL flagged this with `js/incomplete-url-substring-sanitization` (3× **high**) because a URL like `https://evil.com/pool.bitcoin-pocx.org` would substring-match and be labelled as the official pool in the UI.

The fix hoists the existing `this.parseUrl(data.poolUrl)` call (which already uses the WHATWG `URL` constructor) above the name-resolution block and compares `host === 'pool.bitcoin-pocx.org'` directly. The actual RPC connection target was always taken from `parseUrl`, so this only ever affected the *display label* — but the new shape is also genuinely safer and removes the dependency on test ordering between the testnet/mainnet substrings.

### 2. CodeQL `paths-ignore` for `dist/` and `node_modules/`

The `security.yml` workflow runs `npm run build` before analysis. The `security-and-quality` query suite then fires ~86 alerts on the minified output in `web-wallet/dist/` — rules like `js/trivial-conditional`, `js/useless-expression`, `js/automatic-semicolon-insertion` that are artifacts of minification/tree-shaking, not real bugs. Added `paths-ignore` to the CodeQL init step to skip generated artifacts, keeping the quality suite useful on source without the noise.

Weekly cron schedule unchanged per offline discussion.

## Expected result after merge

| Before | After |
|---:|---:|
| 89 open alerts (3 src, 86 dist) | 0 open alerts |

## Test plan
- [ ] After merge, trigger the Security workflow manually (`workflow_dispatch`) or wait for Monday's cron.
- [ ] Confirm https://github.com/PoC-Consortium/phoenix-pocx/security/code-scanning drops to 0 open alerts.
- [ ] In the mining setup wizard, paste each of the known pool URLs and confirm the chain name still resolves to "Nogrod Testnet" / "Nogrod Mainnet" / "CryptoGuru Mainnet".
- [ ] Paste a custom pool URL (e.g. `http://example.com:8080`) and confirm it falls back to `data.chainName || 'Pool'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)