### PR TITLE
chore(ci): drop Miner from Android APK artifact names

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -118,6 +118,6 @@ jobs:
       - name: Upload APK as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Phoenix-PoCX-Miner-Android-ARM64-test
+          name: Phoenix-PoCX-Android-ARM64-test
           path: ${{ steps.find-apk.outputs.apk_path }}
           retention-days: 14

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -139,7 +139,7 @@ jobs:
           VERSION="${TAG#v}"
           APK_FILE="${{ steps.verify.outputs.apk_path }}"
 
-          NEW_NAME="Phoenix-PoCX-Miner-${VERSION}-Android-ARM64.apk"
+          NEW_NAME="Phoenix-PoCX-${VERSION}-Android-ARM64.apk"
           cp "$APK_FILE" "$NEW_NAME"
 
           echo "Uploading $NEW_NAME to release $TAG"


### PR DESCRIPTION
Since #113 the Android build is wallet + miner; artifact/release names follow: Phoenix-PoCX-Android-ARM64-test and Phoenix-PoCX-<version>-Android-ARM64.apk. No doc references to the old names exist in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp