### PR TITLE
security(android): disable Auto-Backup for the seed's sake

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -72,6 +72,11 @@ jobs:
           # Add requestLegacyExternalStorage to application tag
           sed -i 's|<application|<application android:requestLegacyExternalStorage="true"|' "$MANIFEST"
 
+          # Wallet app: the seed lives in app data — keep it out of Google
+          # Auto-Backup and device-to-device migration (Android defaults
+          # allowBackup to true when unset).
+          sed -i 's|<application|<application android:allowBackup="false" tools:replace="android:allowBackup"|' "$MANIFEST"
+
           # Add Samsung DeX meta-data for better process survival on Samsung devices
           sed -i '/<\/application>/i\        <meta-data android:name="com.samsung.android.keepalive.density" android:value="true" />\n        <meta-data android:name="com.samsung.android.multidisplay.keep_process_alive" android:value="true" />\n        <meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />' "$MANIFEST"
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -88,6 +88,11 @@ jobs:
           # Add requestLegacyExternalStorage to application tag
           sed -i 's|<application|<application android:requestLegacyExternalStorage="true"|' "$MANIFEST"
 
+          # Wallet app: the seed lives in app data — keep it out of Google
+          # Auto-Backup and device-to-device migration (Android defaults
+          # allowBackup to true when unset).
+          sed -i 's|<application|<application android:allowBackup="false" tools:replace="android:allowBackup"|' "$MANIFEST"
+
           # Add Samsung DeX meta-data for better process survival on Samsung devices
           sed -i '/<\/application>/i\        <meta-data android:name="com.samsung.android.keepalive.density" android:value="true" />\n        <meta-data android:name="com.samsung.android.multidisplay.keep_process_alive" android:value="true" />\n        <meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />' "$MANIFEST"
 


### PR DESCRIPTION
The Android manifest patching in both workflows never set android:allowBackup, and Android defaults it to TRUE - meaning app data (including seed.mnemonic, which without a passphrase is only obfuscated on Android since the OS-keyring path is desktop-only) was eligible for Google Auto-Backup and device-to-device migration. A compromised Google account could yield the seed.

Fix: force android:allowBackup=false (with tools:replace) in both android-build-test.yml and android-release.yml. Surfaced by the owner asking where secrets are stored; Android Keystore integration remains the planned proper fix for at-rest protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp