### PR TITLE
feat(mining): Android swap-aware memory budget + bump pocx 1.0.5

### DIFF
--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -3869,9 +3869,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_address"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe676e7559332d03568a17ba707e72dac5a9508679a410cd4173ffb365fb3870"
+checksum = "ea7c217832dc955d406c63eeaa06ea7b6b26c8d7132e70f973a8e28942725f8b"
 dependencies = [
  "bech32",
  "bs58",
@@ -3879,9 +3879,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_aggregator"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d739c3eb39bed9efeb0d5e2e959e5b69a6bfea6416b2ff40576dfb8b0591610"
+checksum = "1b93c6cd63a7b920786e0bb44899617006524ef46ed5f28abec237a0fd27e579"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3907,9 +3907,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_hashlib"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d7603ee7b23ae8587bddd25c11c616dde4fd7b15bcf703e9bd70f6ebc94c35"
+checksum = "97338a844879ef11e7540aad3c1bfdc4e1d4d4f6dea1616b660668a28f7698ee"
 dependencies = [
  "hex",
  "page_size",
@@ -3917,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_miner"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de2ce2bae3908a0d5f9444116ee9acdd241e66483dbc64d62008be650474b88"
+checksum = "6f464d9e39596bef2b938a3484a0f9492ea3b348d474ee8f29232b33b5d1c952"
 dependencies = [
  "bytesize",
  "cfg-if",
@@ -3953,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_plotfile"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764b981c972c48a59e7f2ea17d810868e1ab414963fe15b73725f97151af5372"
+checksum = "1fe8cf58a99ff65293078b932a50138b06f2702c9de81602a90b515236af0363"
 dependencies = [
  "cfg-if",
  "filetime",
@@ -3971,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_plotter_v2"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41539a190964f227261a1cf6245e7713de4391f8d731bd753b2401fab098e8b2"
+checksum = "60e0b4c159c8a14933bce3150cabfd113d40dc52d11f0e93ff34399bb3a95007"
 dependencies = [
  "cfg-if",
  "clap",
@@ -3995,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "pocx_protocol"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18ef849f0ad12323413c41a95eebbab0b86d86f83b6a85d58134e6dd62ee9ff"
+checksum = "5523183e371a42cd10a4b72ab7541a332107c7eebd8ed4ad270e3bb56687dda9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -46,10 +46,10 @@ num_cpus = "1.16"
 tokio = { version = "1", features = ["full"] }
 
 # PoCX mining libraries
-pocx_miner = "1.0.4"
-pocx_plotter_v2 = { version = "1.0.4", features = ["opencl"] }
-pocx_address = "1.0.4"
-pocx_aggregator = "1.0.4"
+pocx_miner = "1.0.5"
+pocx_plotter_v2 = { version = "1.0.5", features = ["opencl"] }
+pocx_address = "1.0.5"
+pocx_aggregator = "1.0.5"
 
 
 # SHA256 hashing for node binary verification

--- a/web-wallet/src-tauri/src/mining/devices.rs
+++ b/web-wallet/src-tauri/src/mining/devices.rs
@@ -38,6 +38,10 @@ pub struct DeviceInfo {
     pub gpus: Vec<GpuInfo>,
     pub total_memory_mb: u64,
     pub available_memory_mb: u64,
+    /// Free swap (zram / vendor memory-extension on Android). On Android this is
+    /// added to the available-memory budget to mirror the plotter's swap-aware
+    /// host-memory gate; ignored on desktop where swap is typically disk-backed.
+    pub free_swap_mb: u64,
 }
 
 /// Detect CPU features
@@ -140,5 +144,6 @@ pub fn detect_devices() -> DeviceInfo {
         gpus,
         total_memory_mb: sys.total_memory() / 1024 / 1024,
         available_memory_mb: sys.available_memory() / 1024 / 1024,
+        free_swap_mb: sys.free_swap() / 1024 / 1024,
     }
 }

--- a/web-wallet/src/app/mining/models/mining.models.ts
+++ b/web-wallet/src/app/mining/models/mining.models.ts
@@ -32,6 +32,8 @@ export interface DeviceInfo {
   gpus: GpuInfo[];
   totalMemoryMb: number;
   availableMemoryMb: number;
+  /** Free swap (zram / vendor memory-extension); added to the budget on Android. */
+  freeSwapMb: number;
 }
 
 // ============================================================================

--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -579,18 +579,22 @@ interface ChainModalData {
                   </div>
                   <div class="memory-row memory-total">
                     <span class="memory-label">{{ 'setup_total' | i18n }}</span>
-                    <span class="memory-value"
+                    <span
+                      class="memory-value"
+                      [class.warning]="totalEstimatedMemoryGib() > effectiveMemoryBudgetGib()"
                       >~{{ totalEstimatedMemoryGib() | number: '1.0-0' }} GiB</span
                     >
                   </div>
                   <div class="memory-row memory-available">
                     <span class="memory-label">{{ 'setup_available_ram' | i18n }}</span>
-                    <span
-                      class="memory-value"
-                      [class.warning]="totalEstimatedMemoryGib() > systemMemoryGib()"
-                      >{{ systemMemoryGib() }} GiB</span
-                    >
+                    <span class="memory-value">{{ systemMemoryGib() }} GiB</span>
                   </div>
+                  @if (appMode.isMobile() && availableSwapGib() > 0) {
+                    <div class="memory-row memory-available">
+                      <span class="memory-label">{{ 'setup_available_swap' | i18n }}</span>
+                      <span class="memory-value">+{{ availableSwapGib() }} GiB</span>
+                    </div>
+                  }
                 </div>
               </div>
 
@@ -2017,6 +2021,11 @@ interface ChainModalData {
         color: rgb(0, 35, 65);
       }
 
+      /* Requirement exceeds the available budget (RAM + swap on Android) */
+      .memory-total .memory-value.warning {
+        color: #d32f2f;
+      }
+
       .memory-available {
         color: #666666;
         font-size: 12px;
@@ -2024,10 +2033,6 @@ interface ChainModalData {
 
       .memory-available .memory-value {
         font-weight: 500;
-      }
-
-      .memory-available .memory-value.warning {
-        color: #d32f2f;
       }
 
       .checkbox-row.standalone {
@@ -2663,7 +2668,19 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
   // Device info
   readonly cpuInfo = signal<CpuInfo | null>(null);
   readonly gpus = signal<GpuInfo[]>([]);
-  readonly systemMemoryGib = signal(0); // Available system RAM
+  // Raw memory figures from device detection (MiB)
+  readonly availableMemoryMb = signal(0);
+  // Free swap counted toward the budget on Android only (zram / memory-extension),
+  // mirroring the plotter's swap-aware host-memory gate. Zero on desktop.
+  readonly availableSwapMb = signal(0);
+
+  readonly systemMemoryGib = computed(() => Math.floor(this.availableMemoryMb() / 1024)); // Available system RAM
+  readonly availableSwapGib = computed(() => Math.floor(this.availableSwapMb() / 1024));
+  // Total memory the plotter can draw on; the warning compares against this so the
+  // wizard's assessment matches what the plotter gate will actually allow.
+  readonly effectiveMemoryBudgetGib = computed(() =>
+    Math.floor((this.availableMemoryMb() + this.availableSwapMb()) / 1024)
+  );
 
   // Derive display drives from service cache based on driveConfigs
   // Includes unavailable drives (configured but removed) so users can delete them
@@ -3017,7 +3034,9 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
 
       this.cpuInfo.set(deviceInfo.cpu);
       this.gpus.set(deviceInfo.gpus);
-      this.systemMemoryGib.set(Math.floor(deviceInfo.availableMemoryMb / 1024));
+      this.availableMemoryMb.set(deviceInfo.availableMemoryMb);
+      // Only Android counts swap, matching the plotter's #[cfg(target_os = "android")] gate.
+      this.availableSwapMb.set(this.appMode.isMobile() ? deviceInfo.freeSwapMb : 0);
       // Don't pre-populate availableDrives - user must add folders manually
 
       if (deviceInfo.cpu) {

--- a/web-wallet/src/app/mining/services/mining.service.ts
+++ b/web-wallet/src/app/mining/services/mining.service.ts
@@ -1004,6 +1004,7 @@ export class MiningService {
         gpus: [],
         totalMemoryMb: 0,
         availableMemoryMb: 0,
+        freeSwapMb: 0,
       }
     );
   }

--- a/web-wallet/src/assets/locales/en.json
+++ b/web-wallet/src/assets/locales/en.json
@@ -427,6 +427,7 @@
   "setup_gpu_cache": "GPU Cache",
   "setup_total": "Total",
   "setup_available_ram": "Available RAM",
+  "setup_available_swap": "Available Swap",
   "setup_drives_in_parallel": "Drives to Plot in Parallel",
   "setup_memory_escalation": "Memory Escalation Factor",
   "setup_plot_file_size": "Plot File Size (GiB)",


### PR DESCRIPTION
## Summary

Fixes Android setup-wizard memory reporting/assessment so phones with plenty of RAM are no longer falsely told they have too little to plot, and bumps the pocx crates to 1.0.5 (which carries the matching plotter-side gate).

Two commits:

1. **`feat(mining-wizard)`** — count free swap in the step-2 memory budget on Android.
2. **`chore(deps)`** — bump pocx crates 1.0.4 → 1.0.5.

## Background

On Android, `MemAvailable` is structurally low (~2–3 GiB) regardless of total RAM, because the OS keeps memory full of reclaimable cached apps. The plotter's host-memory pre-flight (and the wizard's "Available RAM" assessment) compared the requirement against this figure, so 6–12 GiB phones were refused even though they could genuinely back the working set (verified on a POCO F3 and an 8+4 GiB Xiaomi: ~2.7 GiB `MemAvailable` + ~6.4 GiB free swap).

## Wizard change (commit 1)

- `detect_devices` now returns `free_swap_mb` (`sys.free_swap()`), plumbed through `DeviceInfo`.
- On Android only (`appMode.isMobile()`, == the plotter's `cfg(target_os = "android")`), the step-2 warning compares against `available RAM + free swap` (zram / vendor memory-extension), matching what the plotter will accept. Desktop is unchanged (disk swap excluded).
- Display stays honest: **"Available RAM"** still shows real `MemAvailable`; a new **"Available Swap"** row appears on Android so a low-RAM-but-not-warned device is explained rather than confusing. Adds the `setup_available_swap` i18n key (en).

## Dependency bump (commit 2)

- `pocx_miner`, `pocx_plotter_v2`, `pocx_address`, `pocx_aggregator` → **1.0.5** (and transitive `pocx_*` in the lockfile).
- 1.0.5 carries the Android swap-aware host-memory gate in `pocx_plotter_v2` and the **RUSTSEC-2026-0185** `quinn-proto` security fix.
- This aligns the bundled plotter's gate with the wizard's swap-aware budget — both now count swap on Android, so the wizard's assessment matches the actual plotting outcome.

## Out of scope (intentionally)

`pocx_plotter_v2 1.0.5` also exposes `PlotterTask.skip_mem_check`, but it is **not** wired up here — the swap-aware budget alone unblocks the affected devices (the POCO F3 / Xiaomi both clear the gate with swap counted), so the unsafe override isn't needed for now.

## Testing

- `cargo check` passes against the published pocx 1.0.5 crates.
- Angular AOT build passes (templates type-checked).
- prettier / cargo fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)