### PR TITLE
Make plot file size configurable in GiB (#80)

### DIFF
--- a/web-wallet/src-tauri/src/mining/state.rs
+++ b/web-wallet/src-tauri/src/mining/state.rs
@@ -152,7 +152,9 @@ pub enum PlotPlanItem {
         #[serde(rename = "batchId")]
         batch_id: u32,
     },
-    /// Create new plot file (1024 warps = 1 TiB, or remainder)
+    /// Create new plot file. `warps` is the per-file size (1 warp = 1 GiB),
+    /// derived from the user-configured `plot_file_size_gib` (default 1024 =
+    /// 1 TiB), or a smaller remainder for the leftover tail.
     Plot {
         path: String,
         warps: u64,
@@ -207,6 +209,8 @@ pub struct MiningConfig {
     pub low_priority: bool,
     #[serde(default = "default_parallel_drives")]
     pub parallel_drives: u32, // Number of drives to plot simultaneously (default 1)
+    #[serde(default = "default_plot_file_size_gib")]
+    pub plot_file_size_gib: u64, // Per-plot-file size in GiB (1 warp = 1 GiB), default 1024 (1 TiB)
     pub hdd_wakeup_seconds: i64,
     #[serde(default)]
     pub simulation_mode: bool, // Dev only: run plotter in benchmark mode (no disk writes)
@@ -263,6 +267,10 @@ fn default_parallel_drives() -> u32 {
     1
 }
 
+fn default_plot_file_size_gib() -> u64 {
+    1024 // 1024 GiB = 1 TiB (preserves the legacy fixed file size)
+}
+
 fn default_poll_interval() -> u64 {
     1000
 }
@@ -305,6 +313,7 @@ impl Default for MiningConfig {
             async_write: default_async_write(),
             low_priority: false,
             parallel_drives: 1,
+            plot_file_size_gib: default_plot_file_size_gib(),
             hdd_wakeup_seconds: 30,
             simulation_mode: false,
             auto_start: false,

--- a/web-wallet/src/app/mining/models/mining.models.ts
+++ b/web-wallet/src/app/mining/models/mining.models.ts
@@ -158,6 +158,7 @@ export interface MiningConfig {
   asyncWrite?: boolean; // Async disk writes (v2 plotter, default true)
   lowPriority?: boolean;
   parallelDrives?: number; // Number of drives to plot simultaneously (default 1)
+  plotFileSizeGib?: number; // Per-plot-file size in GiB (1 warp = 1 GiB); default 1024 (1 TiB)
   hddWakeupSeconds: number;
   // Note: plotPlan has been removed - plan is now runtime-only in PlotterState
   simulationMode?: boolean; // Dev only: run plotter in benchmark mode (no disk writes)

--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -609,6 +609,19 @@ interface ChainModalData {
                     class="escalation-input"
                   />
                 </div>
+                <div class="form-group escalation-group">
+                  <label>{{ 'setup_plot_file_size' | i18n }}</label>
+                  <input
+                    type="number"
+                    [ngModel]="plotFileSizeGib()"
+                    (ngModelChange)="onPlotFileSizeChange($event)"
+                    [min]="MIN_PLOT_FILE_SIZE_GIB"
+                    [max]="MAX_PLOT_FILE_SIZE_GIB"
+                    step="1"
+                    class="escalation-input"
+                    [title]="'setup_plot_file_size_hint' | i18n"
+                  />
+                </div>
                 <div class="form-group">
                   <label>{{ 'setup_pow_scaling' | i18n }}</label>
                   <select
@@ -2647,6 +2660,9 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
   // Step 3: Drives config
   readonly driveConfigs = signal<DriveConfig[]>([]);
   readonly parallelDrives = signal(1); // Number of drives to plot simultaneously
+  readonly plotFileSizeGib = signal(1024); // Per-plot-file size in GiB (1 warp = 1 GiB)
+  readonly MIN_PLOT_FILE_SIZE_GIB = 8; // Smallest practical file; avoids excessive file counts
+  readonly MAX_PLOT_FILE_SIZE_GIB = 16384; // 16 TiB cap; large drives can hold bigger files
   readonly hddWakeup = signal(30);
   readonly miningDirectIo = signal(true);
   readonly systemDriveMaxPercent = signal(80);
@@ -3017,6 +3033,9 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
         }
         if (config.parallelDrives) {
           this.parallelDrives.set(config.parallelDrives);
+        }
+        if (config.plotFileSizeGib) {
+          this.onPlotFileSizeChange(config.plotFileSizeGib);
         }
         if (config.compressionLevel !== undefined) {
           this.compressionLevel.set(config.compressionLevel.toString());
@@ -3443,6 +3462,16 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
 
   onEscalationChange(value: number): void {
     this.escalation.set(Math.max(1, value));
+  }
+
+  onPlotFileSizeChange(value: number): void {
+    // Clamp to sane bounds; 1 warp = 1 GiB so the value maps directly to warps.
+    const gib = Math.floor(Number(value) || this.MIN_PLOT_FILE_SIZE_GIB);
+    const clamped = Math.min(
+      this.MAX_PLOT_FILE_SIZE_GIB,
+      Math.max(this.MIN_PLOT_FILE_SIZE_GIB, gib)
+    );
+    this.plotFileSizeGib.set(clamped);
   }
 
   async onCustomAddressChange(address: string): Promise<void> {
@@ -3904,6 +3933,7 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
         asyncWrite: this.asyncWrite(),
         lowPriority: this.lowPriority(),
         parallelDrives: this.parallelDrives(),
+        plotFileSizeGib: this.plotFileSizeGib(),
         hddWakeupSeconds: this.hddWakeup(),
         // Miner advanced settings
         pollInterval: this.pollInterval(),

--- a/web-wallet/src/app/mining/services/mining.service.ts
+++ b/web-wallet/src/app/mining/services/mining.service.ts
@@ -1732,6 +1732,7 @@ export class MiningService {
     // Generate plan using the service
     const plan = this.plotPlanService.generatePlan(driveInfos, config.drives, {
       parallelDrives: config.parallelDrives ?? 1,
+      plotFileSizeGib: config.plotFileSizeGib ?? 1024,
     });
 
     // Check if there's any work to do

--- a/web-wallet/src/app/mining/services/plot-plan.service.ts
+++ b/web-wallet/src/app/mining/services/plot-plan.service.ts
@@ -8,10 +8,13 @@ import {
   PlotPlanStats,
 } from '../models';
 
-const BATCH_SIZE = 1024; // 1024 warps = 1 TiB
+// Default per-file size when none is configured: 1024 warps = 1 TiB.
+// 1 warp = 1 GiB, so the batch size (in warps) equals the configured GiB.
+const DEFAULT_BATCH_SIZE = 1024;
 
 interface PlotConfig {
   parallelDrives: number;
+  plotFileSizeGib?: number; // Per-file size in GiB (1 warp = 1 GiB); default 1024 (1 TiB)
 }
 
 interface DriveState {
@@ -32,6 +35,13 @@ export class PlotPlanService {
     const plan: PlotPlanItem[] = [];
     const finishedDrives: string[] = [];
     let batchId = 0;
+
+    // Per-file plot size in warps (1 warp = 1 GiB). Falls back to the legacy
+    // 1 TiB default when unset or invalid so existing configs are unaffected.
+    const batchSize =
+      config.plotFileSizeGib && config.plotFileSizeGib > 0
+        ? Math.floor(config.plotFileSizeGib)
+        : DEFAULT_BATCH_SIZE;
 
     // Build drive state from DriveInfo + DriveConfig
     const driveStates: DriveState[] = drives.map(drive => {
@@ -69,8 +79,8 @@ export class PlotPlanService {
       const resumeTasks = drive.incompleteFiles;
       const toPlot = drive.allocatedGib - drive.completeSizeGib;
       const newPlots = Math.max(0, toPlot - drive.incompleteSizeGib);
-      const plotBatches = Math.floor(newPlots / BATCH_SIZE);
-      const remainderWarps = Math.round(newPlots % BATCH_SIZE);
+      const plotBatches = Math.floor(newPlots / batchSize);
+      const remainderWarps = Math.round(newPlots % batchSize);
       const hasRemainder = remainderWarps > 0;
       const totalTasks = resumeTasks + plotBatches + (hasRemainder ? 1 : 0);
 
@@ -181,8 +191,8 @@ export class PlotPlanService {
       const newPlots = Math.max(0, toPlot - drive.incompleteSizeGib);
 
       if (newPlots > 0) {
-        const fullBatches = Math.floor(newPlots / BATCH_SIZE);
-        const remainderWarps = Math.round(newPlots % BATCH_SIZE);
+        const fullBatches = Math.floor(newPlots / batchSize);
+        const remainderWarps = Math.round(newPlots % batchSize);
         driveWork.push({
           path: drive.path,
           fullBatches,
@@ -208,7 +218,7 @@ export class PlotPlanService {
       for (let i = 0; i < work.fullBatches; i++) {
         items.push({
           path: work.path,
-          warps: BATCH_SIZE,
+          warps: batchSize,
           isRemainder: false,
           driveRemainingTasks: totalItems - i,
         });
@@ -383,6 +393,7 @@ export class PlotPlanService {
         allocated: c.allocatedGib,
       })),
       parallelDrives: config.parallelDrives,
+      plotFileSizeGib: config.plotFileSizeGib ?? DEFAULT_BATCH_SIZE,
     };
     // Simple hash: JSON stringify and sum char codes
     const json = JSON.stringify(data);

--- a/web-wallet/src/assets/locales/bg.json
+++ b/web-wallet/src/assets/locales/bg.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Асинхронен запис на диска",
   "setup_max": "Макс:",
   "setup_memory_escalation": "Фактор на ескалация на паметта",
+  "setup_plot_file_size": "Размер на плот файл (GiB)",
+  "setup_plot_file_size_hint": "Размер на всеки плот файл в GiB. По подразбиране 1024 (1 TiB).",
   "setup_mining_direct_io": "Използвай директен I/O за добив",
   "setup_mining_setup": "Настройка на добив",
   "setup_mining_threads": "Нишки за добив:",

--- a/web-wallet/src/assets/locales/ca.json
+++ b/web-wallet/src/assets/locales/ca.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Escriptures de disc asíncrones",
   "setup_max": "Màx:",
   "setup_memory_escalation": "Factor d'escalada de memòria",
+  "setup_plot_file_size": "Mida del fitxer de plot (GiB)",
+  "setup_plot_file_size_hint": "Mida de cada fitxer de plot en GiB. Per defecte 1024 (1 TiB).",
   "setup_mining_direct_io": "Utilitzar E/S directa per a la mineria",
   "setup_mining_setup": "Configuració de mineria",
   "setup_mining_threads": "Fils de mineria:",

--- a/web-wallet/src/assets/locales/cs.json
+++ b/web-wallet/src/assets/locales/cs.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asynchronní zápis na disk",
   "setup_max": "Max:",
   "setup_memory_escalation": "Faktor eskalace pameti",
+  "setup_plot_file_size": "Velikost plot souboru (GiB)",
+  "setup_plot_file_size_hint": "Velikost každého plot souboru v GiB. Výchozí 1024 (1 TiB).",
   "setup_mining_direct_io": "Pouzit primo I/O pro tezbu",
   "setup_mining_setup": "Nastaveni tezby",
   "setup_mining_threads": "Vlakna tezby:",

--- a/web-wallet/src/assets/locales/de-de.json
+++ b/web-wallet/src/assets/locales/de-de.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asynchrone Festplattenschreibvorgänge",
   "setup_max": "Max:",
   "setup_memory_escalation": "Speichereskalationsfaktor",
+  "setup_plot_file_size": "Plot-Dateigröße (GiB)",
+  "setup_plot_file_size_hint": "Größe jeder Plot-Datei in GiB. Standard 1024 (1 TiB).",
   "setup_mining_direct_io": "Direct I/O fuer Mining verwenden",
   "setup_mining_setup": "Mining-Einrichtung",
   "setup_mining_threads": "Mining-Threads:",

--- a/web-wallet/src/assets/locales/el.json
+++ b/web-wallet/src/assets/locales/el.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Ασύγχρονη εγγραφή δίσκου",
   "setup_max": "Μέγ.:",
   "setup_memory_escalation": "Συντελεστής κλιμάκωσης μνήμης",
+  "setup_plot_file_size": "Μέγεθος αρχείου plot (GiB)",
+  "setup_plot_file_size_hint": "Μέγεθος κάθε αρχείου plot σε GiB. Προεπιλογή 1024 (1 TiB).",
   "setup_mining_direct_io": "Χρήση Direct I/O για εξόρυξη",
   "setup_mining_setup": "Ρύθμιση εξόρυξης",
   "setup_mining_threads": "Νήματα εξόρυξης:",

--- a/web-wallet/src/assets/locales/en.json
+++ b/web-wallet/src/assets/locales/en.json
@@ -428,6 +428,8 @@
   "setup_available_ram": "Available RAM",
   "setup_drives_in_parallel": "Drives to Plot in Parallel",
   "setup_memory_escalation": "Memory Escalation Factor",
+  "setup_plot_file_size": "Plot File Size (GiB)",
+  "setup_plot_file_size_hint": "Size of each plot file in GiB. Default 1024 (1 TiB).",
   "setup_pow_scaling": "PoW Scaling",
   "setup_pow_x1": "X1: Years 0–4 (recommended)",
   "setup_pow_x2": "X2: Years 0–12",

--- a/web-wallet/src/assets/locales/es-es.json
+++ b/web-wallet/src/assets/locales/es-es.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Escrituras de disco asíncronas",
   "setup_max": "Máx:",
   "setup_memory_escalation": "Factor de escalación de memoria",
+  "setup_plot_file_size": "Tamaño de archivo de plot (GiB)",
+  "setup_plot_file_size_hint": "Tamaño de cada archivo de plot en GiB. Predeterminado 1024 (1 TiB).",
   "setup_mining_direct_io": "Usar E/S directa para minería",
   "setup_mining_setup": "Configuración de minería",
   "setup_mining_threads": "Hilos de minería:",

--- a/web-wallet/src/assets/locales/fi.json
+++ b/web-wallet/src/assets/locales/fi.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asynkroninen levykirjoitus",
   "setup_max": "Maks:",
   "setup_memory_escalation": "Muistin eskaloitumiskerroin",
+  "setup_plot_file_size": "Plot-tiedoston koko (GiB)",
+  "setup_plot_file_size_hint": "Kunkin plot-tiedoston koko GiB:nä. Oletus 1024 (1 TiB).",
   "setup_mining_direct_io": "Kayta suoraa I/O:ta louhintaan",
   "setup_mining_setup": "Louhinnan asetukset",
   "setup_mining_threads": "Louhintasaikeet:",

--- a/web-wallet/src/assets/locales/fr.json
+++ b/web-wallet/src/assets/locales/fr.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Écritures disque asynchrones",
   "setup_max": "Max :",
   "setup_memory_escalation": "Facteur d'escalade memoire",
+  "setup_plot_file_size": "Taille du fichier de plot (GiB)",
+  "setup_plot_file_size_hint": "Taille de chaque fichier de plot en GiB. Par defaut 1024 (1 TiB).",
   "setup_mining_direct_io": "Utiliser les E/S directes pour le minage",
   "setup_mining_setup": "Configuration du minage",
   "setup_mining_threads": "Threads de minage :",

--- a/web-wallet/src/assets/locales/gl.json
+++ b/web-wallet/src/assets/locales/gl.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Escrituras de disco asíncronas",
   "setup_max": "Máx:",
   "setup_memory_escalation": "Factor de escalado de memoria",
+  "setup_plot_file_size": "Tamaño do ficheiro de plot (GiB)",
+  "setup_plot_file_size_hint": "Tamaño de cada ficheiro de plot en GiB. Predeterminado 1024 (1 TiB).",
   "setup_mining_direct_io": "Usar E/S directa para minaría",
   "setup_mining_setup": "Configuración de minaría",
   "setup_mining_threads": "Fíos de minaría:",

--- a/web-wallet/src/assets/locales/hi.json
+++ b/web-wallet/src/assets/locales/hi.json
@@ -666,6 +666,8 @@
   "setup_async_write": "एसिंक्रोनस डिस्क राइट",
   "setup_max": "अधिकतम:",
   "setup_memory_escalation": "मेमोरी एस्केलेशन फैक्टर",
+  "setup_plot_file_size": "प्लॉट फ़ाइल आकार (GiB)",
+  "setup_plot_file_size_hint": "प्रत्येक प्लॉट फ़ाइल का आकार GiB में। डिफ़ॉल्ट 1024 (1 TiB)।",
   "setup_mining_direct_io": "माइनिंग के लिए डायरेक्ट I/O उपयोग करें",
   "setup_mining_setup": "माइनिंग सेटअप",
   "setup_mining_threads": "माइनिंग थ्रेड्स:",

--- a/web-wallet/src/assets/locales/hr.json
+++ b/web-wallet/src/assets/locales/hr.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asinkrono pisanje na disk",
   "setup_max": "Maks:",
   "setup_memory_escalation": "Faktor eskalacije memorije",
+  "setup_plot_file_size": "Veličina plot datoteke (GiB)",
+  "setup_plot_file_size_hint": "Veličina svake plot datoteke u GiB. Zadano 1024 (1 TiB).",
   "setup_mining_direct_io": "Koristi izravni I/O za rudarenje",
   "setup_mining_setup": "Postavljanje rudarenja",
   "setup_mining_threads": "Dretve za rudarenje:",

--- a/web-wallet/src/assets/locales/id.json
+++ b/web-wallet/src/assets/locales/id.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Penulisan Disk Asinkron",
   "setup_max": "Maks:",
   "setup_memory_escalation": "Faktor Eskalasi Memori",
+  "setup_plot_file_size": "Ukuran File Plot (GiB)",
+  "setup_plot_file_size_hint": "Ukuran setiap file plot dalam GiB. Default 1024 (1 TiB).",
   "setup_mining_direct_io": "Gunakan I/O Langsung untuk penambangan",
   "setup_mining_setup": "Pengaturan Penambangan",
   "setup_mining_threads": "Thread Penambangan:",

--- a/web-wallet/src/assets/locales/it.json
+++ b/web-wallet/src/assets/locales/it.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Scritture disco asincrone",
   "setup_max": "Max:",
   "setup_memory_escalation": "Fattore di escalation memoria",
+  "setup_plot_file_size": "Dimensione file di plot (GiB)",
+  "setup_plot_file_size_hint": "Dimensione di ogni file di plot in GiB. Predefinito 1024 (1 TiB).",
   "setup_mining_direct_io": "Usa I/O diretto per il mining",
   "setup_mining_setup": "Configurazione mining",
   "setup_mining_threads": "Thread di mining:",

--- a/web-wallet/src/assets/locales/ja.json
+++ b/web-wallet/src/assets/locales/ja.json
@@ -666,6 +666,8 @@
   "setup_async_write": "非同期ディスク書き込み",
   "setup_max": "最大:",
   "setup_memory_escalation": "メモリエスカレーション係数",
+  "setup_plot_file_size": "プロットファイルサイズ (GiB)",
+  "setup_plot_file_size_hint": "各プロットファイルのサイズ（GiB）。デフォルト 1024（1 TiB）。",
   "setup_mining_direct_io": "マイニングにダイレクトI/Oを使用",
   "setup_mining_setup": "マイニングセットアップ",
   "setup_mining_threads": "マイニングスレッド:",

--- a/web-wallet/src/assets/locales/lt.json
+++ b/web-wallet/src/assets/locales/lt.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asinchroninis disko rašymas",
   "setup_max": "Maks:",
   "setup_memory_escalation": "Atminties eskalavimo koeficientas",
+  "setup_plot_file_size": "Plot failo dydis (GiB)",
+  "setup_plot_file_size_hint": "Kiekvieno plot failo dydis GiB. Numatytasis 1024 (1 TiB).",
   "setup_mining_direct_io": "Naudoti tiesiogini I/O kasybai",
   "setup_mining_setup": "Kasybos nustatymai",
   "setup_mining_threads": "Kasybos gijos:",

--- a/web-wallet/src/assets/locales/nl.json
+++ b/web-wallet/src/assets/locales/nl.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asynchrone schijfschrijfbewerkingen",
   "setup_max": "Max:",
   "setup_memory_escalation": "Geheugen Escalatie Factor",
+  "setup_plot_file_size": "Plotbestandsgrootte (GiB)",
+  "setup_plot_file_size_hint": "Grootte van elk plotbestand in GiB. Standaard 1024 (1 TiB).",
   "setup_mining_direct_io": "Direct I/O gebruiken voor mijnbouw",
   "setup_mining_setup": "Mijnbouw Instellingen",
   "setup_mining_threads": "Mijnbouw Threads:",

--- a/web-wallet/src/assets/locales/pl.json
+++ b/web-wallet/src/assets/locales/pl.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asynchroniczny zapis na dysku",
   "setup_max": "Max:",
   "setup_memory_escalation": "Wspolczynnik eskalacji pamieci",
+  "setup_plot_file_size": "Rozmiar pliku plot (GiB)",
+  "setup_plot_file_size_hint": "Rozmiar każdego pliku plot w GiB. Domyślnie 1024 (1 TiB).",
   "setup_mining_direct_io": "Uzyj Direct I/O do gornictwa",
   "setup_mining_setup": "Konfiguracja gornictwa",
   "setup_mining_threads": "Watki gornictwa:",

--- a/web-wallet/src/assets/locales/pt-br.json
+++ b/web-wallet/src/assets/locales/pt-br.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Gravação assíncrona em disco",
   "setup_max": "Máx:",
   "setup_memory_escalation": "Fator de escalação de memória",
+  "setup_plot_file_size": "Tamanho do arquivo de plot (GiB)",
+  "setup_plot_file_size_hint": "Tamanho de cada arquivo de plot em GiB. Padrão 1024 (1 TiB).",
   "setup_mining_direct_io": "Usar I/O direto para mineração",
   "setup_mining_setup": "Configuração de mineração",
   "setup_mining_threads": "Threads de mineração:",

--- a/web-wallet/src/assets/locales/ro.json
+++ b/web-wallet/src/assets/locales/ro.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Scrieri asincrone pe disc",
   "setup_max": "Max:",
   "setup_memory_escalation": "Factor de escaladare memorie",
+  "setup_plot_file_size": "Dimensiune fișier plot (GiB)",
+  "setup_plot_file_size_hint": "Dimensiunea fiecărui fișier plot în GiB. Implicit 1024 (1 TiB).",
   "setup_mining_direct_io": "Folosește I/O direct pentru minerit",
   "setup_mining_setup": "Configurare minerit",
   "setup_mining_threads": "Fire de execuție minerit:",

--- a/web-wallet/src/assets/locales/ru.json
+++ b/web-wallet/src/assets/locales/ru.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Асинхронная запись на диск",
   "setup_max": "Макс:",
   "setup_memory_escalation": "Коэффициент эскалации памяти",
+  "setup_plot_file_size": "Размер файла плота (GiB)",
+  "setup_plot_file_size_hint": "Размер каждого файла плота в GiB. По умолчанию 1024 (1 TiB).",
   "setup_mining_direct_io": "Использовать Direct I/O для майнинга",
   "setup_mining_setup": "Настройка майнинга",
   "setup_mining_threads": "Потоки майнинга:",

--- a/web-wallet/src/assets/locales/sk.json
+++ b/web-wallet/src/assets/locales/sk.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asynchrónny zápis na disk",
   "setup_max": "Max:",
   "setup_memory_escalation": "Faktor eskalacia pamate",
+  "setup_plot_file_size": "Veľkosť plot súboru (GiB)",
+  "setup_plot_file_size_hint": "Veľkosť každého plot súboru v GiB. Predvolené 1024 (1 TiB).",
   "setup_mining_direct_io": "Pouzit priamy I/O pre tazbu",
   "setup_mining_setup": "Nastavenie tazby",
   "setup_mining_threads": "Tazobne vlakna:",

--- a/web-wallet/src/assets/locales/sr.json
+++ b/web-wallet/src/assets/locales/sr.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Асинхроно писање на диск",
   "setup_max": "Макс:",
   "setup_memory_escalation": "Фактор ескалације меморије",
+  "setup_plot_file_size": "Величина plot датотеке (GiB)",
+  "setup_plot_file_size_hint": "Величина сваке plot датотеке у GiB. Подразумевано 1024 (1 TiB).",
   "setup_mining_direct_io": "Користи директан I/O за рударење",
   "setup_mining_setup": "Подешавање рударења",
   "setup_mining_threads": "Нити за рударење:",

--- a/web-wallet/src/assets/locales/tr.json
+++ b/web-wallet/src/assets/locales/tr.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Asenkron Disk Yazımı",
   "setup_max": "Maks:",
   "setup_memory_escalation": "Bellek Artış Faktörü",
+  "setup_plot_file_size": "Plot Dosya Boyutu (GiB)",
+  "setup_plot_file_size_hint": "Her plot dosyasının boyutu (GiB). Varsayılan 1024 (1 TiB).",
   "setup_mining_direct_io": "Madencilik için Doğrudan G/Ç kullan",
   "setup_mining_setup": "Madencilik Kurulumu",
   "setup_mining_threads": "Madencilik İş Parçacıkları:",

--- a/web-wallet/src/assets/locales/uk.json
+++ b/web-wallet/src/assets/locales/uk.json
@@ -666,6 +666,8 @@
   "setup_async_write": "Асинхронний запис на диск",
   "setup_max": "Макс:",
   "setup_memory_escalation": "Коефіцієнт ескалації пам'яті",
+  "setup_plot_file_size": "Розмір файлу плоту (GiB)",
+  "setup_plot_file_size_hint": "Розмір кожного файлу плоту в GiB. За замовчуванням 1024 (1 TiB).",
   "setup_mining_direct_io": "Використовувати прямий I/O для майнінгу",
   "setup_mining_setup": "Налаштування майнінгу",
   "setup_mining_threads": "Потоки майнінгу:",

--- a/web-wallet/src/assets/locales/zh-cn.json
+++ b/web-wallet/src/assets/locales/zh-cn.json
@@ -666,6 +666,8 @@
   "setup_async_write": "异步磁盘写入",
   "setup_max": "最大：",
   "setup_memory_escalation": "内存递增系数",
+  "setup_plot_file_size": "绘图文件大小 (GiB)",
+  "setup_plot_file_size_hint": "每个绘图文件的大小（GiB）。默认 1024（1 TiB）。",
   "setup_mining_direct_io": "挖矿使用直接 I/O",
   "setup_mining_setup": "挖矿设置",
   "setup_mining_threads": "挖矿线程：",


### PR DESCRIPTION
Closes #80.

## Summary
The plotter previously emitted plot files of a fixed **1 TiB** (hardcoded `BATCH_SIZE = 1024` warps). This adds a user-configurable **"Plot File Size (GiB)"** setting under the plotting advanced options and derives the per-file warp batch size from it. Default stays **1024 GiB (1 TiB)** so existing setups are unchanged.

## Changes
- **Config (TS + Rust):** new `plotFileSizeGib` field in `MiningConfig` (`mining.models.ts`) and `plot_file_size_gib: u64` in `state.rs`, both defaulting to `1024` via serde default so existing `mining_config.json` files round-trip unaffected.
- **Plot planning:** `plot-plan.service.ts` derives the batch size (in warps) from the configured GiB — `1 warp = 1 GiB` — replacing the constant. The leftover remainder-file logic is unchanged. `plotFileSizeGib` is added to the config hash so changing it invalidates a cached plan.
- **Mining service:** passes `config.plotFileSizeGib ?? 1024` into `generatePlan`.
- **UI:** new bounded number input (8–16384 GiB) in the Step 2 *Advanced Options* form-row, with clamping on change and load/save wired through `saveAndStart`/`loadExistingConfig`.
- **i18n:** `setup_plot_file_size` (label) and `setup_plot_file_size_hint` (tooltip) added and translated across all **26 locales**; `check-keys.js` passes.

## Acceptance criteria
- [x] New "Plot File Size (GiB)" field in plotting advanced options, default 1024 GiB
- [x] Value persisted in mining config (TS + Rust), defaulted so existing configs are unaffected
- [x] Plot planning uses the configured size instead of hardcoded `1024`
- [x] Validation (8–16384 GiB bounds, clamped); smaller-than-allocation sizes just produce more files via existing remainder logic
- [x] New i18n keys added and synced across all 26 locales

## Open questions from the issue
- **Alignment/granularity:** size maps cleanly to warps (1 GiB = 1 warp), so any integer GiB is valid; the value is `Math.floor`-ed.
- **Max bound:** capped at 16 TiB rather than per-drive free space, since the limit is global while free space is per-drive; the existing planner already splits work into multiple files when a drive can't hold one full file.

## Testing
- `ng build` (development) passes — TypeScript + Angular template type-check clean.
- Locale `check-keys.js` reports all 25 non-English files match `en.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)