### PR TITLE
wizard: drop plotting-address gate; mobile: Electrum status parity

### DIFF
--- a/web-wallet/src-tauri/src/btcx_wallet/assignments.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/assignments.rs
@@ -52,18 +52,14 @@ pub fn forging_delays(network: WalletNetwork) -> (u32, u32) {
 /// address (`pocx`/`tpocx`/`rpocx` HRP — the `bitcoin` crate's `Address`
 /// only knows bc/tb/bcrt).
 fn p2wpkh_address(network: WalletNetwork, program: &[u8; 20]) -> Result<String, String> {
-    let hrp = bech32::Hrp::parse(network.params().bech32_hrp)
-        .map_err(|e| format!("chain HRP: {e}"))?;
+    let hrp =
+        bech32::Hrp::parse(network.params().bech32_hrp).map_err(|e| format!("chain HRP: {e}"))?;
     bech32::segwit::encode_v0(hrp, program).map_err(|e| format!("address encoding: {e}"))
 }
 
 /// The 20-byte witness program of a P2WPKH address on `network` — errors on
 /// anything else (assignments are defined over P2WPKH per consensus).
-fn p2wpkh_program(
-    network: WalletNetwork,
-    address: &str,
-    what: &str,
-) -> Result<[u8; 20], String> {
+fn p2wpkh_program(network: WalletNetwork, address: &str, what: &str) -> Result<[u8; 20], String> {
     let spk = network
         .params()
         .parse_address(address.trim())
@@ -506,7 +502,12 @@ fn derive_status(
                     // ASSIGNING-then-immediate-revoke invalid, mirror that.
                     let assigned_active = assign
                         .height
-                        .map(|h| event.height.map(|eh| eh >= h + assign_delay).unwrap_or(tip >= h + assign_delay))
+                        .map(|h| {
+                            event
+                                .height
+                                .map(|eh| eh >= h + assign_delay)
+                                .unwrap_or(tip >= h + assign_delay)
+                        })
                         .unwrap_or(false);
                     if assigned_active {
                         *revoke = Some(event.clone());

--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -12,9 +12,7 @@ use keys_btcx::WalletSeed;
 use seedstore::SeedStore;
 use wallet_btcx::WalletTxInfo;
 
-use super::config::{
-    self, BtcxWalletConfig, DescriptorPolicy, WalletNetwork, TRASH_SUBDIR,
-};
+use super::config::{self, BtcxWalletConfig, DescriptorPolicy, WalletNetwork, TRASH_SUBDIR};
 use super::manager::{self, BranchHit};
 use super::state::{BtcxWalletStatus, SharedBtcxWalletState};
 
@@ -99,8 +97,8 @@ fn import_into_named_wallet(
     policy: DescriptorPolicy,
 ) -> Result<(), String> {
     let root = BtcxWalletConfig::wallet_root(network, name);
-    let mut store = SeedStore::open(&root, None)
-        .map_err(|e| format!("Failed to open seed store: {e:#}"))?;
+    let mut store =
+        SeedStore::open(&root, None).map_err(|e| format!("Failed to open seed store: {e:#}"))?;
     store
         .import_seed(mnemonic, passphrase)
         .map(|_| ())
@@ -433,10 +431,7 @@ pub async fn btcx_wallet_select(
         let config = state.get_config();
         let network = config.network;
         if config.wallet_meta(network, &name).is_none() {
-            return Err(format!(
-                "No wallet named '{name}' on {}",
-                network.as_str()
-            ));
+            return Err(format!("No wallet named '{name}' on {}", network.as_str()));
         }
         if config.active_wallet_name() != name {
             state.close_runtime();
@@ -506,9 +501,8 @@ pub async fn btcx_wallet_delete(
                 n += 1;
                 dest = trash.join(format!("{name}-{ts}-{n}"));
             }
-            std::fs::rename(&root, &dest).map_err(|e| {
-                format!("moving {} to {}: {e}", root.display(), dest.display())
-            })?;
+            std::fs::rename(&root, &dest)
+                .map_err(|e| format!("moving {} to {}: {e}", root.display(), dest.display()))?;
             log::info!("btcx wallet '{name}' moved to {}", dest.display());
         }
         state.update_config(|c| c.remove_wallet_meta(network, &name))?;
@@ -803,10 +797,8 @@ pub async fn btcx_wallet_revoke_assignment(
     state: State<'_, SharedBtcxWalletState>,
 ) -> Result<super::assignments::RevokeAssignmentDto, String> {
     let state = state.inner().clone();
-    blocking(move || {
-        super::assignments::revoke_assignment(&state, &plot_address, fee_rate_sat_vb)
-    })
-    .await
+    blocking(move || super::assignments::revoke_assignment(&state, &plot_address, fee_rate_sat_vb))
+        .await
 }
 
 /// Assignment status of `plot_address`, derived from its Electrum script
@@ -944,7 +936,9 @@ pub async fn btcx_electrum_probe(
         let backend = electrum_btcx::ElectrumBackend::new(params, url.trim())
             .map_err(|e| format!("{e:#}"))?;
         let started = std::time::Instant::now();
-        let (height, _) = backend.tip().map_err(|e| format!("Server unreachable: {e:#}"))?;
+        let (height, _) = backend
+            .tip()
+            .map_err(|e| format!("Server unreachable: {e:#}"))?;
         backend
             .verify_chain()
             .map_err(|e| format!("Wrong chain or unusable server: {e:#}"))?;
@@ -1029,7 +1023,10 @@ mod tests {
             .update_config(|c| {
                 c.network = WalletNetwork::Regtest;
                 // Unreachable on purpose — creation is an offline operation.
-                c.set_servers(WalletNetwork::Regtest, vec!["tcp://127.0.0.1:1".to_string()]);
+                c.set_servers(
+                    WalletNetwork::Regtest,
+                    vec!["tcp://127.0.0.1:1".to_string()],
+                );
             })
             .unwrap();
 
@@ -1056,7 +1053,10 @@ mod tests {
         )
         .unwrap();
         let opened = state.open_runtime(None).unwrap();
-        assert!(opened, "runtime must open with an unreachable server (lazy dial)");
+        assert!(
+            opened,
+            "runtime must open with an unreachable server (lazy dial)"
+        );
 
         let status = state.status().unwrap();
         assert_eq!(status.wallet_name, "mywallet");

--- a/web-wallet/src-tauri/src/btcx_wallet/config.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/config.rs
@@ -357,7 +357,10 @@ pub fn migrate_legacy_layout_at(
     if !root_seed.exists() {
         return Ok(false);
     }
-    log::info!("btcx wallet: migrating legacy single-wallet layout under {}", root.display());
+    log::info!(
+        "btcx wallet: migrating legacy single-wallet layout under {}",
+        root.display()
+    );
 
     let networks = [
         WalletNetwork::Mainnet,
@@ -560,7 +563,14 @@ mod tests {
     fn wallet_name_validation() {
         // Mixed case is VALID (Core parity: saved as stated); uniqueness is
         // handled case-insensitively at creation instead.
-        for good in ["default", "a", "my-wallet_2", "Johnny", "UPPER", &"x".repeat(32)] {
+        for good in [
+            "default",
+            "a",
+            "my-wallet_2",
+            "Johnny",
+            "UPPER",
+            &"x".repeat(32),
+        ] {
             assert!(validate_wallet_name(good).is_ok(), "{good}");
         }
         for bad in [
@@ -595,16 +605,25 @@ mod tests {
         config.set_active_wallet(WalletNetwork::Mainnet, "savings");
         assert_eq!(config.active_wallet_name(), "savings");
         assert_eq!(config.wallet_names(WalletNetwork::Mainnet), vec!["savings"]);
-        assert_eq!(config.wallet_meta(WalletNetwork::Mainnet, "savings"), Some(meta));
-        assert!(config
-            .wallet_db_path()
-            .ends_with(PathBuf::from("mainnet").join("savings").join("wallet").join("btcx.sqlite")));
+        assert_eq!(
+            config.wallet_meta(WalletNetwork::Mainnet, "savings"),
+            Some(meta)
+        );
+        assert!(config.wallet_db_path().ends_with(
+            PathBuf::from("mainnet")
+                .join("savings")
+                .join("wallet")
+                .join("btcx.sqlite")
+        ));
 
         // JSON round trip keeps the registry.
         let json = serde_json::to_string(&config).unwrap();
         let parsed: BtcxWalletConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.active_wallet_name(), "savings");
-        assert_eq!(parsed.wallet_meta(WalletNetwork::Mainnet, "savings"), Some(meta));
+        assert_eq!(
+            parsed.wallet_meta(WalletNetwork::Mainnet, "savings"),
+            Some(meta)
+        );
 
         // Removing the wallet also clears the selection back to default.
         config.remove_wallet_meta(WalletNetwork::Mainnet, "savings");
@@ -622,7 +641,11 @@ mod tests {
         let root = dir.path();
         std::fs::write(root.join(seedstore::SEED_FILE), SEED_BYTES).unwrap();
         std::fs::create_dir_all(root.join("regtest").join("wallet")).unwrap();
-        std::fs::write(root.join("regtest").join("wallet").join("btcx.sqlite"), b"db").unwrap();
+        std::fs::write(
+            root.join("regtest").join("wallet").join("btcx.sqlite"),
+            b"db",
+        )
+        .unwrap();
 
         let mut config = BtcxWalletConfig {
             network: WalletNetwork::Regtest,

--- a/web-wallet/src-tauri/src/btcx_wallet/psbt.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/psbt.rs
@@ -257,10 +257,7 @@ pub fn analyze(psbt_base64: &str) -> Result<PsbtAnalyzeDto, String> {
 
     let fee_sat = psbt.fee().ok().map(|f| f.to_sat());
     let estimated_vsize = if next == "extractor" {
-        psbt.clone()
-            .extract_tx()
-            .ok()
-            .map(|tx| tx.vsize() as u64)
+        psbt.clone().extract_tx().ok().map(|tx| tx.vsize() as u64)
     } else {
         None
     };

--- a/web-wallet/src-tauri/src/btcx_wallet/state.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/state.rs
@@ -133,7 +133,11 @@ pub fn create_btcx_wallet_state() -> SharedBtcxWalletState {
 impl BtcxWalletState {
     /// The seed-cache key of the currently selected wallet.
     fn seed_key(config: &BtcxWalletConfig) -> String {
-        format!("{}/{}", config.network.as_str(), config.active_wallet_name())
+        format!(
+            "{}/{}",
+            config.network.as_str(),
+            config.active_wallet_name()
+        )
     }
 
     /// Run `f` on the ACTIVE wallet's seed store, opening it on first use.
@@ -426,11 +430,9 @@ impl BtcxWalletState {
         // obfuscation wraps auto-read and must present like an unencrypted
         // Core wallet (no padlock).
         let seed_encrypted = seed_status.seed_exists
-            && std::fs::read_to_string(
-                config.active_wallet_root().join(seedstore::SEED_FILE),
-            )
-            .map(|contents| seed_needs_passphrase(&contents))
-            .unwrap_or(false);
+            && std::fs::read_to_string(config.active_wallet_root().join(seedstore::SEED_FILE))
+                .map(|contents| seed_needs_passphrase(&contents))
+                .unwrap_or(false);
 
         Ok(BtcxWalletStatus {
             seed,

--- a/web-wallet/src/app/bitcoin/services/wallet/wallet-manager.service.ts
+++ b/web-wallet/src/app/bitcoin/services/wallet/wallet-manager.service.ts
@@ -233,7 +233,11 @@ export class WalletManagerService {
         isEncrypted: w.seedEncrypted,
         // Selector semantics: undefined = no unlock needed, 0 = locked,
         // >0 = unlocked. Keyring-encrypted seeds auto-unlock → undefined.
-        unlockedUntil: w.seedLocked ? 0 : w.seedEncrypted && w.isOpen ? SESSION_UNLOCK_SECONDS : undefined,
+        unlockedUntil: w.seedLocked
+          ? 0
+          : w.seedEncrypted && w.isOpen
+            ? SESSION_UNLOCK_SECONDS
+            : undefined,
       }));
     }
 

--- a/web-wallet/src/app/core/backend/core-wallet-backend.ts
+++ b/web-wallet/src/app/core/backend/core-wallet-backend.ts
@@ -1,4 +1,8 @@
-import { WalletRpcService, WalletTransaction, UTXO } from '../../bitcoin/services/rpc/wallet-rpc.service';
+import {
+  WalletRpcService,
+  WalletTransaction,
+  UTXO,
+} from '../../bitcoin/services/rpc/wallet-rpc.service';
 import { BlockchainRpcService } from '../../bitcoin/services/rpc/blockchain-rpc.service';
 import {
   WalletBackend,
@@ -50,11 +54,7 @@ export class CoreWalletBackend implements WalletBackend {
     return this.walletRpc.listTransactions(walletName, '*', count, skip);
   }
 
-  async getNewAddress(
-    walletName: string,
-    label = '',
-    type?: CoreAddressType
-  ): Promise<string> {
+  async getNewAddress(walletName: string, label = '', type?: CoreAddressType): Promise<string> {
     return this.walletRpc.getNewAddress(walletName, label, type);
   }
 

--- a/web-wallet/src/app/core/backend/electrum-wallet-backend.ts
+++ b/web-wallet/src/app/core/backend/electrum-wallet-backend.ts
@@ -1,8 +1,5 @@
 import { WalletTransaction, UTXO } from '../../bitcoin/services/rpc/wallet-rpc.service';
-import {
-  BtcxWalletService,
-  BtcxWalletTx,
-} from '../services/btcx-wallet.service';
+import { BtcxWalletService, BtcxWalletTx } from '../services/btcx-wallet.service';
 import { invoke } from '@tauri-apps/api/core';
 import {
   WalletBackend,

--- a/web-wallet/src/app/core/services/btcx-wallet.service.ts
+++ b/web-wallet/src/app/core/services/btcx-wallet.service.ts
@@ -486,11 +486,7 @@ export class BtcxWalletService {
    * Electrum server) and opens the best hit; the result carries the full
    * hit list and an honest fresh verdict. Throws on failure.
    */
-  async restore(
-    mnemonic: string,
-    passphrase?: string,
-    name?: string
-  ): Promise<BtcxRestoreResult> {
+  async restore(mnemonic: string, passphrase?: string, name?: string): Promise<BtcxRestoreResult> {
     const result = await invoke<BtcxRestoreResult>('btcx_wallet_restore', {
       mnemonic,
       passphrase: passphrase || null,

--- a/web-wallet/src/app/core/services/electrum-status.service.ts
+++ b/web-wallet/src/app/core/services/electrum-status.service.ts
@@ -1,9 +1,5 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
-import {
-  BtcxWalletService,
-  BtcxOverallHealth,
-  BtcxServerHealth,
-} from './btcx-wallet.service';
+import { BtcxWalletService, BtcxOverallHealth, BtcxServerHealth } from './btcx-wallet.service';
 import { NodeService } from '../../node/services/node.service';
 
 /** How often the passive health snapshots refresh while no sync events flow. */
@@ -55,9 +51,7 @@ export class ElectrumStatusService {
     const homeState = byUrl.get(configured[0]) ?? 'untested';
     if (homeState === 'healthy') return 'healthy';
     if (homeState === 'down') {
-      return configured.slice(1).some(url => byUrl.get(url) === 'healthy')
-        ? 'degraded'
-        : 'down';
+      return configured.slice(1).some(url => byUrl.get(url) === 'healthy') ? 'degraded' : 'down';
     }
     // Home untested — nothing has talked to it yet this run.
     return 'connecting';

--- a/web-wallet/src/app/features/auth/pages/create-wallet/create-wallet.component.ts
+++ b/web-wallet/src/app/features/auth/pages/create-wallet/create-wallet.component.ts
@@ -91,7 +91,9 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
                 <button
                   mat-raised-button
                   color="primary"
-                  [disabled]="!walletName || walletNameConflict() || walletNameInvalid() || creating()"
+                  [disabled]="
+                    !walletName || walletNameConflict() || walletNameInvalid() || creating()
+                  "
                   (click)="nextStep()"
                 >
                   {{ 'next' | i18n }}
@@ -226,7 +228,9 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
           @if (currentStep() === 4) {
             <div class="step-content">
               <p class="info-text">
-                {{ (isRemote() ? 'wallet_encryption_info_local' : 'wallet_encryption_info') | i18n }}
+                {{
+                  (isRemote() ? 'wallet_encryption_info_local' : 'wallet_encryption_info') | i18n
+                }}
               </p>
 
               <mat-checkbox [(ngModel)]="useWalletEncryption" class="encryption-checkbox">

--- a/web-wallet/src/app/features/auth/pages/import-wallet/import-wallet.component.ts
+++ b/web-wallet/src/app/features/auth/pages/import-wallet/import-wallet.component.ts
@@ -97,7 +97,9 @@ import {
                 <button
                   mat-raised-button
                   color="primary"
-                  [disabled]="!walletName || walletNameConflict() || walletNameInvalid() || importing()"
+                  [disabled]="
+                    !walletName || walletNameConflict() || walletNameInvalid() || importing()
+                  "
                   (click)="nextStep()"
                 >
                   {{ 'next' | i18n }}
@@ -199,7 +201,9 @@ import {
           @if (currentStep() === 3 && !imported()) {
             <div class="step-content">
               <p class="info-text">
-                {{ (isRemote() ? 'wallet_encryption_info_local' : 'wallet_encryption_info') | i18n }}
+                {{
+                  (isRemote() ? 'wallet_encryption_info_local' : 'wallet_encryption_info') | i18n
+                }}
               </p>
 
               <mat-checkbox [(ngModel)]="useWalletEncryption" class="encryption-checkbox">

--- a/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -1351,9 +1351,7 @@ export class DashboardComponent implements AfterViewInit {
 
     try {
       // Routed through the mode's backend (Core RPC or the local BDK wallet).
-      const newTxid = await this.backendRouter
-        .wallet()
-        .bumpFee(walletName, txid, options.feeRate);
+      const newTxid = await this.backendRouter.wallet().bumpFee(walletName, txid, options.feeRate);
 
       this.notification.success(
         this.i18n.get('bump_fee_success').replace('{txid}', newTxid.substring(0, 16) + '...')

--- a/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
+++ b/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
@@ -1336,9 +1336,7 @@ export class ForgingAssignmentComponent implements OnInit, OnDestroy {
       try {
         const utxos = await this.walletService.listUnspent(0);
         const unique = [...new Set(utxos.map(u => u.address).filter(a => !!a))];
-        this.walletAddresses.set(
-          unique.map(address => ({ address, label: '', isSegwitV0: true }))
-        );
+        this.walletAddresses.set(unique.map(address => ({ address, label: '', isSegwitV0: true })));
       } catch (error) {
         console.error('Failed to load wallet addresses:', error);
       }

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -7,6 +7,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { I18nPipe, I18nService, LANGUAGES, Language } from '../../../core/i18n';
 import { BtcxWalletService } from '../../../core/services/btcx-wallet.service';
+import { ElectrumStatusService } from '../../../core/services/electrum-status.service';
 import { MobileNavComponent } from '../../../shared/components/mobile-nav/mobile-nav.component';
 
 /**
@@ -40,6 +41,14 @@ import { MobileNavComponent } from '../../../shared/components/mobile-nav/mobile
             @if (wallet.network() !== 'mainnet') {
               <span class="network-badge">{{ wallet.network() | i18n }}</span>
             }
+
+            <span
+              class="conn-dot"
+              [class.healthy]="electrumStatus.overall() === 'healthy'"
+              [class.degraded]="electrumStatus.overall() === 'degraded'"
+              [class.down]="electrumStatus.overall() === 'down'"
+              [matTooltip]="connTooltip()"
+            ></span>
           </div>
 
           <div class="toolbar-right">
@@ -132,6 +141,24 @@ import { MobileNavComponent } from '../../../shared/components/mobile-nav/mobile
         border: 1px solid currentColor;
         border-radius: 10px;
         padding: 1px 8px;
+      }
+
+      .conn-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: rgba(0, 0, 0, 0.26); /* connecting/unknown */
+        flex-shrink: 0;
+
+        &.healthy {
+          background: #4caf50;
+        }
+        &.degraded {
+          background: #ff9800;
+        }
+        &.down {
+          background: #f44336;
+        }
       }
 
       .toolbar-right {
@@ -233,12 +260,21 @@ import { MobileNavComponent } from '../../../shared/components/mobile-nav/mobile
 export class MobileWalletLayoutComponent implements OnInit {
   readonly i18n = inject(I18nService);
   readonly wallet = inject(BtcxWalletService);
+  readonly electrumStatus = inject(ElectrumStatusService);
 
   languages: Language[] = LANGUAGES;
 
   ngOnInit(): void {
     // Lazy init: only mobile wallet routes touch the btcx wallet backend
     void this.wallet.initialize();
+  }
+
+  /** Tooltip of the connection dot: status text plus synced height. */
+  connTooltip(): string {
+    const parts = [this.i18n.get(`electrum_status_${this.electrumStatus.overall()}`)];
+    const height = this.electrumStatus.height();
+    if (height !== null) parts.push(`#${height}`);
+    return parts.join(' · ');
   }
 
   setLanguage(lang: Language): void {

--- a/web-wallet/src/app/features/mobile-wallet/pages/settings/wallet-settings.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/settings/wallet-settings.component.ts
@@ -71,6 +71,7 @@ import { ElectrumServersEditorComponent } from '../../../../shared/components/el
           [servers]="wallet.electrumServers()"
           [network]="wallet.network()"
           [disabled]="busy()"
+          [showTest]="true"
           (serversChange)="saveServers($event)"
         />
       </div>

--- a/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
+++ b/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
@@ -840,132 +840,134 @@ function withListenPort(listenAddress: string, port: number): string {
                      BDK wallet is one fixed BIP-84 descriptor and cannot
                      adopt foreign keys) -->
                 @if (nodeMode() !== 'remote') {
-                <div class="wif-import-section">
-                  <h3 class="section-title">{{ 'import_wif_wpkh' | i18n }}</h3>
-                  <p class="section-description">
-                    {{ 'import_wif_description' | i18n }}
-                    @if (activeWalletName) {
-                      <strong>"{{ activeWalletName }}"</strong>
-                    }
-                  </p>
+                  <div class="wif-import-section">
+                    <h3 class="section-title">{{ 'import_wif_wpkh' | i18n }}</h3>
+                    <p class="section-description">
+                      {{ 'import_wif_description' | i18n }}
+                      @if (activeWalletName) {
+                        <strong>"{{ activeWalletName }}"</strong>
+                      }
+                    </p>
 
-                  <div class="wif-form">
-                    <div class="wif-input-row">
-                      <mat-form-field appearance="outline" class="wif-field">
-                        <mat-label>{{ 'wif_private_key' | i18n }}</mat-label>
-                        <input
-                          matInput
-                          [type]="wifShowKey() ? 'text' : 'password'"
-                          [value]="wifInput()"
-                          (input)="onWifInputChange($event)"
-                          placeholder="5... / K... / L... / c..."
-                          autocomplete="off"
-                        />
-                        <button
-                          mat-icon-button
-                          matSuffix
-                          (click)="wifShowKey.set(!wifShowKey())"
-                          [matTooltip]="wifShowKey() ? ('hide_key' | i18n) : ('show_key' | i18n)"
-                        >
-                          <mat-icon>{{ wifShowKey() ? 'visibility_off' : 'visibility' }}</mat-icon>
-                        </button>
-                      </mat-form-field>
-                    </div>
-
-                    <mat-form-field appearance="outline" class="label-field">
-                      <mat-label>{{ 'address_label_optional' | i18n }}</mat-label>
-                      <input
-                        matInput
-                        [value]="wifLabel()"
-                        (input)="wifLabel.set($any($event.target).value)"
-                        [placeholder]="'address_label_placeholder' | i18n"
-                      />
-                    </mat-form-field>
-
-                    <div class="wif-rescan-section">
-                      <p class="wif-rescan-label">{{ 'watch_only_rescan_label' | i18n }}</p>
-                      <mat-radio-group
-                        class="wif-rescan-group"
-                        [value]="wifRescanKind()"
-                        (change)="wifRescanKind.set($event.value)"
-                        [disabled]="isImportingWif()"
-                      >
-                        <mat-radio-button value="now">
-                          {{ 'watch_only_rescan_now' | i18n }}
-                        </mat-radio-button>
-                        <mat-radio-button value="date">
-                          {{ 'watch_only_rescan_date' | i18n }}
-                        </mat-radio-button>
-                        <mat-radio-button value="genesis">
-                          {{ 'watch_only_rescan_genesis' | i18n }}
-                        </mat-radio-button>
-                      </mat-radio-group>
-
-                      @if (wifRescanKind() === 'date') {
-                        <mat-form-field appearance="outline" class="wif-rescan-date-field">
-                          <mat-label>{{ 'watch_only_rescan_date_label' | i18n }}</mat-label>
+                    <div class="wif-form">
+                      <div class="wif-input-row">
+                        <mat-form-field appearance="outline" class="wif-field">
+                          <mat-label>{{ 'wif_private_key' | i18n }}</mat-label>
                           <input
                             matInput
-                            type="date"
-                            [(ngModel)]="wifRescanDateInput"
-                            [disabled]="isImportingWif()"
+                            [type]="wifShowKey() ? 'text' : 'password'"
+                            [value]="wifInput()"
+                            (input)="onWifInputChange($event)"
+                            placeholder="5... / K... / L... / c..."
+                            autocomplete="off"
                           />
+                          <button
+                            mat-icon-button
+                            matSuffix
+                            (click)="wifShowKey.set(!wifShowKey())"
+                            [matTooltip]="wifShowKey() ? ('hide_key' | i18n) : ('show_key' | i18n)"
+                          >
+                            <mat-icon>{{
+                              wifShowKey() ? 'visibility_off' : 'visibility'
+                            }}</mat-icon>
+                          </button>
                         </mat-form-field>
-                      }
-
-                      @if (wifRescanKind() === 'now') {
-                        <p class="wif-rescan-warning">
-                          <mat-icon>warning</mat-icon>
-                          {{ 'watch_only_rescan_warning_now' | i18n }}
-                        </p>
-                      }
-                    </div>
-
-                    @if (wifError()) {
-                      <div class="wif-error">
-                        <mat-icon>error</mat-icon>
-                        <span>{{ wifError() }}</span>
                       </div>
-                    }
 
-                    @if (wifPreview()) {
-                      <div class="wif-preview">
-                        <div class="preview-row">
-                          <span class="preview-label">{{ 'address' | i18n }}:</span>
-                          <code class="preview-value">{{ wifPreview()!.address }}</code>
+                      <mat-form-field appearance="outline" class="label-field">
+                        <mat-label>{{ 'address_label_optional' | i18n }}</mat-label>
+                        <input
+                          matInput
+                          [value]="wifLabel()"
+                          (input)="wifLabel.set($any($event.target).value)"
+                          [placeholder]="'address_label_placeholder' | i18n"
+                        />
+                      </mat-form-field>
+
+                      <div class="wif-rescan-section">
+                        <p class="wif-rescan-label">{{ 'watch_only_rescan_label' | i18n }}</p>
+                        <mat-radio-group
+                          class="wif-rescan-group"
+                          [value]="wifRescanKind()"
+                          (change)="wifRescanKind.set($event.value)"
+                          [disabled]="isImportingWif()"
+                        >
+                          <mat-radio-button value="now">
+                            {{ 'watch_only_rescan_now' | i18n }}
+                          </mat-radio-button>
+                          <mat-radio-button value="date">
+                            {{ 'watch_only_rescan_date' | i18n }}
+                          </mat-radio-button>
+                          <mat-radio-button value="genesis">
+                            {{ 'watch_only_rescan_genesis' | i18n }}
+                          </mat-radio-button>
+                        </mat-radio-group>
+
+                        @if (wifRescanKind() === 'date') {
+                          <mat-form-field appearance="outline" class="wif-rescan-date-field">
+                            <mat-label>{{ 'watch_only_rescan_date_label' | i18n }}</mat-label>
+                            <input
+                              matInput
+                              type="date"
+                              [(ngModel)]="wifRescanDateInput"
+                              [disabled]="isImportingWif()"
+                            />
+                          </mat-form-field>
+                        }
+
+                        @if (wifRescanKind() === 'now') {
+                          <p class="wif-rescan-warning">
+                            <mat-icon>warning</mat-icon>
+                            {{ 'watch_only_rescan_warning_now' | i18n }}
+                          </p>
+                        }
+                      </div>
+
+                      @if (wifError()) {
+                        <div class="wif-error">
+                          <mat-icon>error</mat-icon>
+                          <span>{{ wifError() }}</span>
                         </div>
-                      </div>
-                    }
+                      }
 
-                    <div class="wif-actions">
-                      <button
-                        mat-stroked-button
-                        (click)="validateWif()"
-                        [disabled]="!wifInput() || isValidatingWif() || isImportingWif()"
-                      >
-                        @if (isValidatingWif()) {
-                          <mat-spinner diameter="18"></mat-spinner>
-                        } @else {
-                          <mat-icon>preview</mat-icon>
-                        }
-                        {{ 'preview_address' | i18n }}
-                      </button>
-                      <button
-                        mat-raised-button
-                        color="warn"
-                        (click)="importWif()"
-                        [disabled]="!wifPreview() || isImportingWif() || !canImportWif()"
-                      >
-                        @if (isImportingWif()) {
-                          <mat-spinner diameter="18"></mat-spinner>
-                        } @else {
-                          <mat-icon>key</mat-icon>
-                        }
-                        {{ 'import_to_wallet' | i18n }}
-                      </button>
+                      @if (wifPreview()) {
+                        <div class="wif-preview">
+                          <div class="preview-row">
+                            <span class="preview-label">{{ 'address' | i18n }}:</span>
+                            <code class="preview-value">{{ wifPreview()!.address }}</code>
+                          </div>
+                        </div>
+                      }
+
+                      <div class="wif-actions">
+                        <button
+                          mat-stroked-button
+                          (click)="validateWif()"
+                          [disabled]="!wifInput() || isValidatingWif() || isImportingWif()"
+                        >
+                          @if (isValidatingWif()) {
+                            <mat-spinner diameter="18"></mat-spinner>
+                          } @else {
+                            <mat-icon>preview</mat-icon>
+                          }
+                          {{ 'preview_address' | i18n }}
+                        </button>
+                        <button
+                          mat-raised-button
+                          color="warn"
+                          (click)="importWif()"
+                          [disabled]="!wifPreview() || isImportingWif() || !canImportWif()"
+                        >
+                          @if (isImportingWif()) {
+                            <mat-spinner diameter="18"></mat-spinner>
+                          } @else {
+                            <mat-icon>key</mat-icon>
+                          }
+                          {{ 'import_to_wallet' | i18n }}
+                        </button>
+                      </div>
                     </div>
                   </div>
-                </div>
                 }
               </div>
             </div>
@@ -2191,9 +2193,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
         const network = this.remoteNetwork();
         const saved = await this.nodeService.saveRemoteConfig(network, this.remoteServers());
         if (!saved) {
-          this.notification.error(
-            this.nodeService.error() ?? 'Failed to save configuration'
-          );
+          this.notification.error(this.nodeService.error() ?? 'Failed to save configuration');
           return;
         }
         this.store.dispatch(SettingsActions.setNetwork({ network }));

--- a/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
@@ -1381,9 +1381,7 @@ export class TransactionDetailComponent implements OnInit {
 
     try {
       // Routed through the mode's backend (Core RPC or the local BDK wallet).
-      const newTxid = await this.backendRouter
-        .wallet()
-        .bumpFee(walletName, txid, options.feeRate);
+      const newTxid = await this.backendRouter.wallet().bumpFee(walletName, txid, options.feeRate);
 
       this.notification.success(
         this.i18n.get('bump_fee_success').replace('{txid}', newTxid.substring(0, 16) + '...')

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -1175,9 +1175,7 @@ export class TransactionListComponent implements OnInit, OnDestroy {
 
     try {
       // Routed through the mode's backend (Core RPC or the local BDK wallet).
-      const newTxid = await this.backendRouter
-        .wallet()
-        .bumpFee(walletName, txid, options.feeRate);
+      const newTxid = await this.backendRouter.wallet().bumpFee(walletName, txid, options.feeRate);
 
       this.notification.success(
         this.i18n.get('bump_fee_success').replace('{txid}', newTxid.substring(0, 16) + '...')

--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -4277,22 +4277,12 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
 
   // Save and start
   async saveAndStart(): Promise<void> {
+    // Deliberately not validated: plotting for a third party (or an
+    // address from another install) is a supported flow, so whatever
+    // target the user provided is persisted as-is.
     const plottingAddress = (
       this.useCustomAddress() ? this.customPlottingAddress() : this.walletAddress()
     ).trim();
-
-    // A config without a valid plotting address cannot plot or mine —
-    // refuse to save instead of persisting a broken setup (the empty
-    // wallet-address case slipped through here before).
-    if (!plottingAddress || validatePocxAddress(plottingAddress).kind !== 'valid') {
-      this.snackBar.open(
-        this.i18n.get('setup_plotting_address_invalid') ||
-          'Enter a valid plotting address before saving',
-        this.i18n.get('dismiss') || 'Dismiss',
-        { duration: 5000, panelClass: ['snackbar-error'] }
-      );
-      return;
-    }
 
     this.saving.set(true);
 

--- a/web-wallet/src/app/node/services/node.service.ts
+++ b/web-wallet/src/app/node/services/node.service.ts
@@ -298,7 +298,10 @@ export class NodeService {
    * and `btcx_wallet_config.json` (network + Electrum servers). Always use
    * this for remote-mode saves so the two networks can never split-brain.
    */
-  async saveRemoteConfig(network: NodeConfig['network'], electrumServers: string[]): Promise<boolean> {
+  async saveRemoteConfig(
+    network: NodeConfig['network'],
+    electrumServers: string[]
+  ): Promise<boolean> {
     const saved = await this.saveConfig({ ...this._config(), mode: 'remote', network });
     if (!saved) return false;
     try {

--- a/web-wallet/src/app/shared/components/electrum-servers-editor/electrum-servers-editor.component.ts
+++ b/web-wallet/src/app/shared/components/electrum-servers-editor/electrum-servers-editor.component.ts
@@ -6,10 +6,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { I18nPipe } from '../../../core/i18n';
-import {
-  BtcxWalletService,
-  BtcxNetwork,
-} from '../../../core/services/btcx-wallet.service';
+import { BtcxWalletService, BtcxNetwork } from '../../../core/services/btcx-wallet.service';
 
 /**
  * ElectrumServersEditorComponent — the ordered Electrum endpoint list
@@ -44,9 +41,7 @@ import {
       @for (server of servers; track $index) {
         <div class="server-row" [class.primary]="$index === 0">
           @if ($index === 0) {
-            <mat-icon
-              class="primary-icon"
-              [matTooltip]="'electrum_primary_server' | i18n"
+            <mat-icon class="primary-icon" [matTooltip]="'electrum_primary_server' | i18n"
               >star</mat-icon
             >
           } @else {
@@ -283,9 +278,7 @@ export class ElectrumServersEditorComponent {
 
   newServer = '';
   readonly testing = signal<string | null>(null);
-  readonly testResults = signal<Record<string, { ok: boolean; label: string; detail: string }>>(
-    {}
-  );
+  readonly testResults = signal<Record<string, { ok: boolean; label: string; detail: string }>>({});
 
   newServerValid(): boolean {
     const url = this.newServer.trim();

--- a/web-wallet/src/assets/locales/bg.json
+++ b/web-wallet/src/assets/locales/bg.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Експериментални",
   "settings_nodeless_wallet": "Портфейл без възел (експериментално)",
   "settings_nodeless_wallet_desc": "BTCX портфейл, базиран на Electrum, който работи без локален възел. Добавя запис Портфейл без възел в навигацията.",
-  "setup_plotting_address_invalid": "Въведете валиден адрес за плотване преди запазване",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/ca.json
+++ b/web-wallet/src/assets/locales/ca.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimental",
   "settings_nodeless_wallet": "Cartera sense node (experimental)",
   "settings_nodeless_wallet_desc": "Cartera BTCX basada en Electrum que funciona sense node local. Afegeix una entrada Cartera sense node a la navegació.",
-  "setup_plotting_address_invalid": "Introduïu una adreça de plotting vàlida abans de desar",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/cs.json
+++ b/web-wallet/src/assets/locales/cs.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimentální",
   "settings_nodeless_wallet": "Peněženka bez uzlu (experimentální)",
   "settings_nodeless_wallet_desc": "BTCX peněženka založená na Electrum, která funguje bez lokálního uzlu. Přidá do navigace položku Peněženka bez uzlu.",
-  "setup_plotting_address_invalid": "Před uložením zadejte platnou adresu plotování",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/de-de.json
+++ b/web-wallet/src/assets/locales/de-de.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimentell",
   "settings_nodeless_wallet": "Nodeless Wallet (experimentell)",
   "settings_nodeless_wallet_desc": "Electrum-basiertes BTCX-Wallet, das ohne lokalen Node funktioniert. Fügt der Navigation einen Nodeless-Wallet-Eintrag hinzu.",
-  "setup_plotting_address_invalid": "Gib vor dem Speichern eine gültige Plotting-Adresse ein",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/el.json
+++ b/web-wallet/src/assets/locales/el.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Πειραματικά",
   "settings_nodeless_wallet": "Πορτοφόλι χωρίς κόμβο (πειραματικό)",
   "settings_nodeless_wallet_desc": "Πορτοφόλι BTCX βασισμένο στο Electrum που λειτουργεί χωρίς τοπικό κόμβο. Προσθέτει μια καταχώρηση Πορτοφόλι χωρίς κόμβο στην πλοήγηση.",
-  "setup_plotting_address_invalid": "Εισαγάγετε μια έγκυρη διεύθυνση plotting πριν την αποθήκευση",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/en.json
+++ b/web-wallet/src/assets/locales/en.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimental",
   "settings_nodeless_wallet": "Nodeless wallet (experimental)",
   "settings_nodeless_wallet_desc": "Electrum-backed BTCX wallet that works without a local node. Adds a Nodeless Wallet entry to the navigation.",
-  "setup_plotting_address_invalid": "Enter a valid plotting address before saving",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/es-es.json
+++ b/web-wallet/src/assets/locales/es-es.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimental",
   "settings_nodeless_wallet": "Billetera sin nodo (experimental)",
   "settings_nodeless_wallet_desc": "Billetera BTCX basada en Electrum que funciona sin nodo local. Añade una entrada Billetera sin nodo a la navegación.",
-  "setup_plotting_address_invalid": "Introduce una dirección de plotting válida antes de guardar",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/fi.json
+++ b/web-wallet/src/assets/locales/fi.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Kokeelliset",
   "settings_nodeless_wallet": "Solmuton lompakko (kokeellinen)",
   "settings_nodeless_wallet_desc": "Electrum-pohjainen BTCX-lompakko, joka toimii ilman paikallista solmua. Lisää navigaatioon Solmuton lompakko -kohdan.",
-  "setup_plotting_address_invalid": "Anna kelvollinen plotausosoite ennen tallentamista",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/fr.json
+++ b/web-wallet/src/assets/locales/fr.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Expérimental",
   "settings_nodeless_wallet": "Portefeuille sans nœud (expérimental)",
   "settings_nodeless_wallet_desc": "Portefeuille BTCX basé sur Electrum qui fonctionne sans nœud local. Ajoute une entrée Portefeuille sans nœud à la navigation.",
-  "setup_plotting_address_invalid": "Saisissez une adresse de plotting valide avant d'enregistrer",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/gl.json
+++ b/web-wallet/src/assets/locales/gl.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimental",
   "settings_nodeless_wallet": "Carteira sen nodo (experimental)",
   "settings_nodeless_wallet_desc": "Carteira BTCX baseada en Electrum que funciona sen nodo local. Engade unha entrada Carteira sen nodo á navegación.",
-  "setup_plotting_address_invalid": "Introduce un enderezo de trazado válido antes de gardar",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/hi.json
+++ b/web-wallet/src/assets/locales/hi.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "प्रायोगिक",
   "settings_nodeless_wallet": "नोडलेस वॉलेट (प्रायोगिक)",
   "settings_nodeless_wallet_desc": "Electrum-आधारित BTCX वॉलेट जो स्थानीय नोड के बिना काम करता है। नेविगेशन में नोडलेस वॉलेट प्रविष्टि जोड़ता है।",
-  "setup_plotting_address_invalid": "सहेजने से पहले एक मान्य प्लॉटिंग पता दर्ज करें",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/hr.json
+++ b/web-wallet/src/assets/locales/hr.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Eksperimentalno",
   "settings_nodeless_wallet": "Novčanik bez čvora (eksperimentalno)",
   "settings_nodeless_wallet_desc": "BTCX novčanik temeljen na Electrumu koji radi bez lokalnog čvora. Dodaje stavku Novčanik bez čvora u navigaciju.",
-  "setup_plotting_address_invalid": "Unesite valjanu adresu za plotanje prije spremanja",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/id.json
+++ b/web-wallet/src/assets/locales/id.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Eksperimental",
   "settings_nodeless_wallet": "Dompet tanpa node (eksperimental)",
   "settings_nodeless_wallet_desc": "Dompet BTCX berbasis Electrum yang bekerja tanpa node lokal. Menambahkan entri Dompet Tanpa Node ke navigasi.",
-  "setup_plotting_address_invalid": "Masukkan alamat plotting yang valid sebelum menyimpan",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/it.json
+++ b/web-wallet/src/assets/locales/it.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Sperimentale",
   "settings_nodeless_wallet": "Portafoglio senza nodo (sperimentale)",
   "settings_nodeless_wallet_desc": "Portafoglio BTCX basato su Electrum che funziona senza nodo locale. Aggiunge una voce Portafoglio senza nodo alla navigazione.",
-  "setup_plotting_address_invalid": "Inserisci un indirizzo plotting valido prima di salvare",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/ja.json
+++ b/web-wallet/src/assets/locales/ja.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "実験的機能",
   "settings_nodeless_wallet": "ノードレスウォレット（実験的）",
   "settings_nodeless_wallet_desc": "ローカルノードなしで動作する Electrum ベースの BTCX ウォレット。ナビゲーションにノードレスウォレットの項目を追加します。",
-  "setup_plotting_address_invalid": "保存する前に有効なプロッティングアドレスを入力してください",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/lt.json
+++ b/web-wallet/src/assets/locales/lt.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Eksperimentinės",
   "settings_nodeless_wallet": "Piniginė be mazgo (eksperimentinė)",
   "settings_nodeless_wallet_desc": "Electrum pagrindu veikianti BTCX piniginė, veikianti be vietinio mazgo. Prideda navigacijoje įrašą Piniginė be mazgo.",
-  "setup_plotting_address_invalid": "Prieš išsaugodami įveskite galiojantį plotinimo adresą",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/nl.json
+++ b/web-wallet/src/assets/locales/nl.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimenteel",
   "settings_nodeless_wallet": "Nodeless wallet (experimenteel)",
   "settings_nodeless_wallet_desc": "Electrum-gebaseerde BTCX-wallet die zonder lokale node werkt. Voegt een Nodeless wallet-item toe aan de navigatie.",
-  "setup_plotting_address_invalid": "Voer een geldig plotting-adres in voordat je opslaat",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/pl.json
+++ b/web-wallet/src/assets/locales/pl.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Eksperymentalne",
   "settings_nodeless_wallet": "Portfel bez węzła (eksperymentalny)",
   "settings_nodeless_wallet_desc": "Portfel BTCX oparty na Electrum, działający bez lokalnego węzła. Dodaje pozycję Portfel bez węzła do nawigacji.",
-  "setup_plotting_address_invalid": "Przed zapisaniem wprowadź prawidłowy adres plotowania",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/pt-br.json
+++ b/web-wallet/src/assets/locales/pt-br.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimental",
   "settings_nodeless_wallet": "Carteira sem nó (experimental)",
   "settings_nodeless_wallet_desc": "Carteira BTCX baseada em Electrum que funciona sem nó local. Adiciona uma entrada Carteira sem nó à navegação.",
-  "setup_plotting_address_invalid": "Insira um endereço de plotagem válido antes de salvar",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/ro.json
+++ b/web-wallet/src/assets/locales/ro.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimental",
   "settings_nodeless_wallet": "Portofel fără nod (experimental)",
   "settings_nodeless_wallet_desc": "Portofel BTCX bazat pe Electrum care funcționează fără nod local. Adaugă o intrare Portofel fără nod în navigare.",
-  "setup_plotting_address_invalid": "Introduceți o adresă de plotare validă înainte de a salva",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/ru.json
+++ b/web-wallet/src/assets/locales/ru.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Экспериментальные",
   "settings_nodeless_wallet": "Кошелек без узла (экспериментально)",
   "settings_nodeless_wallet_desc": "BTCX-кошелек на основе Electrum, работающий без локального узла. Добавляет пункт «Кошелек без узла» в навигацию.",
-  "setup_plotting_address_invalid": "Перед сохранением введите действительный адрес плоттинга",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/sk.json
+++ b/web-wallet/src/assets/locales/sk.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Experimentálne",
   "settings_nodeless_wallet": "Peňaženka bez uzla (experimentálne)",
   "settings_nodeless_wallet_desc": "BTCX peňaženka založená na Electrum, ktorá funguje bez lokálneho uzla. Pridá do navigácie položku Peňaženka bez uzla.",
-  "setup_plotting_address_invalid": "Pred uložením zadajte platnú adresu plotovania",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/sr.json
+++ b/web-wallet/src/assets/locales/sr.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Експериментално",
   "settings_nodeless_wallet": "Новчаник без чвора (експериментално)",
   "settings_nodeless_wallet_desc": "BTCX новчаник заснован на Electrum-у који ради без локалног чвора. Додаје ставку Новчаник без чвора у навигацију.",
-  "setup_plotting_address_invalid": "Унесите важећу адресу за плотирање пре чувања",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/tr.json
+++ b/web-wallet/src/assets/locales/tr.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Deneysel",
   "settings_nodeless_wallet": "Düğümsüz cüzdan (deneysel)",
   "settings_nodeless_wallet_desc": "Yerel düğüm olmadan çalışan Electrum tabanlı BTCX cüzdanı. Gezinmeye Düğümsüz Cüzdan girişi ekler.",
-  "setup_plotting_address_invalid": "Kaydetmeden önce geçerli bir çizim adresi girin",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/uk.json
+++ b/web-wallet/src/assets/locales/uk.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "Експериментальні",
   "settings_nodeless_wallet": "Гаманець без вузла (експериментально)",
   "settings_nodeless_wallet_desc": "BTCX-гаманець на основі Electrum, що працює без локального вузла. Додає пункт «Гаманець без вузла» до навігації.",
-  "setup_plotting_address_invalid": "Перед збереженням введіть дійсну адресу плоттингу",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",

--- a/web-wallet/src/assets/locales/zh-cn.json
+++ b/web-wallet/src/assets/locales/zh-cn.json
@@ -1140,7 +1140,6 @@
   "settings_experimental": "实验性功能",
   "settings_nodeless_wallet": "无节点钱包（实验性）",
   "settings_nodeless_wallet_desc": "基于 Electrum 的 BTCX 钱包，无需本地节点即可使用。在导航中添加无节点钱包入口。",
-  "setup_plotting_address_invalid": "保存前请输入有效的绘图地址",
   "node_setup_remote_title": "Remote Node (Electrum)",
   "node_setup_remote_desc": "No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.",
   "node_remote_node": "Remote (Electrum)",


### PR DESCRIPTION
Post-#119 alignment, per owner direction:

1. Wizard saveAndStart: the plotting-address validation gate (added in #116) is removed - plotting for others / arbitrary targets is a supported flow. Key removed from all 26 locales.
2. Mobile assessment after #119: mobile is already correct on the named-wallet surface (name-less flows land on the documented default wallet; config shape unchanged; one-click intact) - no corrective work needed. Two parity items taken: live Electrum connection dot in the mobile toolbar (ElectrumStatusService), and showTest on the shared server editor in mobile settings.

Gates: prod build, lint, test:ci 58/58 green. Note: format:check fails on 14 pre-existing #119 files (untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp