### PR TITLE
Bump version 2.0.4 -> 2.0.5 + swap Nogrod/CryptoGuru pool order

### DIFF
--- a/web-wallet/package-lock.json
+++ b/web-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-wallet",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-wallet",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@angular/animations": "^21.2.0",
         "@angular/cdk": "^21.2.0",

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-wallet",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-pocx"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "anyhow",
  "dirs",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-pocx"
-version = "2.0.4"
+version = "2.0.5"
 description = "Phoenix PoCX Wallet - Bitcoin-PoCX Desktop Wallet"
 authors = ["The Proof of Capacity Consortium <development@pocx.io>"]
 license = "GPL-3.0"

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phoenix PoCX Wallet",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "identifier": "org.pocx.phoenix",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/web-wallet/src/app/mining/models/mining.models.ts
+++ b/web-wallet/src/app/mining/models/mining.models.ts
@@ -175,18 +175,6 @@ export function predefinedPoolUrl(pool: PredefinedPool): string {
  */
 export const PREDEFINED_POOLS: PredefinedPool[] = [
   {
-    id: 'cryptoguru-mainnet',
-    name: 'CryptoGuru Mainnet',
-    rpcTransport: 'https',
-    rpcHost: 'btcx-pool.cryptoguru.org',
-    rpcPort: 443,
-    network: 'mainnet',
-    blockTimeSeconds: 120,
-    poolAddresses: [
-      { label: 'CryptoGuru Mainnet', address: 'pocx1qrp00l665mrl94cuhlwngyvua0q3xsvayg8e6zn' },
-    ],
-  },
-  {
     id: 'nogrod-mainnet',
     name: 'Nogrod Mainnet',
     rpcTransport: 'https',
@@ -196,6 +184,18 @@ export const PREDEFINED_POOLS: PredefinedPool[] = [
     blockTimeSeconds: 120,
     poolAddresses: [
       { label: 'Nogrod Mainnet', address: 'pocx1qp00ljf5sy0kdk4h8x5n4erzdshkzj4cdmvjpsv' },
+    ],
+  },
+  {
+    id: 'cryptoguru-mainnet',
+    name: 'CryptoGuru Mainnet',
+    rpcTransport: 'https',
+    rpcHost: 'btcx-pool.cryptoguru.org',
+    rpcPort: 443,
+    network: 'mainnet',
+    blockTimeSeconds: 120,
+    poolAddresses: [
+      { label: 'CryptoGuru Mainnet', address: 'pocx1qrp00l665mrl94cuhlwngyvua0q3xsvayg8e6zn' },
     ],
   },
   {


### PR DESCRIPTION
## What
- Bump version `2.0.4` -> `2.0.5` across package.json, package-lock.json, Cargo.toml, Cargo.lock, tauri.conf.json.
- Swap the first two entries in the setup wizard pool list so **Nogrod Mainnet** appears before **CryptoGuru Mainnet**.

## Notes
List order is near-irrelevant to how users actually pick a pool (they compare capacity/fees/features), so this is purely a presentation tweak alongside the routine version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)