### PR TITLE
Fix active-chain card stuck on "Scanning 100%" after last chain finishes

### DIFF
--- a/web-wallet/src/app/mining/services/mining.service.ts
+++ b/web-wallet/src/app/mining/services/mining.service.ts
@@ -2227,6 +2227,28 @@ export class MiningService {
       'miner:scan-status',
       async event => {
         if (event.payload.status === 'finished') {
+          // Mark this chain's scan as complete. scanProgress is a single shared
+          // object tracking only the actively-scanning chain, and progress is
+          // accumulated from warpsDelta events that may not sum to exactly
+          // totalWarps (leaving e.g. 99.x%, which rounds to "100" while still
+          // < 100). For every chain but the last in a round, the next chain's
+          // scan-started resets it; the last chain has no follow-up scan until
+          // the next block, so without this it stays stuck showing "Scanning
+          // 100%". Force progress to 100 so the dashboard's (progress < 100)
+          // guard flips it back to "Ready".
+          this._minerState.update(s =>
+            s.scanProgress.chain === event.payload.chain
+              ? {
+                  ...s,
+                  scanProgress: {
+                    ...s.scanProgress,
+                    scannedWarps: s.scanProgress.totalWarps,
+                    progress: 100,
+                  },
+                }
+              : s
+          );
+
           // Fetch bounded deadline list from backend (720/chain cap enforced there)
           const deadlines = await this.fetchRecentDeadlines();
           this._minerState.update(s => ({ ...s, recentDeadlines: deadlines }));


### PR DESCRIPTION
## Problem

In a multi-chain setup, after the **last** chain in a round finishes scanning, its active-chain card on the mining dashboard sometimes stays stuck showing **"Scanning 100%"** instead of returning to **"Ready"**. It's intermittent and self-heals on the next block.

Example reported by a user (two chains):

```
Chain               Height   Difficulty    PoW Scale      Status
CryptoGuru Mainnet  24.918   24010.9 TiB   POCX1-POCX2    Ready
Local Test          24.918   24010.9 TiB   POCX1-POCX2    Scanning 100%   <-- stuck
```

## Root cause

The dashboard derives each chain's status from a **single shared `scanProgress` signal** that only ever tracks the one actively-scanning chain. Two things combine:

1. `progress` is accumulated from `warpsDelta` events and may not sum to *exactly* `totalWarps`, so a finished scan often lands at ~99.x%. `toFixed(0)` rounds that to **"100"**, but the value is still `< 100`, so `getChainStatus`'s `progress < 100` "scanning" branch stays true.
2. The `miner:scan-status` → `finished` handler never marks `scanProgress` complete — it only refetches deadlines.

For every chain **except the last in a round**, the next chain's `scan-started` event resets `scanProgress`, wiping the stale near-100 value → those chains show "Ready". The **last** chain to finish has no follow-up `scan-started` until the next block, so its ~99.x% state lingers → "Scanning 100%". The reporter's logs confirm it: the last `finished` is immediately followed by `queue: [] waiting for new block` with nothing resetting state.

## Fix

In the `miner:scan-status` `finished` handler, mark the finishing chain's `scanProgress` as complete (`progress = 100`, `scannedWarps = totalWarps`), guarded by a chain match. That flips the dashboard's `progress < 100` guard so the chain immediately shows "Ready".

This is a frontend-display-only fix; the miner itself behaves correctly.

## Testing

Manual: run `npm run tauri:dev` with a two-chain setup and confirm both cards return to "Ready" after the second chain finishes a round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
