### PR TITLE
Bump version 2.0.3 -> 2.0.4

### DIFF
--- a/web-wallet/package-lock.json
+++ b/web-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-wallet",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-wallet",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "@angular/animations": "^21.2.0",
         "@angular/cdk": "^21.2.0",

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-wallet",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-pocx"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "dirs",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-pocx"
-version = "2.0.3"
+version = "2.0.4"
 description = "Phoenix PoCX Wallet - Bitcoin-PoCX Desktop Wallet"
 authors = ["The Proof of Capacity Consortium <development@pocx.io>"]
 license = "GPL-3.0"

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phoenix PoCX Wallet",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "identifier": "org.pocx.phoenix",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Bumps the Phoenix PoCX Wallet version 2.0.3 → 2.0.4 across all manifests:

- `web-wallet/package.json`
- `web-wallet/package-lock.json`
- `web-wallet/src-tauri/Cargo.toml`
- `web-wallet/src-tauri/Cargo.lock`
- `web-wallet/src-tauri/tauri.conf.json`

Version-only chore; no functional changes. Mirrors the prior bump (#88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)