### PR TITLE
fix(mobile): white top bar, gradient page headers, fit-based pagination

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/components/page-header/page-header.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/components/page-header/page-header.component.ts
@@ -1,0 +1,126 @@
+import { Component, inject, input, output } from '@angular/core';
+import { Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { I18nPipe } from '../../../../core/i18n';
+
+/**
+ * PageHeaderComponent - the mobile subpage header band.
+ *
+ * The desktop pages' gradient page header (features/send `.header`,
+ * transaction-list, receive: `linear-gradient(135deg, #1e3a5f, #2d5a87)`
+ * with white, weight-300 title and a translucent back button), sized for
+ * mobile. Full-bleed band; the inner row aligns with the 480px page column
+ * the mobile pages use.
+ *
+ * API:
+ * - `titleKey`  - i18n key of the page title (required)
+ * - `backLink`  - back target (default '/wallet'); null hands control to
+ *                 the `back` output only (e.g. send's stage-aware back)
+ * - `back`      - emitted on every back tap, before any navigation
+ * - projected content - right-aligned extras (icon buttons, the send
+ *   page's available-balance chip); projected icon buttons are tinted
+ *   white for the gradient surface
+ */
+@Component({
+  selector: 'app-mwallet-page-header',
+  standalone: true,
+  imports: [MatButtonModule, MatIconModule, I18nPipe],
+  template: `
+    <div class="header-band">
+      <div class="header-inner">
+        <button mat-icon-button class="back-button" (click)="onBack()">
+          <mat-icon>arrow_back</mat-icon>
+        </button>
+        <h1 class="page-title">{{ titleKey() | i18n }}</h1>
+        <span class="spacer"></span>
+        <ng-content></ng-content>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+        flex-shrink: 0;
+      }
+
+      /* Desktop page header: features/send/pages/send .header. */
+      .header-band {
+        background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
+        color: white;
+        padding: 8px 16px;
+      }
+
+      .header-inner {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        max-width: 448px; /* the 480px page column minus its 16px padding */
+        margin: 0 auto;
+        min-height: 40px;
+      }
+
+      .back-button {
+        color: rgba(255, 255, 255, 0.9);
+        flex-shrink: 0;
+        margin-left: -8px;
+
+        &:hover {
+          background: rgba(255, 255, 255, 0.1);
+        }
+      }
+
+      /* Desktop header h1: weight 300, white — mobile-sized. */
+      .page-title {
+        margin: 0;
+        font-size: 20px;
+        font-weight: 300;
+        color: white;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .spacer {
+        flex: 1;
+      }
+
+      /* Projected right-side icon buttons (refresh, add contact, ...):
+         the desktop header's translucent-white button treatment. */
+      :host ::ng-deep .header-inner .mat-mdc-icon-button {
+        color: rgba(255, 255, 255, 0.9);
+
+        &:disabled {
+          color: rgba(255, 255, 255, 0.4);
+        }
+      }
+
+      /* Desktop keeps the same gradient in dark theme (send/receive/
+         transaction-list :host-context(.dark-theme) .header). */
+      :host-context(.dark-theme) .header-band {
+        background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
+      }
+    `,
+  ],
+})
+export class PageHeaderComponent {
+  private readonly router = inject(Router);
+
+  /** i18n key of the page title. */
+  readonly titleKey = input.required<string>();
+
+  /** Back navigation target; null = emit `back` only (custom handling). */
+  readonly backLink = input<string | null>('/wallet');
+
+  /** Emitted on every back tap (before any backLink navigation). */
+  readonly back = output<void>();
+
+  onBack(): void {
+    this.back.emit();
+    const link = this.backLink();
+    if (link !== null) {
+      void this.router.navigate([link]);
+    }
+  }
+}

--- a/web-wallet/src/app/features/mobile-wallet/fit-rows.directive.ts
+++ b/web-wallet/src/app/features/mobile-wallet/fit-rows.directive.ts
@@ -1,0 +1,73 @@
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  NgZone,
+  OnDestroy,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+
+/**
+ * FitRowsDirective - "how many rows fit this box without scrolling".
+ *
+ * Attach to a row container whose height is viewport-derived (flex-fill
+ * with `flex-basis: 0` / `min-height: 0`, so it never grows with its own
+ * content). The directive measures the first row matching `fitRowSelector`
+ * (falling back to `fitFallbackRowPx` before anything rendered), computes
+ * `floor(containerHeight / rowHeight)` clamped to `fitMinRows..fitMaxRows`,
+ * and emits it — once on attach and again whenever a ResizeObserver sees
+ * the container resize (rotation, window resize, cards above growing).
+ *
+ * Used by the mobile wallet home (recent-transactions preview length) and
+ * the transactions page (fit-derived mat-paginator pageSize).
+ */
+@Directive({
+  selector: '[appFitRows]',
+  standalone: true,
+})
+export class FitRowsDirective implements AfterViewInit, OnDestroy {
+  /** Selector of one row inside the container (its live height is used). */
+  readonly fitRowSelector = input('.tx-item');
+  /** Readability floor: never report fewer rows than this. */
+  readonly fitMinRows = input(1);
+  /** Sanity ceiling for very tall screens. */
+  readonly fitMaxRows = input(50);
+  /** Assumed row height before any row rendered, px. */
+  readonly fitFallbackRowPx = input(64);
+
+  /** Rows that fit, emitted on attach and whenever the fit changes. */
+  readonly fitRows = output<number>();
+
+  private readonly el = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly zone = inject(NgZone);
+  private observer: ResizeObserver | null = null;
+  private lastFit: number | null = null;
+
+  ngAfterViewInit(): void {
+    // ResizeObserver isn't zone-patched — re-enter for change detection.
+    this.observer = new ResizeObserver(() => this.zone.run(() => this.measure()));
+    this.observer.observe(this.el.nativeElement);
+    this.measure();
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect();
+    this.observer = null;
+  }
+
+  private measure(): void {
+    const host = this.el.nativeElement;
+    const row = host.querySelector<HTMLElement>(this.fitRowSelector());
+    const rowHeight = row?.getBoundingClientRect().height || this.fitFallbackRowPx();
+    const fit = Math.min(
+      this.fitMaxRows(),
+      Math.max(this.fitMinRows(), Math.floor(host.clientHeight / rowHeight))
+    );
+    if (fit !== this.lastFit) {
+      this.lastFit = fit;
+      this.fitRows.emit(fit);
+    }
+  }
+}

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -531,18 +531,16 @@ interface NavGroup {
         background: #eaf0f6;
       }
 
-      /* Phoenix-gradient header (round 6): the desktop wallet's toolbar is
-         plain white — the Phoenix identity gradient lives on its sidenav
-         (main-layout), which the drawer and dashboard cards here already
-         mirror. The mobile toolbar carries the same gradient so every
-         wallet page's header reads as desktop-Phoenix. */
+      /* Plain white toolbar — the desktop toolbar (layout/toolbar), which
+         is white with dark text/icons. The Phoenix identity gradient lives
+         on the page headers and the drawer, not on the top bar. */
       .wallet-toolbar {
         position: relative;
-        background: linear-gradient(90deg, #1e3a5f 0%, #2d5a87 100%) !important;
-        color: white !important;
+        background-color: white !important;
+        color: rgba(0, 0, 0, 0.87) !important;
         padding: 0;
         height: 56px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         flex-shrink: 0;
         z-index: 2;
       }
@@ -566,7 +564,7 @@ interface NavGroup {
       .app-name {
         font-size: 16px;
         font-weight: 500;
-        color: white;
+        color: rgba(0, 0, 0, 0.87);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -587,13 +585,13 @@ interface NavGroup {
           font-size: 20px;
           width: 20px;
           height: 20px;
-          color: rgba(255, 255, 255, 0.8);
+          color: rgba(0, 0, 0, 0.54);
         }
 
         .wallet-chip-name {
           font-size: 15px;
           font-weight: 500;
-          color: white;
+          color: rgba(0, 0, 0, 0.87);
           max-width: 96px;
           overflow: hidden;
           text-overflow: ellipsis;
@@ -604,7 +602,7 @@ interface NavGroup {
           font-size: 18px;
           width: 18px;
           height: 18px;
-          color: rgba(255, 255, 255, 0.8);
+          color: rgba(0, 0, 0, 0.54);
           margin: 0;
         }
       }
@@ -679,7 +677,7 @@ interface NavGroup {
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.5px;
-        color: #ffb74d;
+        color: #e65100;
         border: 1px solid currentColor;
         border-radius: 10px;
         padding: 1px 8px;
@@ -688,7 +686,7 @@ interface NavGroup {
       }
 
       /* Electrum indicator (the desktop toolbar's .status-indicator),
-         sized as a touch target and tinted for the gradient surface. */
+         sized as a touch target. Same colors as the desktop toolbar. */
       .status-indicator {
         display: flex;
         align-items: center;
@@ -701,7 +699,7 @@ interface NavGroup {
           font-size: 22px;
           width: 22px;
           height: 22px;
-          color: rgba(255, 255, 255, 0.45);
+          color: rgba(0, 0, 0, 0.25);
           transition: color 0.2s ease;
 
           &.electrum-healthy {
@@ -717,7 +715,7 @@ interface NavGroup {
           }
 
           &.electrum-connecting {
-            color: rgba(255, 255, 255, 0.45);
+            color: rgba(0, 0, 0, 0.38);
           }
         }
 
@@ -815,7 +813,7 @@ interface NavGroup {
       .toolbar-separator {
         height: 56px;
         width: 1px;
-        background: rgba(255, 255, 255, 0.15);
+        background: rgba(0, 0, 0, 0.12);
         flex-shrink: 0;
       }
 
@@ -840,12 +838,12 @@ interface NavGroup {
       }
 
       .secondary-text {
-        color: rgba(255, 255, 255, 0.85);
+        color: rgba(0, 0, 0, 0.54);
       }
 
       .lang-button {
         .lang-name-text {
-          color: white;
+          color: rgba(0, 0, 0, 0.87);
           display: inline;
         }
 
@@ -886,9 +884,57 @@ interface NavGroup {
           background: linear-gradient(180deg, #1a1a2e 0%, #16213e 100%);
         }
 
-        /* Same treatment, the dark sidenav gradient (desktop main-layout). */
+        /* Dark surface with light text — the pre-gradient dark toolbar. */
         .wallet-toolbar {
-          background: linear-gradient(90deg, #1a1a2e 0%, #16213e 100%) !important;
+          background-color: #424242 !important;
+          color: white !important;
+        }
+
+        .app-name {
+          color: white;
+        }
+
+        .wallet-chip-content {
+          .wallet-icon,
+          .dropdown-arrow {
+            color: rgba(255, 255, 255, 0.7);
+          }
+
+          .wallet-chip-name {
+            color: white;
+          }
+        }
+
+        .secondary-text {
+          color: rgba(255, 255, 255, 0.7);
+        }
+
+        .toolbar-separator {
+          background: rgba(255, 255, 255, 0.12);
+        }
+
+        .network-badge {
+          color: #ffb74d;
+        }
+
+        .status-indicator mat-icon {
+          color: rgba(255, 255, 255, 0.3);
+
+          &.electrum-healthy {
+            color: #4caf50;
+          }
+
+          &.electrum-degraded {
+            color: #ff9800;
+          }
+
+          &.electrum-down {
+            color: #e53935;
+          }
+
+          &.electrum-connecting {
+            color: rgba(255, 255, 255, 0.45);
+          }
         }
       }
     `,

--- a/web-wallet/src/app/features/mobile-wallet/pages/assignment/wallet-assignment.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/assignment/wallet-assignment.component.ts
@@ -27,6 +27,7 @@ import type {
 } from '../../../../bitcoin/services/rpc/mining-rpc.service';
 import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
 import { MiningService } from '../../../../mining/services';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 import {
   PoolAddressOption,
   poolAddressOptionsForChains,
@@ -82,25 +83,21 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
     NgTemplateOutlet,
     HashTruncatePipe,
     I18nPipe,
+    PageHeaderComponent,
   ],
   template: `
-    <div class="page">
-      <div class="header-row">
-        <button mat-icon-button routerLink="/wallet">
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-        <h2>{{ 'forging_assignment' | i18n }}</h2>
-        <span class="spacer"></span>
-        <button
-          mat-icon-button
-          [disabled]="statusLoading() || !plotAddress"
-          (click)="checkStatus()"
-          [matTooltip]="'refresh' | i18n"
-        >
-          <mat-icon [class.spinning]="statusLoading()">refresh</mat-icon>
-        </button>
-      </div>
+    <app-mwallet-page-header titleKey="forging_assignment">
+      <button
+        mat-icon-button
+        [disabled]="statusLoading() || !plotAddress"
+        (click)="checkStatus()"
+        [matTooltip]="'refresh' | i18n"
+      >
+        <mat-icon [class.spinning]="statusLoading()">refresh</mat-icon>
+      </button>
+    </app-mwallet-page-header>
 
+    <div class="page">
       @if (!wallet.walletActive()) {
         <div class="card empty-card">
           <mat-icon class="empty-icon">lock</mat-icon>
@@ -401,22 +398,6 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
         width: 100%;
         margin: 0 auto;
         box-sizing: border-box;
-      }
-
-      .header-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-
-        h2 {
-          margin: 0;
-          font-size: 18px;
-          font-weight: 500;
-        }
-
-        .spacer {
-          flex: 1;
-        }
       }
 
       .spinning {

--- a/web-wallet/src/app/features/mobile-wallet/pages/contacts/wallet-contacts.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/contacts/wallet-contacts.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal, computed, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -22,6 +22,7 @@ import {
 } from '../../../../shared/components/confirm-dialog/confirm-dialog.component';
 import { validatePocxAddress } from '../../../../bitcoin/utils/address-validation';
 import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 /**
  * WalletContactsComponent - the mobile address book.
@@ -37,7 +38,6 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
   standalone: true,
   imports: [
     FormsModule,
-    RouterModule,
     MatButtonModule,
     MatIconModule,
     MatFormFieldModule,
@@ -47,20 +47,16 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
     MatTooltipModule,
     HashTruncatePipe,
     I18nPipe,
+    PageHeaderComponent,
   ],
   template: `
-    <div class="page">
-      <div class="header-row">
-        <button mat-icon-button routerLink="/wallet">
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-        <h2>{{ 'contacts' | i18n }}</h2>
-        <span class="spacer"></span>
-        <button mat-icon-button (click)="startAdd()" [matTooltip]="'add_contact' | i18n">
-          <mat-icon>person_add</mat-icon>
-        </button>
-      </div>
+    <app-mwallet-page-header titleKey="contacts">
+      <button mat-icon-button (click)="startAdd()" [matTooltip]="'add_contact' | i18n">
+        <mat-icon>person_add</mat-icon>
+      </button>
+    </app-mwallet-page-header>
 
+    <div class="page">
       <!-- Add / edit form -->
       @if (formOpen()) {
         <div class="card">
@@ -168,22 +164,6 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
         width: 100%;
         margin: 0 auto;
         box-sizing: border-box;
-      }
-
-      .header-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-
-        h2 {
-          margin: 0;
-          font-size: 18px;
-          font-weight: 500;
-        }
-
-        .spacer {
-          flex: 1;
-        }
       }
 
       .card {

--- a/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal, computed, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -12,6 +12,7 @@ import { I18nPipe } from '../../../../core/i18n';
 import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
 import { sanitizeReturnTo } from '../../return-to';
 import { isInvalidWalletName, isWalletNameTaken, suggestWalletName } from '../../wallet-name';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 type CreateStep = 'phrase' | 'verify' | 'protect';
 
@@ -37,7 +38,6 @@ type CreateStep = 'phrase' | 'verify' | 'protect';
   standalone: true,
   imports: [
     FormsModule,
-    RouterModule,
     MatButtonModule,
     MatIconModule,
     MatCheckboxModule,
@@ -46,16 +46,12 @@ type CreateStep = 'phrase' | 'verify' | 'protect';
     MatProgressSpinnerModule,
     MatRadioModule,
     I18nPipe,
+    PageHeaderComponent,
   ],
   template: `
-    <div class="page">
-      <div class="header-row">
-        <button mat-icon-button routerLink="/wallet">
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-        <h2>{{ 'mwallet_create_wallet' | i18n }}</h2>
-      </div>
+    <app-mwallet-page-header titleKey="mwallet_create_wallet" />
 
+    <div class="page">
       @if (step() === 'phrase') {
         <div class="card">
           <h3>{{ 'mwallet_backup_title' | i18n }}</h3>
@@ -232,18 +228,6 @@ type CreateStep = 'phrase' | 'verify' | 'protect';
         width: 100%;
         margin: 0 auto;
         box-sizing: border-box;
-      }
-
-      .header-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-
-        h2 {
-          margin: 0;
-          font-size: 18px;
-          font-weight: 500;
-        }
       }
 
       .card {

--- a/web-wallet/src/app/features/mobile-wallet/pages/history/wallet-history.component.spec.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/history/wallet-history.component.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+
+import { WalletHistoryComponent } from './wallet-history.component';
+import { BtcxWalletService, BtcxWalletTx } from '../../../../core/services/btcx-wallet.service';
+import { ClipboardService, ContactsStoreService } from '../../../../shared/services';
+
+function stubTx(i: number): BtcxWalletTx {
+  return { txid: `tx${i}` } as BtcxWalletTx;
+}
+
+describe('WalletHistoryComponent (fit-derived pagination)', () => {
+  let component: WalletHistoryComponent;
+  let transactions: ReturnType<typeof signal<BtcxWalletTx[]>>;
+
+  beforeEach(() => {
+    transactions = signal(Array.from({ length: 40 }, (_, i) => stubTx(i)));
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: BtcxWalletService,
+          useValue: {
+            transactions,
+            walletActive: signal(true),
+            initialize: () => Promise.resolve(),
+            refreshTransactions: () => Promise.resolve(),
+            syncNow: () => Promise.resolve(),
+          },
+        },
+        { provide: ClipboardService, useValue: {} },
+        { provide: ContactsStoreService, useValue: { load: () => {} } },
+      ],
+    });
+    component = TestBed.runInInjectionContext(() => new WalletHistoryComponent());
+  });
+
+  it('adopts the measured fit as the page size', () => {
+    component.onFitRows(7);
+    expect(component.pageSize()).toBe(7);
+    expect(component.visibleTransactions().length).toBe(7);
+  });
+
+  it('keeps the page containing the previously first visible tx on fit change', () => {
+    component.onFitRows(8);
+    component.onPageChange({ pageIndex: 4, pageSize: 8, length: 40 });
+    // First visible tx is index 32.
+    component.onFitRows(5);
+    expect(component.pageIndex()).toBe(6); // floor(32 / 5): page 6 spans 30..34
+    expect(component.visibleTransactions()[0].txid).toBe('tx30');
+  });
+
+  it('clamps the page when a refresh shrinks the list below the current page', () => {
+    component.onFitRows(8);
+    component.onPageChange({ pageIndex: 4, pageSize: 8, length: 40 });
+    transactions.set(Array.from({ length: 10 }, (_, i) => stubTx(i)));
+    expect(component.visibleTransactions()[0].txid).toBe('tx8'); // last page (1)
+  });
+});

--- a/web-wallet/src/app/features/mobile-wallet/pages/history/wallet-history.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/history/wallet-history.component.ts
@@ -1,5 +1,4 @@
 import { Component, inject, signal, computed, OnInit } from '@angular/core';
-import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
@@ -8,51 +7,51 @@ import { I18nPipe } from '../../../../core/i18n';
 import { ClipboardService, ContactsStoreService } from '../../../../shared/services';
 import { BtcxWalletService, BtcxWalletTx } from '../../../../core/services/btcx-wallet.service';
 import { TxRowComponent } from '../../components/tx-row/tx-row.component';
-
-/** Desktop transaction-list page sizes, defaulting to the mobile-sensible 25. */
-const PAGE_SIZE = 25;
+import { FitRowsDirective } from '../../fit-rows.directive';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 /**
  * WalletHistoryComponent - transaction list (newest first).
  *
  * Rows are the shared mobile TxRowComponent (same row the home preview
  * renders, including the per-row menu). Pagination mirrors the desktop
- * transaction-list: a mat-paginator with page-size options and first/last
- * buttons over a client-side slice, instead of the former "load more"
- * button. Refresh pokes the background sync worker (sync_now) and
- * re-reads the cached history. Tapping an item expands a simple detail:
- * txid with copy, address, fee, vsize.
+ * transaction-list's mat-paginator (first/last buttons over a client-side
+ * slice), but the page size is not chosen from a dropdown: the list card
+ * flex-fills the viewport and the shared FitRowsDirective (the home page's
+ * recent-list fill, round 6) derives how many rows fit without scrolling —
+ * that fit IS the page size, recomputed on resize/rotation. When the fit
+ * changes, the pager stays on the page containing the previously first
+ * visible transaction. Refresh pokes the background sync worker (sync_now)
+ * and re-reads the cached history. Tapping an item expands a simple
+ * detail: txid with copy, address, fee, vsize (the list scrolls the
+ * few overflowing pixels while a detail is open).
  */
 @Component({
   selector: 'app-wallet-history',
   standalone: true,
   imports: [
-    RouterModule,
     MatButtonModule,
     MatIconModule,
     MatPaginatorModule,
     MatTooltipModule,
     I18nPipe,
     TxRowComponent,
+    FitRowsDirective,
+    PageHeaderComponent,
   ],
   template: `
-    <div class="page">
-      <div class="header-row">
-        <button mat-icon-button routerLink="/wallet">
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-        <h2>{{ 'transactions' | i18n }}</h2>
-        <span class="spacer"></span>
-        <button
-          mat-icon-button
-          [disabled]="refreshing()"
-          (click)="refresh()"
-          [matTooltip]="'refresh' | i18n"
-        >
-          <mat-icon [class.spinning]="refreshing()">refresh</mat-icon>
-        </button>
-      </div>
+    <app-mwallet-page-header titleKey="transactions">
+      <button
+        mat-icon-button
+        [disabled]="refreshing()"
+        (click)="refresh()"
+        [matTooltip]="'refresh' | i18n"
+      >
+        <mat-icon [class.spinning]="refreshing()">refresh</mat-icon>
+      </button>
+    </app-mwallet-page-header>
 
+    <div class="page">
       <div class="card list-card">
         @if (wallet.transactions().length === 0) {
           <div class="empty-state">
@@ -60,53 +59,64 @@ const PAGE_SIZE = 25;
             <span>{{ 'no_transactions' | i18n }}</span>
           </div>
         } @else {
-          @for (tx of visibleTransactions(); track tx.txid) {
-            <div class="tx-item" (click)="toggleDetail(tx)">
-              <app-mwallet-tx-row [tx]="tx" />
+          <div
+            class="tx-list"
+            appFitRows
+            [fitRowSelector]="'.tx-item:not(:has(.tx-detail))'"
+            [fitMinRows]="3"
+            (fitRows)="onFitRows($event)"
+          >
+            @for (tx of visibleTransactions(); track tx.txid) {
+              <div class="tx-item" (click)="toggleDetail(tx)">
+                <app-mwallet-tx-row [tx]="tx" />
 
-              @if (expandedTxid() === tx.txid) {
-                <div class="tx-detail">
-                  <div class="detail-line">
-                    <span class="detail-label">{{ 'transaction_id' | i18n }}</span>
-                    <div
-                      class="detail-value copyable"
-                      (click)="copyTxid(tx.txid); $event.stopPropagation()"
-                      [matTooltip]="'copy' | i18n"
-                    >
-                      <span class="mono">{{ tx.txid }}</span>
-                      <mat-icon class="copy-icon">content_copy</mat-icon>
-                    </div>
-                  </div>
-                  @if (tx.address) {
+                @if (expandedTxid() === tx.txid) {
+                  <div class="tx-detail">
                     <div class="detail-line">
-                      <span class="detail-label">{{ 'address' | i18n }}</span>
+                      <span class="detail-label">{{ 'transaction_id' | i18n }}</span>
                       <div
                         class="detail-value copyable"
-                        (click)="copyAddress(tx.address); $event.stopPropagation()"
+                        (click)="copyTxid(tx.txid); $event.stopPropagation()"
                         [matTooltip]="'copy' | i18n"
                       >
-                        <span class="mono">{{ tx.address }}</span>
+                        <span class="mono">{{ tx.txid }}</span>
                         <mat-icon class="copy-icon">content_copy</mat-icon>
                       </div>
                     </div>
-                  }
-                  @if (tx.feeSat !== null) {
-                    <div class="detail-line">
-                      <span class="detail-label">{{ 'fee' | i18n }}</span>
-                      <span class="detail-value mono">{{ tx.feeSat }} sat ({{ tx.vsize }} vB)</span>
-                    </div>
-                  }
-                </div>
-              }
-            </div>
-          }
+                    @if (tx.address) {
+                      <div class="detail-line">
+                        <span class="detail-label">{{ 'address' | i18n }}</span>
+                        <div
+                          class="detail-value copyable"
+                          (click)="copyAddress(tx.address); $event.stopPropagation()"
+                          [matTooltip]="'copy' | i18n"
+                        >
+                          <span class="mono">{{ tx.address }}</span>
+                          <mat-icon class="copy-icon">content_copy</mat-icon>
+                        </div>
+                      </div>
+                    }
+                    @if (tx.feeSat !== null) {
+                      <div class="detail-line">
+                        <span class="detail-label">{{ 'fee' | i18n }}</span>
+                        <span class="detail-value mono"
+                          >{{ tx.feeSat }} sat ({{ tx.vsize }} vB)</span
+                        >
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+            }
+          </div>
 
-          <!-- Desktop transaction-list pagination, scaled to mobile -->
+          <!-- Desktop transaction-list pagination; the page size is the
+               measured fit, so there is no size dropdown. -->
           <mat-paginator
             [length]="wallet.transactions().length"
             [pageSize]="pageSize()"
             [pageIndex]="pageIndex()"
-            [pageSizeOptions]="pageSizeOptions"
+            [hidePageSize]="true"
             (page)="onPageChange($event)"
             [showFirstLastButtons]="true"
           >
@@ -117,31 +127,26 @@ const PAGE_SIZE = 25;
   `,
   styles: [
     `
+      /* Fill the wallet-content column so the list card can flex into the
+         leftover viewport height (same fill idiom as the home page). */
+      :host {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+
       .page {
         padding: 16px;
         display: flex;
         flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
         gap: 16px;
         max-width: 480px;
         width: 100%;
         margin: 0 auto;
         box-sizing: border-box;
-      }
-
-      .header-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-
-        h2 {
-          margin: 0;
-          font-size: 18px;
-          font-weight: 500;
-        }
-
-        .spacer {
-          flex: 1;
-        }
       }
 
       .spinning {
@@ -163,8 +168,27 @@ const PAGE_SIZE = 25;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
       }
 
+      /* Flex-fill: basis 0 so the card's height comes from the leftover
+         viewport space (never from its own rows); the min-height floor
+         keeps ~3 rows readable on tiny viewports (the page then scrolls
+         slightly instead). */
       .list-card {
         padding: 4px 0 0;
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 0;
+        min-height: 280px;
+        overflow: hidden;
+      }
+
+      /* The measured row viewport: exactly the space between card top and
+         paginator (basis 0: its height never depends on its own rows).
+         Steady-state the fit-sized page never scrolls; an expanded detail
+         scrolls its extra height here. */
+      .tx-list {
+        flex: 1 1 0;
+        min-height: 0;
+        overflow-y: auto;
       }
 
       .empty-state {
@@ -196,6 +220,7 @@ const PAGE_SIZE = 25;
       /* Compact paginator (the desktop transaction-list pager, mobile-sized). */
       mat-paginator {
         border-radius: 0 0 8px 8px;
+        flex-shrink: 0;
 
         ::ng-deep .mat-mdc-paginator-container {
           min-height: 44px;
@@ -203,11 +228,6 @@ const PAGE_SIZE = 25;
           justify-content: center;
         }
 
-        ::ng-deep .mat-mdc-paginator-page-size {
-          margin-right: 4px;
-        }
-
-        ::ng-deep .mat-mdc-paginator-page-size-label,
         ::ng-deep .mat-mdc-paginator-range-label {
           font-size: 11px;
           margin: 0 6px;
@@ -299,10 +319,10 @@ export class WalletHistoryComponent implements OnInit {
   readonly refreshing = signal(false);
   readonly expandedTxid = signal<string | null>(null);
 
-  // Desktop transaction-list pagination state (client-side slicing).
-  readonly pageSize = signal(PAGE_SIZE);
+  // Fit-derived pagination: the page size is whatever FitRowsDirective
+  // measures (initial value only covers the first paint before AfterViewInit).
+  readonly pageSize = signal(8);
   readonly pageIndex = signal(0);
-  readonly pageSizeOptions = [10, 25, 50];
 
   readonly visibleTransactions = computed(() => {
     const txs = this.wallet.transactions();
@@ -337,8 +357,21 @@ export class WalletHistoryComponent implements OnInit {
     }
   }
 
+  /**
+   * New measured fit (rotation, resize, first measurement): adopt it as
+   * the page size and keep the user on the page that contains the
+   * previously first visible transaction (cheap: one division) instead
+   * of resetting to page 0.
+   */
+  onFitRows(fit: number): void {
+    const oldSize = this.pageSize();
+    if (fit === oldSize) return;
+    const firstVisibleIndex = this.pageIndex() * oldSize;
+    this.pageSize.set(fit);
+    this.pageIndex.set(Math.floor(firstVisibleIndex / fit));
+  }
+
   onPageChange(event: PageEvent): void {
-    this.pageSize.set(event.pageSize);
     this.pageIndex.set(event.pageIndex);
     this.expandedTxid.set(null);
   }

--- a/web-wallet/src/app/features/mobile-wallet/pages/home/wallet-home.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/home/wallet-home.component.ts
@@ -1,15 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  NgZone,
-  OnDestroy,
-  OnInit,
-  computed,
-  effect,
-  inject,
-  signal,
-  viewChild,
-} from '@angular/core';
+import { Component, OnInit, computed, effect, inject, signal } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
@@ -22,6 +11,7 @@ import { I18nPipe } from '../../../../core/i18n';
 import { BtcxPipe } from '../../../../shared/pipes';
 import { ContactsStoreService } from '../../../../shared/services';
 import { TxRowComponent } from '../../components/tx-row/tx-row.component';
+import { FitRowsDirective } from '../../fit-rows.directive';
 import { BtcxWalletService, BtcxChainInfo } from '../../../../core/services/btcx-wallet.service';
 import { MiningService } from '../../../../mining/services';
 import {
@@ -62,6 +52,7 @@ import {
     BtcxPipe,
     I18nPipe,
     TxRowComponent,
+    FitRowsDirective,
   ],
   template: `
     <div class="page">
@@ -219,8 +210,8 @@ import {
         </div>
 
         <!-- Recent transactions: fills the viewport height left by the
-             cards above (as many rows as fit, min 3 / max 10 — measured
-             with a ResizeObserver, so rotation/resize recomputes). -->
+             cards above (as many rows as fit, min 3 / max 10 — the shared
+             FitRowsDirective, so rotation/resize recomputes). -->
         <div class="card recent-card">
           <div class="card-title plain">
             <mat-icon>history</mat-icon>
@@ -229,7 +220,13 @@ import {
           @if (recentTransactions().length === 0) {
             <p class="hint-text no-tx">{{ 'no_transactions' | i18n }}</p>
           } @else {
-            <div class="tx-list" #txList>
+            <div
+              class="tx-list"
+              appFitRows
+              [fitMinRows]="3"
+              [fitMaxRows]="10"
+              (fitRows)="visibleTxCount.set($event)"
+            >
               @for (tx of recentTransactions(); track tx.txid) {
                 <div class="tx-item" routerLink="/wallet/history">
                   <app-mwallet-tx-row [tx]="tx" />
@@ -549,11 +546,10 @@ import {
     `,
   ],
 })
-export class WalletHomeComponent implements OnInit, OnDestroy {
+export class WalletHomeComponent implements OnInit {
   readonly wallet = inject(BtcxWalletService);
   private readonly mining = inject(MiningService);
   private readonly contactsStore = inject(ContactsStoreService);
-  private readonly zone = inject(NgZone);
 
   readonly balance = computed(() => this.wallet.balance());
   readonly pendingSat = computed(() => {
@@ -564,17 +560,9 @@ export class WalletHomeComponent implements OnInit, OnDestroy {
 
   // --- Recent list viewport fill (round 6) -------------------------------
   // The card flex-fills the height left by the cards above (flex-basis 0,
-  // so its height never depends on its own rows); a ResizeObserver on the
-  // row container derives how many rows fit. Row height is measured from
-  // the first rendered row (full addresses wrap, so it isn't a constant),
-  // falling back to a typical row before anything rendered.
-  private static readonly MIN_ROWS = 3;
-  private static readonly MAX_ROWS = 10;
-  private static readonly FALLBACK_ROW_PX = 64;
-
-  private readonly txList = viewChild<ElementRef<HTMLElement>>('txList');
-  private readonly visibleTxCount = signal(WalletHomeComponent.MIN_ROWS);
-  private resizeObserver: ResizeObserver | null = null;
+  // so its height never depends on its own rows); the shared
+  // FitRowsDirective on the row container derives how many rows fit.
+  readonly visibleTxCount = signal(3);
 
   /** Recent activity preview — as many newest entries as fit the screen. */
   readonly recentTransactions = computed(() =>
@@ -606,37 +594,6 @@ export class WalletHomeComponent implements OnInit, OnDestroy {
         void this.refreshChain();
       }
     });
-
-    // (Re)attach the ResizeObserver whenever the row container (re)appears —
-    // it lives inside @if/@for branches, so it comes and goes.
-    effect(() => {
-      const list = this.txList()?.nativeElement ?? null;
-      this.resizeObserver?.disconnect();
-      if (!list) return;
-      this.resizeObserver ??= new ResizeObserver(() => {
-        // ResizeObserver isn't zone-patched — re-enter for change detection.
-        this.zone.run(() => this.measureVisibleRows());
-      });
-      this.resizeObserver.observe(list);
-      this.measureVisibleRows();
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.resizeObserver?.disconnect();
-    this.resizeObserver = null;
-  }
-
-  /** floor(listHeight / rowHeight), clamped to MIN_ROWS..MAX_ROWS. */
-  private measureVisibleRows(): void {
-    const list = this.txList()?.nativeElement;
-    if (!list) return;
-    const first = list.querySelector<HTMLElement>('.tx-item');
-    const rowHeight = first?.getBoundingClientRect().height || WalletHomeComponent.FALLBACK_ROW_PX;
-    const fit = Math.floor(list.clientHeight / rowHeight);
-    this.visibleTxCount.set(
-      Math.min(WalletHomeComponent.MAX_ROWS, Math.max(WalletHomeComponent.MIN_ROWS, fit))
-    );
   }
 
   ngOnInit(): void {

--- a/web-wallet/src/app/features/mobile-wallet/pages/receive/wallet-receive.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/receive/wallet-receive.component.ts
@@ -1,5 +1,4 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
-import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -8,6 +7,7 @@ import { QRCodeComponent } from 'angularx-qrcode';
 import { I18nPipe } from '../../../../core/i18n';
 import { ClipboardService } from '../../../../shared/services';
 import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 /**
  * WalletReceiveComponent - current receive address with QR and copy.
@@ -16,23 +16,18 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
   selector: 'app-wallet-receive',
   standalone: true,
   imports: [
-    RouterModule,
     MatButtonModule,
     MatIconModule,
     MatProgressSpinnerModule,
     MatTooltipModule,
     QRCodeComponent,
     I18nPipe,
+    PageHeaderComponent,
   ],
   template: `
-    <div class="page">
-      <div class="header-row">
-        <button mat-icon-button routerLink="/wallet">
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-        <h2>{{ 'receive' | i18n }}</h2>
-      </div>
+    <app-mwallet-page-header titleKey="receive" />
 
+    <div class="page">
       <div class="card">
         @if (address()) {
           <div class="qr-container">
@@ -88,18 +83,6 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
         width: 100%;
         margin: 0 auto;
         box-sizing: border-box;
-      }
-
-      .header-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-
-        h2 {
-          margin: 0;
-          font-size: 18px;
-          font-weight: 500;
-        }
       }
 
       .card {

--- a/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
@@ -21,6 +21,7 @@ import {
   suggestSiblingWalletName,
   suggestWalletName,
 } from '../../wallet-name';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 /**
  * WalletRestoreComponent - restore-from-mnemonic flow.
@@ -62,16 +63,12 @@ import {
     MatProgressSpinnerModule,
     MnemonicEntryComponent,
     I18nPipe,
+    PageHeaderComponent,
   ],
   template: `
-    <div class="page">
-      <div class="header-row">
-        <button mat-icon-button routerLink="/wallet">
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-        <h2>{{ 'mwallet_restore_wallet' | i18n }}</h2>
-      </div>
+    <app-mwallet-page-header titleKey="mwallet_restore_wallet" />
 
+    <div class="page">
       @if (restored()) {
         <!-- Success: branch verdict of the restore probe -->
         <div class="card success-card">
@@ -237,18 +234,6 @@ import {
         width: 100%;
         margin: 0 auto;
         box-sizing: border-box;
-      }
-
-      .header-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-
-        h2 {
-          margin: 0;
-          font-size: 18px;
-          font-weight: 500;
-        }
       }
 
       .card {

--- a/web-wallet/src/app/features/mobile-wallet/pages/send/wallet-send.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/send/wallet-send.component.ts
@@ -19,6 +19,7 @@ import {
   BtcxFeeEstimates,
   BtcxSendRequest,
 } from '../../../../core/services/btcx-wallet.service';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 type SendStage = 'form' | 'review' | 'success';
 
@@ -54,18 +55,18 @@ const PREVIEW_VSIZE_VB = 141;
     DecimalPipe,
     HashTruncatePipe,
     I18nPipe,
+    PageHeaderComponent,
   ],
   template: `
-    <div class="page">
-      <div class="header-row">
-        <button mat-icon-button (click)="onBack()">
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-        <h2>{{ 'send' | i18n }}</h2>
-        <span class="spacer"></span>
-        <span class="balance-hint"> {{ spendableSat() / 100000000 | number: '1.8-8' }} BTCX </span>
+    <app-mwallet-page-header titleKey="send" [backLink]="null" (back)="onBack()">
+      <!-- Desktop send header's available-balance chip, stacked for width -->
+      <div class="balance-display">
+        <span class="balance-label">{{ 'balance_available' | i18n }}</span>
+        <span class="balance-value"> {{ spendableSat() / 100000000 | number: '1.8-8' }} BTCX </span>
       </div>
+    </app-mwallet-page-header>
 
+    <div class="page">
       @if (stage() === 'success') {
         <div class="card success-card">
           <mat-icon class="success-icon">check_circle</mat-icon>
@@ -339,25 +340,28 @@ const PREVIEW_VSIZE_VB = 141;
         box-sizing: border-box;
       }
 
-      .header-row {
+      /* Desktop send header's .balance-display, stacked to fit a phone. */
+      .balance-display {
         display: flex;
-        align-items: center;
-        gap: 8px;
+        flex-direction: column;
+        align-items: flex-end;
+        background: rgba(255, 255, 255, 0.1);
+        padding: 4px 10px;
+        border-radius: 8px;
+        min-width: 0;
 
-        h2 {
-          margin: 0;
-          font-size: 18px;
-          font-weight: 500;
+        .balance-label {
+          font-size: 10px;
+          color: rgba(255, 255, 255, 0.7);
+          white-space: nowrap;
         }
 
-        .spacer {
-          flex: 1;
-        }
-
-        .balance-hint {
+        .balance-value {
           font-size: 12px;
-          color: rgba(0, 0, 0, 0.55);
-          font-variant-numeric: tabular-nums;
+          font-weight: 600;
+          font-family: monospace;
+          color: white;
+          white-space: nowrap;
         }
       }
 
@@ -621,10 +625,6 @@ const PREVIEW_VSIZE_VB = 141;
       :host-context(.dark-theme) {
         .card {
           background: #424242;
-        }
-
-        .header-row .balance-hint {
-          color: rgba(255, 255, 255, 0.55);
         }
 
         .hint-text,

--- a/web-wallet/src/app/features/mobile-wallet/pages/settings/wallet-settings.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/settings/wallet-settings.component.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../../core/services/btcx-wallet.service';
 import { ElectrumServersEditorComponent } from '../../../../shared/components/electrum-servers-editor/electrum-servers-editor.component';
 import { isInvalidWalletName, isWalletNameTaken } from '../../wallet-name';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 /** Width of ONE swipe-revealed action button, px. */
 const ACTION_PX = 56;
@@ -76,16 +77,12 @@ const DRAG_SLOP_PX = 8;
     MatTooltipModule,
     I18nPipe,
     ElectrumServersEditorComponent,
+    PageHeaderComponent,
   ],
   template: `
-    <div class="page">
-      <div class="header-row">
-        <button mat-icon-button routerLink="/wallet">
-          <mat-icon>arrow_back</mat-icon>
-        </button>
-        <h2>{{ 'mwallet_settings_title' | i18n }}</h2>
-      </div>
+    <app-mwallet-page-header titleKey="mwallet_settings_title" />
 
+    <div class="page">
       <!-- Wallets (the switcher's management surface) -->
       @if (wallet.hasSeed()) {
         <div class="card">
@@ -261,18 +258,6 @@ const DRAG_SLOP_PX = 8;
         width: 100%;
         margin: 0 auto;
         box-sizing: border-box;
-      }
-
-      .header-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-
-        h2 {
-          margin: 0;
-          font-size: 18px;
-          font-weight: 500;
-        }
       }
 
       .card {


### PR DESCRIPTION
Mobile feedback round 7 — three precise UI items, desktop Phoenix as the design north star.

## 1. Top toolbar back to WHITE
The round-6 blue gradient on the mobile top bar is reverted: the bar again matches the desktop toolbar (`layout/toolbar`) — plain white with dark text/icons (dark theme: the pre-gradient `#424242`). The Electrum bolt keeps its green/orange/red status colors and takes the desktop toolbar's neutral base tints; wallet chip, separators, settings/language buttons and the network badge return to their pre-round-6 colors. The round-6 additions (bolt popover, segwit badge) are kept.

## 2. Per-page gradient headers (shared component)
New `app-mwallet-page-header` mirrors the desktop pages' gradient header (send/receive/transaction-list `.header`: `linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%)`, white weight-300 title, translucent back button, same gradient in dark theme) as a full-bleed band whose inner row aligns with the 480px page column.

API: `titleKey` (required), `backLink` (default `/wallet`; `null` hands back-handling to the `back` output — used by send's stage-aware back), projected right-side content (icon buttons auto-tinted white).

Adopted on all eight subpages: **send** (with the desktop header's available-balance chip, stacked to fit a phone), **receive**, **history**, **contacts** (+add), **assignment** (+refresh), **settings**, **create**, **restore** — replacing eight ad-hoc `header-row` copies.

## 3. Transactions pagination = fit-derived page size
The home page's round-6 viewport-fill (measured row height + ResizeObserver, clamped `floor(container / row)`) is extracted into a shared `FitRowsDirective`; home now uses it for its recent-preview length, and the history page uses it to derive the `mat-paginator` **pageSize**: the list card flex-fills the viewport (same idiom as home) and exactly as many rows as fit are shown per page (floor 3; no scrolling in steady state). The 10/25/50 dropdown is gone (`hidePageSize`), first/last buttons kept.

- **Resize/rotation**: fit recomputes; the pager stays on the page containing the previously first visible tx (`floor(firstVisibleIndex / newSize)`) — cheap, so no page-0 reset.
- **Expanded tx detail**: its extra height scrolls inside the list (`overflow-y: auto`) rather than distorting the fit; row height is measured from a collapsed row (`:not(:has(.tx-detail))`).
- Unit spec covers fit adoption, keep-position math and shrink-clamping.

## i18n
Zero new keys (`balance_available` and all titles already exist in all 26 locales).

## Verification
`npm ci` / `npm run build` (prod) / `npm run lint` / `npm run format:check` / `npm run test:ci` (79/79) — all green. Desktop pages untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp