### PR TITLE
chore: bump version 2.0.2 -> 2.0.3

### DIFF
--- a/web-wallet/package-lock.json
+++ b/web-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-wallet",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-wallet",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@angular/animations": "^21.2.0",
         "@angular/cdk": "^21.2.0",

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-wallet",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-pocx"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "dirs",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-pocx"
-version = "2.0.2"
+version = "2.0.3"
 description = "Phoenix PoCX Wallet - Bitcoin-PoCX Desktop Wallet"
 authors = ["The Proof of Capacity Consortium <development@pocx.io>"]
 license = "GPL-3.0"

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phoenix PoCX Wallet",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "identifier": "org.pocx.phoenix",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Bumps the app version from `2.0.2` to `2.0.3` across all four version sources:

- `web-wallet/package.json`
- `web-wallet/package-lock.json`
- `web-wallet/src-tauri/Cargo.toml`
- `web-wallet/src-tauri/Cargo.lock`
- `web-wallet/src-tauri/tauri.conf.json`

Verified by building a local Windows NSIS installer (`Phoenix PoCX Wallet_2.0.3_x64-setup.exe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)