### PR TITLE
fix(mobile): name-first flows, import overlay, O(visible) transaction loading

### DIFF
--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -964,26 +964,60 @@ pub fn tx_display_address(
     super::psbt::spk_to_address(network, spk)
 }
 
-/// Transaction history, newest first (the activity feed), each entry
-/// carrying the display address derived from its outputs.
-#[tauri::command]
-pub fn btcx_wallet_transactions(
-    state: State<'_, SharedBtcxWalletState>,
-) -> Result<Vec<BtcxWalletTxDto>, String> {
+/// One page of the activity feed: the requested slice plus the total entry
+/// count (the transaction page's paginator length; `limit: 0` is a cheap
+/// count-only query).
+#[derive(Debug, Clone, Serialize)]
+pub struct BtcxWalletTxPage {
+    pub items: Vec<BtcxWalletTxDto>,
+    /// History size BEFORE the limit/offset slice.
+    pub total: usize,
+}
+
+/// Seam behind `btcx_wallet_transactions` (unit-testable from the live
+/// regtest suite). The crate builds the full sorted history (cheap in-
+/// process arithmetic per entry); the slice is applied BEFORE the per-item
+/// display-address derivation (tx-graph reads + bech32 encoding), DTO
+/// mapping and IPC serialization — the parts that actually hurt on a fat
+/// wallet — so absent `limit`/`offset` keep the old full-list behavior.
+pub fn wallet_transactions_impl(
+    state: &SharedBtcxWalletState,
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> Result<BtcxWalletTxPage, String> {
     let network = state.get_config().network;
     let infos = state
         .backend()?
         .wallet_transactions()
         .map_err(|e| format!("{e:#}"))?;
+    let total = infos.len();
     state.with_entry(|entry| {
-        Ok(infos
-            .into_iter()
-            .map(|info| {
-                let address = tx_display_address(entry, network, &info);
-                BtcxWalletTxDto { info, address }
-            })
-            .collect())
+        Ok(BtcxWalletTxPage {
+            items: infos
+                .into_iter()
+                .skip(offset.unwrap_or(0))
+                .take(limit.unwrap_or(usize::MAX))
+                .map(|info| {
+                    let address = tx_display_address(entry, network, &info);
+                    BtcxWalletTxDto { info, address }
+                })
+                .collect(),
+            total,
+        })
     })
+}
+
+/// Transaction history, newest first (the activity feed), each entry
+/// carrying the display address derived from its outputs. Optional
+/// `limit`/`offset` slice the feed so the dashboard/transaction pages stay
+/// O(visible) on fat wallets; both absent = the full history.
+#[tauri::command]
+pub fn btcx_wallet_transactions(
+    limit: Option<usize>,
+    offset: Option<usize>,
+    state: State<'_, SharedBtcxWalletState>,
+) -> Result<BtcxWalletTxPage, String> {
+    wallet_transactions_impl(&state, limit, offset)
 }
 
 /// A send request. Exactly one of `amount_sat` / `send_all` must be given.

--- a/web-wallet/src-tauri/tests/btcx_wallet_regtest.rs
+++ b/web-wallet/src-tauri/tests/btcx_wallet_regtest.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use phoenix_pocx_lib::btcx_wallet::commands::{
     create_wallet_impl, current_address_of, import_descriptor_wallet_impl, rename_wallet_impl,
-    restore_wallet_impl, select_wallet_impl, tx_display_address,
+    restore_wallet_impl, select_wallet_impl, tx_display_address, wallet_transactions_impl,
 };
 use phoenix_pocx_lib::btcx_wallet::config::{DescriptorKindCfg, DescriptorPolicy, WalletNetwork};
 use phoenix_pocx_lib::btcx_wallet::manager::{
@@ -933,6 +933,144 @@ fn regtest_chain_only_broadcast() {
     mine_block(&dest);
     rpc(None, "setmocktime", serde_json::json!([0]));
     println!("chain-only Electrum broadcast smoke: OK ({txid})");
+}
+
+/// Fat-wallet pagination (feedback round 8), live: a wallet accumulates
+/// ~30 history entries (one funding + 29 small sends back to the miner,
+/// mined in batches), then `wallet_transactions_impl` — the seam behind
+/// `btcx_wallet_transactions` — must slice it correctly: absent args = the
+/// full feed (old behavior), `limit: 0` = a cheap count-only query, pages
+/// of 10 concatenate txid-for-txid to the full feed, a tail slice past the
+/// end truncates, and an offset beyond the end is empty — with `total`
+/// carrying the full size on every shape.
+#[test]
+#[ignore = "needs a running regtest bitcoind (127.0.0.1:18443) + electrs (127.0.0.1:60401)"]
+fn regtest_transactions_limit_offset_pagination() {
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("PHOENIX_DATA_DIR", dir.path());
+    // Never touch the developer's real OS keychain from a test.
+    std::env::set_var("PACT_DISABLE_KEYRING", "1");
+
+    let state = phoenix_pocx_lib::btcx_wallet::create_btcx_wallet_state();
+    state
+        .update_config(|c| {
+            c.network = WalletNetwork::Regtest;
+            c.set_servers(WalletNetwork::Regtest, vec![ELECTRUM_URL.to_string()]);
+        })
+        .unwrap();
+
+    // A FRESH mnemonic every run — the shared regtest chain must not leak
+    // history from earlier runs.
+    let seed_dir = tempfile::tempdir().unwrap();
+    let mut scratch = seedstore::SeedStore::open(seed_dir.path(), None).unwrap();
+    let mnemonic = scratch.create_seed(None, 24).unwrap();
+
+    // 1. Create + fund "fat" once (entry #1: received).
+    let status = create_wallet_impl(&state, None, &mnemonic, None, Some("fat".into()), None)
+        .expect("create fat");
+    assert_eq!(status.wallet_name, "fat");
+    let addr = state.backend().unwrap().wallet_new_address().unwrap();
+    fund_and_mine(&addr, 1.0);
+    wait_for_balance(&state, 100_000_000, "fat after funding");
+
+    // 2. 29 small sends back to the miner (entries #2..#30). BDK chains
+    //    the unconfirmed change, so sends batch between blocks; a block
+    //    every 5 keeps the mempool ancestor chains comfortably short.
+    let wallets = rpc(None, "listwallets", serde_json::json!([]));
+    let wallet_name = wallets[0]
+        .as_str()
+        .expect("a loaded miner wallet on the regtest node")
+        .to_string();
+    let miner_addr = rpc(Some(&wallet_name), "getnewaddress", serde_json::json!([]))
+        .as_str()
+        .unwrap()
+        .to_string();
+    const SENDS: usize = 29;
+    for i in 0..SENDS {
+        let txid = state
+            .backend()
+            .unwrap()
+            .wallet_send(
+                &miner_addr,
+                100_000,
+                electrum_btcx::SendFee::RatePerKvb(2000),
+            )
+            .unwrap_or_else(|e| panic!("send #{}: {e:#}", i + 1));
+        assert_eq!(txid.len(), 64);
+        if (i + 1) % 5 == 0 {
+            mine_block(&miner_addr);
+        }
+    }
+    mine_block(&miner_addr);
+
+    // Wait until the whole history is confirmed and visible.
+    let total_expected = SENDS + 1;
+    let mut confirmed = 0usize;
+    for _ in 0..60 {
+        state.poke().unwrap();
+        std::thread::sleep(Duration::from_secs(1));
+        let acts = state.backend().unwrap().wallet_transactions().unwrap();
+        confirmed = acts.iter().filter(|t| t.confirmations > 0).count();
+        if acts.len() == total_expected && confirmed == total_expected {
+            break;
+        }
+    }
+    assert_eq!(
+        confirmed, total_expected,
+        "all {total_expected} history entries must confirm"
+    );
+
+    // 3. Absent limit/offset = the full feed (the pre-round-8 behavior).
+    let full = wallet_transactions_impl(&state, None, None).expect("full feed");
+    assert_eq!(full.total, total_expected);
+    assert_eq!(full.items.len(), total_expected);
+    // Newest first: the sorted feed ends with the one funding receive.
+    assert_eq!(full.items.last().unwrap().info.direction, "received");
+    assert_eq!(full.items.last().unwrap().info.amount_sat, 100_000_000);
+    assert!(
+        full.items
+            .iter()
+            .take(SENDS)
+            .all(|t| t.info.direction == "sent" && t.info.amount_sat == 100_000),
+        "the 29 sends precede the funding receive"
+    );
+
+    // 4. limit 0 = count-only: total without items (the txCount query).
+    let count = wallet_transactions_impl(&state, Some(0), None).expect("count-only");
+    assert_eq!(count.total, total_expected);
+    assert!(count.items.is_empty());
+
+    // 5. Pages of 10 concatenate txid-for-txid to the full feed.
+    let mut paged = Vec::new();
+    for page in 0..3 {
+        let p = wallet_transactions_impl(&state, Some(10), Some(page * 10)).expect("page");
+        assert_eq!(p.total, total_expected);
+        assert_eq!(p.items.len(), 10, "page {page} is full");
+        paged.extend(p.items);
+    }
+    let full_txids: Vec<&str> = full.items.iter().map(|t| t.info.txid.as_str()).collect();
+    let paged_txids: Vec<&str> = paged.iter().map(|t| t.info.txid.as_str()).collect();
+    assert_eq!(paged_txids, full_txids, "pages must tile the full feed");
+
+    // 6. A tail slice truncates; an offset beyond the end is empty.
+    let tail = wallet_transactions_impl(&state, Some(10), Some(25)).expect("tail");
+    assert_eq!(tail.total, total_expected);
+    assert_eq!(tail.items.len(), 5);
+    assert_eq!(tail.items[0].info.txid, full.items[25].info.txid);
+    let beyond =
+        wallet_transactions_impl(&state, Some(10), Some(total_expected)).expect("beyond the end");
+    assert_eq!(beyond.total, total_expected);
+    assert!(beyond.items.is_empty());
+
+    // Leave the node's clock alone for whoever runs next.
+    rpc(None, "setmocktime", serde_json::json!([0]));
+    state.close_runtime();
+    std::env::remove_var("PHOENIX_DATA_DIR");
+    std::env::remove_var("PACT_DISABLE_KEYRING");
+    println!(
+        "fat-wallet pagination smoke: OK ({total_expected} entries, 3 pages of 10 tiled, \
+         count-only + tail + beyond-end verified)"
+    );
 }
 
 /// The wallet rename flow (feedback round 6), live: a funded named wallet

--- a/web-wallet/src/app/core/backend/electrum-wallet-backend.ts
+++ b/web-wallet/src/app/core/backend/electrum-wallet-backend.ts
@@ -84,8 +84,9 @@ export class ElectrumWalletBackend implements WalletBackend {
   }
 
   async getWalletDetails(): Promise<WalletBackendDetails> {
-    const txs = await this.btcxWallet.refreshTransactions();
-    return { txCount: txs.length, watchOnly: false };
+    // limit 0 = count-only: total without items, DTO mapping or IPC bulk.
+    const { total } = await this.btcxWallet.fetchTransactionsPage(0);
+    return { txCount: total, watchOnly: false };
   }
 
   async listTransactions(
@@ -93,9 +94,11 @@ export class ElectrumWalletBackend implements WalletBackend {
     count: number,
     skip = 0
   ): Promise<WalletTransaction[]> {
-    // The full history is a local sqlite read — paginate client-side.
-    const txs = await this.btcxWallet.refreshTransactions();
-    return txs.slice(skip, skip + count).map(mapBtcxTxToWalletTransaction);
+    // Page on the Rust side; only the requested slice crosses the IPC
+    // boundary (and fetchTransactionsPage leaves the mobile UI's window
+    // signals alone).
+    const { items } = await this.btcxWallet.fetchTransactionsPage(count, skip);
+    return items.map(mapBtcxTxToWalletTransaction);
   }
 
   async getNewAddress(): Promise<string> {

--- a/web-wallet/src/app/core/services/btcx-wallet.service.ts
+++ b/web-wallet/src/app/core/services/btcx-wallet.service.ts
@@ -73,6 +73,13 @@ export interface BtcxWalletTxDto {
   address?: string;
 }
 
+/** Wire shape of one `btcx_wallet_transactions` page (items + total). */
+export interface BtcxWalletTxPageDto {
+  items: BtcxWalletTxDto[];
+  /** History size BEFORE the limit/offset slice (the paginator length). */
+  total: number;
+}
+
 /** A wallet transaction, mapped to camelCase for the UI. */
 export interface BtcxWalletTx {
   txid: string;
@@ -344,6 +351,14 @@ export interface BtcxUtxo {
 export const BTCX_COIN_TYPE = 0x504f4358;
 
 /**
+ * Default transaction window: the home page's recent-list maximum (its
+ * FitRowsDirective caps at 10 rows). The service never fetches more than
+ * the last consumer asked for, so a fat wallet's history stays on the Rust
+ * side until the transactions page pages through it.
+ */
+export const RECENT_TX_LIMIT = 10;
+
+/**
  * Map one snake_case transaction DTO from `btcx_wallet_transactions` to the
  * camelCase shape the UI uses. Exported for unit testing.
  */
@@ -370,6 +385,13 @@ export class BtcxWalletService {
   private readonly _status = signal<BtcxWalletStatus | null>(null);
   private readonly _balance = signal<BtcxBalance | null>(null);
   private readonly _transactions = signal<BtcxWalletTx[]>([]);
+  private readonly _transactionsTotal = signal(0);
+  /**
+   * The window the `transactions` signal currently holds — re-requested
+   * verbatim on every sync tick / refreshAll, so background refreshes stay
+   * as small as whatever the visible page last asked for.
+   */
+  private _txWindow: { limit?: number; offset?: number } = { limit: RECENT_TX_LIMIT };
   private readonly _config = signal<BtcxWalletConfig | null>(null);
   private readonly _wallets = signal<BtcxWalletSummary[]>([]);
   private readonly _lastSync = signal<BtcxSyncEvent | null>(null);
@@ -387,7 +409,10 @@ export class BtcxWalletService {
   // Public readonly signals
   readonly status = this._status.asReadonly();
   readonly balance = this._balance.asReadonly();
+  /** The last requested transaction WINDOW (see refreshTransactions). */
   readonly transactions = this._transactions.asReadonly();
+  /** Full history size behind the window (the paginator's length). */
+  readonly transactionsTotal = this._transactionsTotal.asReadonly();
   readonly config = this._config.asReadonly();
   /** Registered wallets of the active network (refreshWallets snapshot). */
   readonly wallets = this._wallets.asReadonly();
@@ -461,7 +486,7 @@ export class BtcxWalletService {
       await this.setupEventListeners();
       await Promise.all([this.refreshStatus(), this.refreshConfig()]);
       if (this.walletActive()) {
-        await Promise.all([this.refreshBalance(), this.refreshTransactions()]);
+        await Promise.all([this.refreshBalance(), this.refreshTransactions(RECENT_TX_LIMIT)]);
       }
       this._initialized.set(true);
     } catch (err) {
@@ -482,10 +507,11 @@ export class BtcxWalletService {
 
     const syncUnlisten = await listen<BtcxSyncEvent>('btcx-wallet:sync', event => {
       this._lastSync.set(event.payload);
-      // Keep the cheap cached views fresh on every sync/height change
+      // Keep the cheap cached views fresh on every sync/height change —
+      // re-requesting only the WINDOW the UI currently shows.
       void this.refreshStatus();
       void this.refreshBalance();
-      void this.refreshTransactions();
+      void this.refreshTransactions(this._txWindow.limit, this._txWindow.offset);
     });
     this._eventUnlisteners.push(syncUnlisten);
   }
@@ -637,7 +663,7 @@ export class BtcxWalletService {
       const status = await invoke<BtcxWalletStatus>('btcx_wallet_lock');
       this._status.set(status);
       this._balance.set(null);
-      this._transactions.set([]);
+      this.resetTransactionWindow();
       this._lastSync.set(null);
       return status;
     } catch (err) {
@@ -680,7 +706,7 @@ export class BtcxWalletService {
     const status = await invoke<BtcxWalletStatus>('btcx_wallet_select', { name });
     this._status.set(status);
     this._balance.set(null);
-    this._transactions.set([]);
+    this.resetTransactionWindow();
     // The previous runtime's sync events no longer describe this wallet.
     this._lastSync.set(null);
     await this.refreshConfig();
@@ -696,11 +722,18 @@ export class BtcxWalletService {
     const status = await invoke<BtcxWalletStatus>('btcx_wallet_close');
     this._status.set(status);
     this._balance.set(null);
-    this._transactions.set([]);
+    this.resetTransactionWindow();
     // The closed runtime's sync events are stale — the toolbar falls back
     // to the passive per-server health snapshots.
     this._lastSync.set(null);
     return status;
+  }
+
+  /** Empty the transaction signals and fall back to the default window. */
+  private resetTransactionWindow(): void {
+    this._transactions.set([]);
+    this._transactionsTotal.set(0);
+    this._txWindow = { limit: RECENT_TX_LIMIT };
   }
 
   /**
@@ -757,13 +790,39 @@ export class BtcxWalletService {
     }
   }
 
-  /** Refresh the transaction history (newest first), mapping the snake_case DTO. */
-  async refreshTransactions(): Promise<BtcxWalletTx[]> {
+  /**
+   * Fetch one WINDOW of the transaction history (newest first) WITHOUT
+   * touching the signals — the backend-router seam (desktop remote mode)
+   * pages through here so it never clobbers the mobile UI's window.
+   * `limit: 0` is a cheap count-only query (no items, no per-item work).
+   * Both absent = the full history. Throws on failure.
+   */
+  async fetchTransactionsPage(
+    limit?: number,
+    offset?: number
+  ): Promise<{ items: BtcxWalletTx[]; total: number }> {
+    const page = await invoke<BtcxWalletTxPageDto>('btcx_wallet_transactions', {
+      limit: limit ?? null,
+      offset: offset ?? null,
+    });
+    return { items: page.items.map(mapWalletTx), total: page.total };
+  }
+
+  /**
+   * Refresh the `transactions` signal with one WINDOW of the history
+   * (newest first) and remember the window: every background refresh
+   * (sync tick, refreshAll after a send) re-requests the same small slice,
+   * so nothing ever pulls a fat wallet's full history over IPC. The home
+   * page asks for its recent-list maximum, the transactions page for its
+   * fit-sized paginator page; `transactionsTotal` carries the full size.
+   */
+  async refreshTransactions(limit?: number, offset?: number): Promise<BtcxWalletTx[]> {
+    this._txWindow = { limit, offset };
     try {
-      const txs = await invoke<BtcxWalletTxDto[]>('btcx_wallet_transactions');
-      const mapped = txs.map(mapWalletTx);
-      this._transactions.set(mapped);
-      return mapped;
+      const { items, total } = await this.fetchTransactionsPage(limit, offset);
+      this._transactions.set(items);
+      this._transactionsTotal.set(total);
+      return items;
     } catch (err) {
       console.error('Failed to get btcx wallet transactions:', err);
       return [];
@@ -999,11 +1058,17 @@ export class BtcxWalletService {
   // Helpers
   // ============================================================================
 
-  /** Refresh balance + transactions when the wallet is open (no-ops otherwise). */
+  /**
+   * Refresh balance + the current transaction window when the wallet is
+   * open (no-ops otherwise) — never more than the UI's visible slice.
+   */
   private async refreshAll(): Promise<void> {
     await this.refreshStatus();
     if (this.walletActive()) {
-      await Promise.all([this.refreshBalance(), this.refreshTransactions()]);
+      await Promise.all([
+        this.refreshBalance(),
+        this.refreshTransactions(this._txWindow.limit, this._txWindow.offset),
+      ]);
     }
   }
 

--- a/web-wallet/src/app/features/mobile-wallet/components/wallet-name-section/wallet-name-section.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/components/wallet-name-section/wallet-name-section.component.ts
@@ -1,0 +1,112 @@
+import { Component, computed, input, model } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { I18nPipe } from '../../../../core/i18n';
+import { isInvalidWalletName, isWalletNameTaken } from '../../wallet-name';
+
+/**
+ * WalletNameSectionComponent - the "name your wallet" section shared by the
+ * three acquisition flows (create / restore / import-descriptor).
+ *
+ * Owner rule (feedback round 8): naming comes FIRST — a separate first step
+ * on the stepped create flow, the first thing on the all-in-one restore and
+ * import pages — so one component keeps the three visually identical.
+ *
+ * Renders the badge heading, the pre-fill explanation, and the outlined
+ * name field with the desktop naming rules mirrored live
+ * (`isWalletNameTaken` / `isInvalidWalletName` against `existingNames`).
+ * The field's subscript is `subscriptSizing="dynamic"`: hints and errors
+ * that wrap in longer locales grow the field instead of overflowing the
+ * fixed one-line subscript box onto whatever follows (the import page's
+ * overlay bug).
+ *
+ * API:
+ * - `name`          - two-way bound wallet name (`[(name)]`); parents keep
+ *                     pre-filling it with `suggestWalletName(...)`
+ * - `existingNames` - registry names for the case-insensitive conflict check
+ * - `disabled`      - freeze the field while the flow commits
+ * - `conflict` / `invalid` / `hasError` - live verdicts for the parents'
+ *   button gating (template ref: `#nameSection`) and submit guards
+ */
+@Component({
+  selector: 'app-mwallet-name-section',
+  standalone: true,
+  imports: [FormsModule, MatFormFieldModule, MatIconModule, MatInputModule, I18nPipe],
+  template: `
+    <h3 class="name-heading">
+      <mat-icon class="name-icon">badge</mat-icon>
+      {{ 'wallet_name' | i18n }}
+    </h3>
+    <p class="hint-text">{{ 'mwallet_name_hint' | i18n }}</p>
+    <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
+      <mat-label>{{ 'wallet_name' | i18n }}</mat-label>
+      <input
+        matInput
+        [ngModel]="name()"
+        (ngModelChange)="name.set($event)"
+        [disabled]="disabled()"
+        autocomplete="off"
+        autocapitalize="none"
+        spellcheck="false"
+      />
+      @if (conflict()) {
+        <mat-error>{{ 'wallet_name_conflict' | i18n }}</mat-error>
+      } @else if (invalid()) {
+        <mat-error>{{ 'wallet_name_invalid_local' | i18n }}</mat-error>
+      } @else {
+        <mat-hint>{{ 'wallet_name_hint_local' | i18n }}</mat-hint>
+      }
+    </mat-form-field>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .name-heading {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin: 0 0 4px;
+        font-size: 15px;
+        font-weight: 500;
+
+        .name-icon {
+          font-size: 18px;
+          width: 18px;
+          height: 18px;
+          color: #1976d2;
+        }
+      }
+
+      .hint-text {
+        color: rgba(0, 0, 0, 0.6);
+        font-size: 12px;
+        margin: 0 0 12px;
+      }
+
+      .full-width {
+        width: 100%;
+      }
+
+      :host-context(.dark-theme) .hint-text {
+        color: rgba(255, 255, 255, 0.6);
+      }
+    `,
+  ],
+})
+export class WalletNameSectionComponent {
+  /** The wallet name, two-way bound; parents pre-fill the suggestion. */
+  readonly name = model('');
+  /** Registry names for suggestion + case-insensitive conflict checks. */
+  readonly existingNames = input<string[]>([]);
+  readonly disabled = input(false);
+
+  /** Mirror the Rust-side naming rules before the commit (desktop parity). */
+  readonly conflict = computed(() => isWalletNameTaken(this.name(), this.existingNames()));
+  readonly invalid = computed(() => isInvalidWalletName(this.name()));
+  readonly hasError = computed(() => this.conflict() || this.invalid());
+}

--- a/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed, OnInit } from '@angular/core';
+import { Component, inject, signal, computed, viewChild, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -13,18 +13,21 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
 import { sanitizeReturnTo } from '../../return-to';
 import { isInvalidWalletName, isWalletNameTaken, suggestWalletName } from '../../wallet-name';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
+import { WalletNameSectionComponent } from '../../components/wallet-name-section/wallet-name-section.component';
 
-type CreateStep = 'phrase' | 'verify' | 'protect';
+type CreateStep = 'name' | 'phrase' | 'verify' | 'protect';
 
 /**
  * WalletCreateComponent - create-wallet onboarding flow.
  *
- * 1. phrase:  generate + display the 24 words with a write-it-down gate
- * 2. verify:  confirm a few words from the written backup
- * 3. protect: wallet name (pre-filled with the next free default, desktop
- *             naming rules), optional at-rest passphrase, and a collapsed
- *             ADVANCED address-type choice (BIP-84 segwit default /
- *             BIP-86 taproot), then create
+ * 1. name:    wallet name as its own FIRST step (owner rule, round 8) —
+ *             pre-filled with the next free default, desktop naming rules
+ *             (the shared WalletNameSectionComponent)
+ * 2. phrase:  generate + display the 24 words with a write-it-down gate
+ * 3. verify:  confirm a few words from the written backup
+ * 4. protect: optional at-rest passphrase and a collapsed ADVANCED
+ *             address-type choice (BIP-84 segwit default / BIP-86
+ *             taproot), then create
  *
  * No skippable-backup shortcuts: the acknowledge checkbox and the word
  * check are both required before the seed is committed.
@@ -47,12 +50,33 @@ type CreateStep = 'phrase' | 'verify' | 'protect';
     MatRadioModule,
     I18nPipe,
     PageHeaderComponent,
+    WalletNameSectionComponent,
   ],
   template: `
     <app-mwallet-page-header titleKey="mwallet_create_wallet" />
 
     <div class="page">
-      @if (step() === 'phrase') {
+      @if (step() === 'name') {
+        <div class="card">
+          <!-- Wallet name — its own FIRST step so the pre-filled default is
+               a conscious choice, not something to overlook. -->
+          <app-mwallet-name-section
+            #nameSection
+            [(name)]="walletName"
+            [existingNames]="existingNames()"
+          />
+
+          <button
+            mat-raised-button
+            color="primary"
+            class="full-width step-button"
+            [disabled]="nameSection.hasError()"
+            (click)="step.set('phrase')"
+          >
+            {{ 'next' | i18n }}
+          </button>
+        </div>
+      } @else if (step() === 'phrase') {
         <div class="card">
           <h3>{{ 'mwallet_backup_title' | i18n }}</h3>
           <p class="warning-text">
@@ -79,15 +103,19 @@ type CreateStep = 'phrase' | 'verify' | 'protect';
             {{ 'mwallet_backup_ack' | i18n }}
           </mat-checkbox>
 
-          <button
-            mat-raised-button
-            color="primary"
-            class="full-width step-button"
-            [disabled]="!acknowledged || words().length === 0"
-            (click)="startVerify()"
-          >
-            {{ 'next' | i18n }}
-          </button>
+          <div class="button-row step-button">
+            <button mat-stroked-button (click)="step.set('name')">
+              {{ 'back' | i18n }}
+            </button>
+            <button
+              mat-raised-button
+              color="primary"
+              [disabled]="!acknowledged || words().length === 0"
+              (click)="startVerify()"
+            >
+              {{ 'next' | i18n }}
+            </button>
+          </div>
         </div>
       } @else if (step() === 'verify') {
         <div class="card">
@@ -127,32 +155,6 @@ type CreateStep = 'phrase' | 'verify' | 'protect';
         </div>
       } @else {
         <div class="card">
-          <!-- Wallet name — its own labeled section so the pre-filled
-               default is a conscious choice, not something to overlook. -->
-          <h3 class="name-heading">
-            <mat-icon class="name-icon">badge</mat-icon>
-            {{ 'wallet_name' | i18n }}
-          </h3>
-          <p class="hint-text">{{ 'mwallet_name_hint' | i18n }}</p>
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'wallet_name' | i18n }}</mat-label>
-            <input
-              matInput
-              [(ngModel)]="walletName"
-              (ngModelChange)="onWalletNameChange()"
-              autocomplete="off"
-              autocapitalize="none"
-              spellcheck="false"
-            />
-            @if (walletNameConflict()) {
-              <mat-error>{{ 'wallet_name_conflict' | i18n }}</mat-error>
-            } @else if (walletNameInvalid()) {
-              <mat-error>{{ 'wallet_name_invalid_local' | i18n }}</mat-error>
-            } @else {
-              <mat-hint>{{ 'wallet_name_hint_local' | i18n }}</mat-hint>
-            }
-          </mat-form-field>
-
           <h3>{{ 'mwallet_passphrase_title' | i18n }}</h3>
           <p class="hint-text">{{ 'mwallet_passphrase_hint' | i18n }}</p>
 
@@ -251,19 +253,6 @@ type CreateStep = 'phrase' | 'verify' | 'protect';
         &.small {
           font-size: 12px;
           margin: 0 0 8px;
-        }
-      }
-
-      .name-heading {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-
-        .name-icon {
-          font-size: 18px;
-          width: 18px;
-          height: 18px;
-          color: #1976d2;
         }
       }
 
@@ -422,7 +411,7 @@ export class WalletCreateComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
 
-  readonly step = signal<CreateStep>('phrase');
+  readonly step = signal<CreateStep>('name');
   readonly words = signal<string[]>([]);
   readonly checks = signal<{ index: number; entered: string }[]>([]);
   readonly verifyError = signal(false);
@@ -435,8 +424,8 @@ export class WalletCreateComponent implements OnInit {
 
   /** Wallet name — pre-filled with the next free default; desktop rules. */
   walletName = '';
-  readonly walletNameConflict = signal(false);
-  readonly walletNameInvalid = signal(false);
+  /** The shared name section (rendered on the 'name' step only). */
+  private readonly nameSection = viewChild(WalletNameSectionComponent);
 
   /** Advanced section (collapsed): descriptor family for the new wallet. */
   readonly showAdvanced = signal(false);
@@ -444,7 +433,7 @@ export class WalletCreateComponent implements OnInit {
 
   private mnemonic = '';
   /** Registry names for suggestion + case-insensitive conflict checks. */
-  private existingNames: string[] = [];
+  readonly existingNames = signal<string[]>([]);
 
   readonly allChecksFilled = computed(() => this.checks().every(c => c.entered.trim().length > 0));
 
@@ -455,9 +444,9 @@ export class WalletCreateComponent implements OnInit {
   private async generate(): Promise<void> {
     try {
       await this.wallet.initialize();
-      this.existingNames = (await this.wallet.refreshWallets()).map(w => w.name);
+      this.existingNames.set((await this.wallet.refreshWallets()).map(w => w.name));
       if (!this.walletName) {
-        this.walletName = suggestWalletName(this.existingNames);
+        this.walletName = suggestWalletName(this.existingNames());
       }
       this.mnemonic = await this.wallet.generateMnemonic();
       this.words.set(this.mnemonic.split(' '));
@@ -465,12 +454,6 @@ export class WalletCreateComponent implements OnInit {
       console.error('Failed to generate mnemonic:', err);
       this.createError.set(`${err}`);
     }
-  }
-
-  /** Mirror the Rust-side naming rules before the commit (desktop parity). */
-  onWalletNameChange(): void {
-    this.walletNameConflict.set(isWalletNameTaken(this.walletName, this.existingNames));
-    this.walletNameInvalid.set(isInvalidWalletName(this.walletName));
   }
 
   startVerify(): void {
@@ -496,7 +479,16 @@ export class WalletCreateComponent implements OnInit {
   }
 
   canCreate(): boolean {
-    if (this.walletNameConflict() || this.walletNameInvalid()) return false;
+    // The name step gated conflicts/invalid names already; re-check with
+    // the same rules in case the registry moved (the section may be
+    // off-screen by now, so don't rely on its viewChild).
+    if (
+      this.nameSection()?.hasError() ||
+      isWalletNameTaken(this.walletName, this.existingNames()) ||
+      isInvalidWalletName(this.walletName)
+    ) {
+      return false;
+    }
     if (!this.passphrase) return true;
     return this.passphrase === this.passphraseConfirm;
   }
@@ -507,7 +499,7 @@ export class WalletCreateComponent implements OnInit {
     this.createError.set(null);
     try {
       // An emptied name field falls back to the suggested default.
-      const name = this.walletName.trim() || suggestWalletName(this.existingNames);
+      const name = this.walletName.trim() || suggestWalletName(this.existingNames());
       await this.wallet.create(this.mnemonic, this.passphrase || undefined, name, this.kind);
       this.mnemonic = '';
       this.words.set([]);

--- a/web-wallet/src/app/features/mobile-wallet/pages/history/wallet-history.component.spec.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/history/wallet-history.component.spec.ts
@@ -9,21 +9,37 @@ function stubTx(i: number): BtcxWalletTx {
   return { txid: `tx${i}` } as BtcxWalletTx;
 }
 
-describe('WalletHistoryComponent (fit-derived pagination)', () => {
+describe('WalletHistoryComponent (fit-derived server-side pagination)', () => {
   let component: WalletHistoryComponent;
+  let history: BtcxWalletTx[];
   let transactions: ReturnType<typeof signal<BtcxWalletTx[]>>;
+  let transactionsTotal: ReturnType<typeof signal<number>>;
+  /** The windows the component requested, newest last. */
+  let requests: { limit?: number; offset?: number }[];
 
-  beforeEach(() => {
-    transactions = signal(Array.from({ length: 40 }, (_, i) => stubTx(i)));
+  beforeEach(async () => {
+    history = Array.from({ length: 40 }, (_, i) => stubTx(i));
+    transactions = signal<BtcxWalletTx[]>([]);
+    transactionsTotal = signal(0);
+    requests = [];
     TestBed.configureTestingModule({
       providers: [
         {
           provide: BtcxWalletService,
           useValue: {
             transactions,
+            transactionsTotal,
             walletActive: signal(true),
             initialize: () => Promise.resolve(),
-            refreshTransactions: () => Promise.resolve(),
+            // Emulate the Rust-side window: slice + total.
+            refreshTransactions: (limit?: number, offset?: number) => {
+              requests.push({ limit, offset });
+              const start = offset ?? 0;
+              const items = history.slice(start, limit === undefined ? undefined : start + limit);
+              transactions.set(items);
+              transactionsTotal.set(history.length);
+              return Promise.resolve(items);
+            },
             syncNow: () => Promise.resolve(),
           },
         },
@@ -32,27 +48,41 @@ describe('WalletHistoryComponent (fit-derived pagination)', () => {
       ],
     });
     component = TestBed.runInInjectionContext(() => new WalletHistoryComponent());
+    component.ngOnInit();
+    await Promise.resolve(); // initialize()
+    await Promise.resolve(); // loadPage's first fetch
   });
 
-  it('adopts the measured fit as the page size', () => {
+  it('adopts the measured fit as the page size and fetches that window', async () => {
     component.onFitRows(7);
+    await Promise.resolve();
     expect(component.pageSize()).toBe(7);
+    expect(requests[requests.length - 1]).toEqual({ limit: 7, offset: 0 });
     expect(component.visibleTransactions().length).toBe(7);
   });
 
-  it('keeps the page containing the previously first visible tx on fit change', () => {
+  it('keeps the page containing the previously first visible tx on fit change', async () => {
     component.onFitRows(8);
     component.onPageChange({ pageIndex: 4, pageSize: 8, length: 40 });
+    await Promise.resolve();
     // First visible tx is index 32.
     component.onFitRows(5);
+    await Promise.resolve();
     expect(component.pageIndex()).toBe(6); // floor(32 / 5): page 6 spans 30..34
+    expect(requests[requests.length - 1]).toEqual({ limit: 5, offset: 30 });
     expect(component.visibleTransactions()[0].txid).toBe('tx30');
   });
 
-  it('clamps the page when a refresh shrinks the list below the current page', () => {
+  it('clamps to the last page when a refresh shrinks the list below the current page', async () => {
     component.onFitRows(8);
     component.onPageChange({ pageIndex: 4, pageSize: 8, length: 40 });
-    transactions.set(Array.from({ length: 10 }, (_, i) => stubTx(i)));
-    expect(component.visibleTransactions()[0].txid).toBe('tx8'); // last page (1)
+    await Promise.resolve();
+    history = Array.from({ length: 10 }, (_, i) => stubTx(i));
+    await component.refresh();
+    // Page 4 no longer exists (10 txs / size 8 → last page 1); the reload
+    // must land on the last page that still exists.
+    expect(component.pageIndex()).toBe(1);
+    expect(requests[requests.length - 1]).toEqual({ limit: 8, offset: 8 });
+    expect(component.visibleTransactions()[0].txid).toBe('tx8');
   });
 });

--- a/web-wallet/src/app/features/mobile-wallet/pages/history/wallet-history.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/history/wallet-history.component.ts
@@ -15,16 +15,22 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
  *
  * Rows are the shared mobile TxRowComponent (same row the home preview
  * renders, including the per-row menu). Pagination mirrors the desktop
- * transaction-list's mat-paginator (first/last buttons over a client-side
- * slice), but the page size is not chosen from a dropdown: the list card
- * flex-fills the viewport and the shared FitRowsDirective (the home page's
- * recent-list fill, round 6) derives how many rows fit without scrolling —
- * that fit IS the page size, recomputed on resize/rotation. When the fit
- * changes, the pager stays on the page containing the previously first
- * visible transaction. Refresh pokes the background sync worker (sync_now)
- * and re-reads the cached history. Tapping an item expands a simple
- * detail: txid with copy, address, fee, vsize (the list scrolls the
- * few overflowing pixels while a detail is open).
+ * transaction-list's mat-paginator (first/last buttons), but the page size
+ * is not chosen from a dropdown: the list card flex-fills the viewport and
+ * the shared FitRowsDirective (the home page's recent-list fill, round 6)
+ * derives how many rows fit without scrolling — that fit IS the page size,
+ * recomputed on resize/rotation. When the fit changes, the pager stays on
+ * the page containing the previously first visible transaction.
+ *
+ * Fat-wallet rule (round 8): each page is fetched from the backend with
+ * `refreshTransactions(pageSize, offset)` — only the visible slice ever
+ * crosses IPC, the paginator length comes from `transactionsTotal`, and
+ * sync ticks re-request the same current page through the service's
+ * remembered window. Refresh pokes the background sync worker (sync_now)
+ * and re-reads the current page. Tapping an item expands a simple detail:
+ * txid with copy, address, fee, vsize (the list scrolls the few
+ * overflowing pixels while a detail is open) — all from data already in
+ * the row.
  */
 @Component({
   selector: 'app-wallet-history',
@@ -53,7 +59,7 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
 
     <div class="page">
       <div class="card list-card">
-        @if (wallet.transactions().length === 0) {
+        @if (wallet.transactionsTotal() === 0) {
           <div class="empty-state">
             <mat-icon>receipt_long</mat-icon>
             <span>{{ 'no_transactions' | i18n }}</span>
@@ -113,7 +119,7 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
           <!-- Desktop transaction-list pagination; the page size is the
                measured fit, so there is no size dropdown. -->
           <mat-paginator
-            [length]="wallet.transactions().length"
+            [length]="wallet.transactionsTotal()"
             [pageSize]="pageSize()"
             [pageIndex]="pageIndex()"
             [hidePageSize]="true"
@@ -324,14 +330,15 @@ export class WalletHistoryComponent implements OnInit {
   readonly pageSize = signal(8);
   readonly pageIndex = signal(0);
 
-  readonly visibleTransactions = computed(() => {
-    const txs = this.wallet.transactions();
-    // Clamp: a refresh can shrink the list below the current page.
-    const lastPage = Math.max(0, Math.ceil(txs.length / this.pageSize()) - 1);
-    const page = Math.min(this.pageIndex(), lastPage);
-    const start = page * this.pageSize();
-    return txs.slice(start, start + this.pageSize());
-  });
+  /**
+   * The service's transaction window IS the current page (the history
+   * fetches per page — only the visible slice crosses IPC). The defensive
+   * slice covers the transient where another page's window (e.g. the
+   * home's recent list) is still in the signal.
+   */
+  readonly visibleTransactions = computed(() =>
+    this.wallet.transactions().slice(0, this.pageSize())
+  );
 
   ngOnInit(): void {
     // Fresh contacts book for the row menu's "add to contact" visibility.
@@ -342,8 +349,25 @@ export class WalletHistoryComponent implements OnInit {
   private async init(): Promise<void> {
     await this.wallet.initialize();
     if (this.wallet.walletActive()) {
-      await this.wallet.refreshTransactions();
+      await this.loadPage(this.pageIndex());
     }
+  }
+
+  /**
+   * Fetch one fit-sized page from the backend and clamp: a refresh can
+   * shrink the history below the requested page — then re-request the
+   * last page that still exists. The service remembers the window, so
+   * sync ticks keep this page fresh without another explicit fetch.
+   */
+  private async loadPage(index: number): Promise<void> {
+    const size = this.pageSize();
+    await this.wallet.refreshTransactions(size, index * size);
+    const lastPage = Math.max(0, Math.ceil(this.wallet.transactionsTotal() / size) - 1);
+    if (index > lastPage) {
+      index = lastPage;
+      await this.wallet.refreshTransactions(size, index * size);
+    }
+    this.pageIndex.set(index);
   }
 
   async refresh(): Promise<void> {
@@ -351,7 +375,7 @@ export class WalletHistoryComponent implements OnInit {
     this.refreshing.set(true);
     try {
       await this.wallet.syncNow();
-      await this.wallet.refreshTransactions();
+      await this.loadPage(this.pageIndex());
     } finally {
       this.refreshing.set(false);
     }
@@ -368,11 +392,11 @@ export class WalletHistoryComponent implements OnInit {
     if (fit === oldSize) return;
     const firstVisibleIndex = this.pageIndex() * oldSize;
     this.pageSize.set(fit);
-    this.pageIndex.set(Math.floor(firstVisibleIndex / fit));
+    void this.loadPage(Math.floor(firstVisibleIndex / fit));
   }
 
   onPageChange(event: PageEvent): void {
-    this.pageIndex.set(event.pageIndex);
+    void this.loadPage(event.pageIndex);
     this.expandedTxid.set(null);
   }
 

--- a/web-wallet/src/app/features/mobile-wallet/pages/home/wallet-home.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/home/wallet-home.component.ts
@@ -12,7 +12,11 @@ import { BtcxPipe } from '../../../../shared/pipes';
 import { ContactsStoreService } from '../../../../shared/services';
 import { TxRowComponent } from '../../components/tx-row/tx-row.component';
 import { FitRowsDirective } from '../../fit-rows.directive';
-import { BtcxWalletService, BtcxChainInfo } from '../../../../core/services/btcx-wallet.service';
+import {
+  BtcxWalletService,
+  BtcxChainInfo,
+  RECENT_TX_LIMIT,
+} from '../../../../core/services/btcx-wallet.service';
 import { MiningService } from '../../../../mining/services';
 import {
   BTCX_BLOCK_TIME_SECONDS,
@@ -224,7 +228,7 @@ import {
               class="tx-list"
               appFitRows
               [fitMinRows]="3"
-              [fitMaxRows]="10"
+              [fitMaxRows]="recentTxLimit"
               (fitRows)="visibleTxCount.set($event)"
             >
               @for (tx of recentTransactions(); track tx.txid) {
@@ -563,8 +567,14 @@ export class WalletHomeComponent implements OnInit {
   // so its height never depends on its own rows); the shared
   // FitRowsDirective on the row container derives how many rows fit.
   readonly visibleTxCount = signal(3);
+  /** The fit ceiling — also the window the service fetches (round 8). */
+  readonly recentTxLimit = RECENT_TX_LIMIT;
 
-  /** Recent activity preview — as many newest entries as fit the screen. */
+  /**
+   * Recent activity preview — as many newest entries as fit the screen.
+   * The service's transaction window is already capped at RECENT_TX_LIMIT
+   * (O(visible) on fat wallets); the slice trims it to the measured fit.
+   */
   readonly recentTransactions = computed(() =>
     this.wallet.transactions().slice(0, this.visibleTxCount())
   );
@@ -603,6 +613,12 @@ export class WalletHomeComponent implements OnInit {
     void this.wallet.initialize().then(() => {
       if (this.wallet.hasElectrumServer()) {
         void this.refreshChain();
+      }
+      // Point the service's transaction window back at the recent slice
+      // (a visit to the transactions page moves it to that page's offset);
+      // sync ticks keep re-requesting this same small window.
+      if (this.wallet.walletActive()) {
+        void this.wallet.refreshTransactions(RECENT_TX_LIMIT);
       }
     });
     void this.mining.getState().then(() => this.miningStateLoaded.set(true));

--- a/web-wallet/src/app/features/mobile-wallet/pages/import-descriptor/wallet-import-descriptor.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/import-descriptor/wallet-import-descriptor.component.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../core/services/btcx-wallet.service';
 import { isInvalidWalletName, isWalletNameTaken, suggestWalletName } from '../../wallet-name';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
+import { WalletNameSectionComponent } from '../../components/wallet-name-section/wallet-name-section.component';
 
 /** Error code → translated message key (backend `descriptors::ImportError`). */
 const ERROR_KEYS: Record<BtcxImportErrorCode, string> = {
@@ -45,8 +46,10 @@ const ERROR_KEYS: Record<BtcxImportErrorCode, string> = {
  * (debounced, offline): errors surface a translated message keyed by the
  * structured error code, a valid paste shows its script-type
  * classification (SegWit / Taproot / Legacy — legacy imports work for
- * funds but are gated from mining/assignments, same as taproot). Name
- * field and optional at-rest passphrase mirror the create/restore pages.
+ * funds but are gated from mining/assignments, same as taproot). The
+ * wallet name leads the page (owner rule, round 8: name first — the
+ * shared WalletNameSectionComponent) and the optional at-rest passphrase
+ * mirrors the create/restore pages.
  *
  * Unlike restore there is no branch probe: the descriptors already say
  * which scripts the wallet owns, and the fresh store's first sync
@@ -65,6 +68,7 @@ const ERROR_KEYS: Record<BtcxImportErrorCode, string> = {
     MatProgressSpinnerModule,
     I18nPipe,
     PageHeaderComponent,
+    WalletNameSectionComponent,
   ],
   template: `
     <app-mwallet-page-header titleKey="mwallet_import_wallet" />
@@ -90,6 +94,15 @@ const ERROR_KEYS: Record<BtcxImportErrorCode, string> = {
         </div>
       } @else {
         <div class="card">
+          <!-- Wallet name FIRST (owner rule, round 8) — shared section
+               with the pre-filled default and live desktop naming rules. -->
+          <app-mwallet-name-section
+            #nameSection
+            [(name)]="walletName"
+            [existingNames]="existingNames()"
+            [disabled]="importing()"
+          />
+
           <p class="hint-text">{{ 'mwallet_import_description' | i18n }}</p>
 
           <mat-form-field appearance="outline" class="full-width">
@@ -141,31 +154,6 @@ const ERROR_KEYS: Record<BtcxImportErrorCode, string> = {
             </div>
           }
 
-          <!-- Wallet name — same rules and pre-fill as create/restore. -->
-          <h3 class="name-heading">
-            <mat-icon class="name-icon">badge</mat-icon>
-            {{ 'wallet_name' | i18n }}
-          </h3>
-          <p class="hint-text small">{{ 'mwallet_name_hint' | i18n }}</p>
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'wallet_name' | i18n }}</mat-label>
-            <input
-              matInput
-              [(ngModel)]="walletName"
-              (ngModelChange)="onWalletNameChange()"
-              autocomplete="off"
-              autocapitalize="none"
-              spellcheck="false"
-            />
-            @if (walletNameConflict()) {
-              <mat-error>{{ 'wallet_name_conflict' | i18n }}</mat-error>
-            } @else if (walletNameInvalid()) {
-              <mat-error>{{ 'wallet_name_invalid_local' | i18n }}</mat-error>
-            } @else {
-              <mat-hint>{{ 'wallet_name_hint_local' | i18n }}</mat-hint>
-            }
-          </mat-form-field>
-
           <mat-form-field appearance="outline" class="full-width">
             <mat-label>{{ 'mwallet_passphrase_optional' | i18n }}</mat-label>
             <input matInput type="password" [(ngModel)]="passphrase" autocomplete="off" />
@@ -180,9 +168,7 @@ const ERROR_KEYS: Record<BtcxImportErrorCode, string> = {
             mat-raised-button
             color="primary"
             class="full-width"
-            [disabled]="
-              !validation()?.valid || walletNameConflict() || walletNameInvalid() || importing()
-            "
+            [disabled]="!validation()?.valid || nameSection.hasError() || importing()"
             (click)="importWallet()"
           >
             @if (importing()) {
@@ -281,19 +267,6 @@ const ERROR_KEYS: Record<BtcxImportErrorCode, string> = {
         }
       }
 
-      .name-heading {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-
-        .name-icon {
-          font-size: 18px;
-          width: 18px;
-          height: 18px;
-          color: #1976d2;
-        }
-      }
-
       .full-width {
         width: 100%;
       }
@@ -341,10 +314,8 @@ export class WalletImportDescriptorComponent implements OnInit, OnDestroy {
 
   /** Wallet name — pre-filled with the next free default; desktop rules. */
   walletName = '';
-  readonly walletNameConflict = signal(false);
-  readonly walletNameInvalid = signal(false);
   /** Registry names for suggestion + case-insensitive conflict checks. */
-  private readonly existingNames = signal<string[]>([]);
+  readonly existingNames = signal<string[]>([]);
 
   /** Latest validation verdict of the CURRENT paste (null while empty). */
   readonly validation = signal<BtcxImportValidation | null>(null);
@@ -393,12 +364,6 @@ export class WalletImportDescriptorComponent implements OnInit, OnDestroy {
     this.passphrase = '';
   }
 
-  /** Mirror the Rust-side naming rules before the commit (desktop parity). */
-  onWalletNameChange(): void {
-    this.walletNameConflict.set(isWalletNameTaken(this.walletName, this.existingNames()));
-    this.walletNameInvalid.set(isInvalidWalletName(this.walletName));
-  }
-
   /** Debounced live validation against the backend parser (offline). */
   onInputChange(): void {
     if (this.validateTimer) {
@@ -423,7 +388,12 @@ export class WalletImportDescriptorComponent implements OnInit, OnDestroy {
 
   async importWallet(): Promise<void> {
     if (!this.validation()?.valid || this.importing()) return;
-    if (this.walletNameConflict() || this.walletNameInvalid()) return;
+    if (
+      isWalletNameTaken(this.walletName, this.existingNames()) ||
+      isInvalidWalletName(this.walletName)
+    ) {
+      return;
+    }
     this.importing.set(true);
     this.importError.set(null);
     try {

--- a/web-wallet/src/app/features/mobile-wallet/pages/import-descriptor/wallet-import-descriptor.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/import-descriptor/wallet-import-descriptor.component.ts
@@ -105,7 +105,12 @@ const ERROR_KEYS: Record<BtcxImportErrorCode, string> = {
 
           <p class="hint-text">{{ 'mwallet_import_description' | i18n }}</p>
 
-          <mat-form-field appearance="outline" class="full-width">
+          <!-- subscriptSizing dynamic: the multi-line hint below the
+               textarea must grow the field. In the default 'fixed' mode
+               the hint wrapper is absolutely positioned in a one-line-high
+               subscript box, so the wrapped hint painted OVER the section
+               that followed (the wallet-name label overlay bug). -->
+          <mat-form-field appearance="outline" class="full-width" subscriptSizing="dynamic">
             <mat-label>{{ 'mwallet_import_input_label' | i18n }}</mat-label>
             <textarea
               matInput

--- a/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
@@ -22,14 +22,17 @@ import {
   suggestWalletName,
 } from '../../wallet-name';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
+import { WalletNameSectionComponent } from '../../components/wallet-name-section/wallet-name-section.component';
 
 /**
  * WalletRestoreComponent - restore-from-mnemonic flow.
  *
- * The phrase is entered through the shared MnemonicEntryComponent (the
- * desktop import-wallet grid): 12/24-word selector, per-word BIP39
- * autocomplete and validation, checksum warning. The wallet name is
- * pre-filled with the next free default (desktop naming rules).
+ * The wallet name leads the page (owner rule, round 8: name first — the
+ * shared WalletNameSectionComponent), pre-filled with the next free
+ * default (desktop naming rules). The phrase is then entered through the
+ * shared MnemonicEntryComponent (the desktop import-wallet grid):
+ * 12/24-word selector, per-word BIP39 autocomplete and validation,
+ * checksum warning.
  *
  * The backend probes EVERY descriptor branch the seed's history could live
  * on (BIP-84/86 x BTCX-coin-type/legacy coin-0') against the configured
@@ -64,6 +67,7 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
     MnemonicEntryComponent,
     I18nPipe,
     PageHeaderComponent,
+    WalletNameSectionComponent,
   ],
   template: `
     <app-mwallet-page-header titleKey="mwallet_restore_wallet" />
@@ -147,8 +151,6 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
         </div>
       } @else {
         <div class="card">
-          <p class="hint-text">{{ 'import_mnemonic_description' | i18n }}</p>
-
           @if (!wallet.hasElectrumServer()) {
             <div class="notice-box">
               <mat-icon class="notice-icon">cloud_off</mat-icon>
@@ -159,36 +161,20 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
               {{ 'mwallet_server_settings' | i18n }}
             </button>
           } @else {
+            <!-- Wallet name FIRST (owner rule, round 8) — shared section
+                 with the pre-filled default and live desktop naming rules. -->
+            <app-mwallet-name-section
+              #nameSection
+              [(name)]="walletName"
+              [existingNames]="existingNames()"
+              [disabled]="restoring()"
+            />
+
+            <p class="hint-text">{{ 'import_mnemonic_description' | i18n }}</p>
             <app-mnemonic-entry
               [disabled]="restoring()"
               (changed)="onMnemonicChanged($event)"
             ></app-mnemonic-entry>
-
-            <!-- Wallet name — its own labeled section so the pre-filled
-                 default is a conscious choice, not something to overlook. -->
-            <h3 class="name-heading">
-              <mat-icon class="name-icon">badge</mat-icon>
-              {{ 'wallet_name' | i18n }}
-            </h3>
-            <p class="hint-text small">{{ 'mwallet_name_hint' | i18n }}</p>
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'wallet_name' | i18n }}</mat-label>
-              <input
-                matInput
-                [(ngModel)]="walletName"
-                (ngModelChange)="onWalletNameChange()"
-                autocomplete="off"
-                autocapitalize="none"
-                spellcheck="false"
-              />
-              @if (walletNameConflict()) {
-                <mat-error>{{ 'wallet_name_conflict' | i18n }}</mat-error>
-              } @else if (walletNameInvalid()) {
-                <mat-error>{{ 'wallet_name_invalid_local' | i18n }}</mat-error>
-              } @else {
-                <mat-hint>{{ 'wallet_name_hint_local' | i18n }}</mat-hint>
-              }
-            </mat-form-field>
 
             <mat-form-field appearance="outline" class="full-width">
               <mat-label>{{ 'mwallet_passphrase_optional' | i18n }}</mat-label>
@@ -206,9 +192,7 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
               mat-raised-button
               color="primary"
               class="full-width"
-              [disabled]="
-                !mnemonicValid() || walletNameConflict() || walletNameInvalid() || restoring()
-              "
+              [disabled]="!mnemonicValid() || nameSection.hasError() || restoring()"
               (click)="restore()"
             >
               @if (restoring()) {
@@ -264,19 +248,6 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
         color: #c62828;
         font-size: 13px;
         margin: 0 0 12px;
-      }
-
-      .name-heading {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-
-        .name-icon {
-          font-size: 18px;
-          width: 18px;
-          height: 18px;
-          color: #1976d2;
-        }
       }
 
       .notice-box {
@@ -375,10 +346,8 @@ export class WalletRestoreComponent implements OnInit, OnDestroy {
 
   /** Wallet name — pre-filled with the next free default; desktop rules. */
   walletName = '';
-  readonly walletNameConflict = signal(false);
-  readonly walletNameInvalid = signal(false);
   /** Registry names for suggestion + case-insensitive conflict checks. */
-  private readonly existingNames = signal<string[]>([]);
+  readonly existingNames = signal<string[]>([]);
 
   /** Lower-cased, space-joined phrase from the shared entry grid. */
   private mnemonic = '';
@@ -484,12 +453,6 @@ export class WalletRestoreComponent implements OnInit, OnDestroy {
     this.heldPassphrase = '';
   }
 
-  /** Mirror the Rust-side naming rules before the commit (desktop parity). */
-  onWalletNameChange(): void {
-    this.walletNameConflict.set(isWalletNameTaken(this.walletName, this.existingNames()));
-    this.walletNameInvalid.set(isInvalidWalletName(this.walletName));
-  }
-
   onMnemonicChanged(state: MnemonicEntryState): void {
     this.mnemonic = state.mnemonic;
     this.mnemonicValid.set(state.valid);
@@ -497,7 +460,12 @@ export class WalletRestoreComponent implements OnInit, OnDestroy {
 
   async restore(): Promise<void> {
     if (!this.mnemonicValid() || this.restoring()) return;
-    if (this.walletNameConflict() || this.walletNameInvalid()) return;
+    if (
+      isWalletNameTaken(this.walletName, this.existingNames()) ||
+      isInvalidWalletName(this.walletName)
+    ) {
+      return;
+    }
     this.restoring.set(true);
     this.restoreError.set(null);
     try {


### PR DESCRIPTION
Mobile feedback round 8 — three items on the wallet app.

## 1. Wallet name first on all three acquisition flows

- **Create** gains a dedicated **name step** ahead of phrase/verify/protect ("a first separate step"); the phrase step gets a Back link to it.
- **Restore** and **Import descriptors** (all-in-one pages) put the name section at the very top of the card, before the mnemonic grid / descriptor box.
- The previously triplicated heading/hint/field/error markup is extracted into a shared **`WalletNameSectionComponent`** (badge heading, pre-fill explanation, live desktop naming rules) so the three flows stay pixel-identical. No new i18n keys — everything reuses the existing `wallet_name*` strings.

## 2. Import page overlay bug

The long localized hint under the descriptor textarea wraps to 2–3 lines on narrow screens. Root cause: Material's default `subscriptSizing="fixed"` absolutely positions the hint wrapper (`.mat-mdc-form-field-hint-wrapper { position: absolute; top: 0; … }`) inside a **one-line-high** subscript box, so the wrapped lines escape the box and paint over the next section — the wallet-name label. Fixed structurally with `subscriptSizing="dynamic"` (wrapper becomes static, the field grows), the same idiom the electrum-servers editor already uses. The name fields on create/restore/import shared the latent pattern and are dynamic now too via the shared section.

## 3. O(visible) transaction loading for fat wallets

- **Rust**: `btcx_wallet_transactions(limit?, offset?)` (serde-default `None` = full feed) returns an `{items, total}` envelope; `limit: 0` is a cheap count-only query. The slice is applied in the command layer after `wallet-btcx` returns — the crate (read-only) still builds the full sorted list, but that is cheap in-process arithmetic; the costs that scale badly (per-item display-address derivation with tx-graph reads + bech32, DTO mapping, JSON IPC) now cover only the visible window.
- **Service**: `refreshTransactions(limit?, offset?)` remembers the window and re-requests exactly it on every `btcx-wallet:sync` tick / `refreshAll`; `transactionsTotal` signal carries the full size; signal-free `fetchTransactionsPage` for the backend router.
- **Home** fetches its recent maximum (`RECENT_TX_LIMIT = 10`, the FitRows ceiling) and sync ticks re-request that same small slice. **History** fetches per fit-sized paginator page (`length` = `transactionsTotal`), clamping when a refresh shrinks the history. **Desktop remote mode** (`ElectrumWalletBackend`) pages through `fetchTransactionsPage`; `getWalletDetails` uses the count-only query. Nothing requests the full history anymore. Expanded row details keep working from row data.
- **Live regtest**: new `regtest_transactions_limit_offset_pagination` — 30 entries (1 funding + 29 chained sends, mined in batches), asserting full-feed parity, 10-per-page tiling, count-only, tail truncation, beyond-end offsets. Full ignored suite run against the local stack: **8 passed, 0 failed** (42.89s).

## Verification

- `npm ci`, `ng build --configuration production`, `ng lint`, `format:check`, `test:ci` (79/79) ✅
- `cargo build`, `cargo test` (68/68 unit), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` ✅
- Live regtest suite incl. the new pagination test: 8/8 ✅

### Device-check list (owner)

- Create: name step → phrase → verify → protect flows forward/back correctly; suggested name pre-fills.
- Restore / Import: name section renders first, identical look across the three pages.
- Import: long descriptor hint no longer collides with the section below (check a wrap-happy locale, e.g. de-de/el, on a narrow viewport).
- Home: recent list fills the viewport as before; new txs appear on sync ticks.
- History: pager shows the true total, page flips fetch instantly, rotation keeps the visible page, expanded row detail intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp