### PR TITLE
docs(handbook): sync for 2.1.0 — remote mode, full Android wallet, multi-wallet, imports

### DIFF
--- a/handbook/BASED-ON.md
+++ b/handbook/BASED-ON.md
@@ -6,10 +6,10 @@ between this commit and the new HEAD) instead of a full re-read.
 
 | Field            | Value                                      |
 |------------------|--------------------------------------------|
-| Based-on commit  | `5e6a96ca2f48971c55949cfeb24b15ce270b6153` |
-| Short SHA        | `5e6a96c`                                   |
-| App version      | `2.0.5`                                      |
-| Synced on        | 2026-07-03                                   |
+| Based-on commit  | `6dd9a77` (origin/master)                   |
+| Short SHA        | `6dd9a77`                                   |
+| App version      | `2.1.0` (`package.json` still reads `2.0.5` — version bump pending) |
+| Synced on        | 2026-07-11                                   |
 
 ## How to update the handbook against a newer wallet
 
@@ -34,6 +34,7 @@ between this commit and the new HEAD) instead of a full re-read.
 
 | Synced on  | Based-on  | Version | Notes                                              |
 |------------|-----------|---------|----------------------------------------------------|
+| 2026-07-11 | `6dd9a77` | 2.1.0   | Remote (Electrum/nodeless) node mode — new Chapter 26; full rewrite of ch23 (Android is now a wallet + miner); ch04/ch12 gain the remote node mode; ch05 gains BTCX coin type + restore branch report + a nodeless note; ch06 remote toolbar/nav surfaces; ch08 Electrum broadcast is now live and remote compose limits; ch02/ch03 Android no longer mining-only. New FAQ entries (remote mode, do-I-need-a-node, phone wallet, change-address balance, coin type, imports, no cloud backup) and glossary entries (Coin type, Derivation branch, Electrum server, Remote mode, SegWit, Taproot, Nodeless; Descriptor/WIF updated). Part V renumbered 26–29 → 27–30. Screenshots for remote mode and the rebuilt Android wallet not yet captured. |
 | 2026-07-03 | `5e6a96c` | 2.0.5   | Added the Transaction Builder (PSBT) to ch08 and the multisig wallet wizard to ch05; tour, glossary, and FAQ updates; Android swap-aware memory note. New screenshots captured (3 for the multisig wizard, 4 for the Transaction Builder). |
 | 2026-06-22 | `9e4854c` | 2.0.3   | First recorded revision. See `UPDATE-NOTES-2026-06.md`. |
 | (original) | `4c48855` | 2.0     | Initial handbook authoring (no revision was recorded). |

--- a/handbook/build.ps1
+++ b/handbook/build.ps1
@@ -47,6 +47,7 @@ $inputs = @(
     "chapters/ch23-android.md",
     "chapters/ch24-aggregator.md",
     "chapters/ch25-external-node.md",
+    "chapters/ch25b-remote-node.md",
     "chapters/part5.md",
     "chapters/ch26-troubleshooting.md",
     "chapters/ch27-faq.md",

--- a/handbook/chapters/ch01-about.md
+++ b/handbook/chapters/ch01-about.md
@@ -76,4 +76,4 @@ Chapter 11 — *Backup, Security & Recovery* — covers these topics in depth.
 
 ## Where to get help
 
-If you run into a problem the handbook does not cover, see Chapter 28 — *Where to Get Help* — for community channels and instructions for filing an issue.
+If you run into a problem the handbook does not cover, see Chapter 30 — *Where to Get Help* — for community channels and instructions for filing an issue.

--- a/handbook/chapters/ch02-introducing.md
+++ b/handbook/chapters/ch02-introducing.md
@@ -18,7 +18,7 @@ If you are already familiar with proof-of-capacity mining, feel free to skim thi
 
 Phoenix PoCX combines features that traditionally come from several different programs — a wallet, a node, a plotter, and a miner — into a single window. Whether you want to use it only as a wallet, only for mining, or as both at the same time, the application adapts to what you need.
 
-It runs on Windows, macOS, and Linux as a full-featured desktop application, and on Android as a **mining-only** client (no built-in node and no wallet creation; Android is covered separately in Chapter 24).
+It runs on Windows, macOS, and Linux as a full-featured desktop application, and on Android as a full **wallet and miner** — holding its own wallets and mining into them without a local node, syncing over Electrum servers instead. Android is covered separately in Chapter 23.
 
 ## What Bitcoin-PoCX is
 

--- a/handbook/chapters/ch03-installing.md
+++ b/handbook/chapters/ch03-installing.md
@@ -13,7 +13,7 @@ A single application that bundles the wallet, the node manager, the plotter, the
 | Windows  | NSIS installer (`.exe`)   | Windows 10 or later                                                              |
 | macOS    | Disk image (`.dmg`)       | macOS 10.13 (High Sierra) or later                                               |
 | Linux    | `AppImage`, `.deb`, `.rpm`| Most modern distributions                                                        |
-| Android  | APK (`.apk`)              | Android 7 (API 24) or later — **mining-only** build, no node and no wallet creation |
+| Android  | APK (`.apk`)              | Android 7 (API 24) or later — full **wallet + miner**, nodeless (no solo mining)   |
 
 ## System requirements
 
@@ -161,7 +161,7 @@ The AppImage is self-contained and does not need to be installed system-wide. To
 
 The Android build is distributed as an APK on GitHub Releases — Phoenix PoCX is not currently published on Google Play or F-Droid.
 
-> **Note** — The Android build is **mining-only**. It does not run a node and does not let you create or manage a wallet on the device itself. It is meant to contribute mining capacity to a Phoenix instance running elsewhere (typically through the aggregator described in Chapter 24). If you are looking for a phone wallet to send and receive BTCX, install Phoenix on a desktop machine instead.
+> **Note** — The Android build is a full **wallet and miner**. It holds its own wallets and can mine into them, without running a local node — it syncs over Electrum servers, the nodeless (remote) model of Chapter 26. It cannot *solo* mine (that needs a full node), but it can send, receive, hold wallets, and pool-mine on its own. Chapter 23 covers Android in detail.
 
 1. On your Android device, open a browser and navigate to the project website or GitHub Releases.
 2. Download `phoenix-pocx-wallet-<version>.apk`. Android may warn that the file can be harmful — this caution appears for any APK downloaded outside the Play Store. If prompted, tap **Download anyway**.

--- a/handbook/chapters/ch04-first-launch.md
+++ b/handbook/chapters/ch04-first-launch.md
@@ -13,22 +13,24 @@ The heavy lifting on a Bitcoin-PoCX system is done by a program called **Bitcoin
 
 Phoenix is the user interface that drives Core. When you click **Send**, Phoenix asks Core to build and sign the transaction; when you check a balance, Phoenix asks Core what it knows. Phoenix on its own does nothing — it always needs a Core instance to talk to. The wizard exists to set that up.
 
-You have two ways to provide Core:
+You have three ways to connect:
 
 - **Managed mode** *(recommended)* — Phoenix downloads, installs, runs, and updates Bitcoin-PoCX Core for you. You never have to interact with it directly. This is the right choice for almost everyone.
 - **External mode** — You bring your own Core instance. You have already installed Bitcoin-PoCX Core somewhere (your own server, a different machine on the network) and you tell Phoenix how to reach it. Useful for advanced users running a hardened or shared setup.
+- **Remote mode** — No local node at all. Phoenix keeps a wallet on this computer and reaches the network through public **Electrum servers**. Nothing to download or sync; ideal for a laptop, a low-disk machine, or when you just want a wallet. Solo mining is unavailable in this mode (pool mining works). Remote mode has its own chapter — Chapter 26.
 
 The wizard walks through mode selection first; if you choose managed mode, it then handles the Core download.
 
 ## Step 1 — Choose a mode
 
-The first screen asks: *"How would you like to connect to the Bitcoin-PoCX network?"* Below the question are two selectable cards.
+The first screen asks: *"How would you like to connect to the Bitcoin-PoCX network?"* Below the question are three selectable cards.
 
 
 | Card             | Pick this if…                                                                                                          |
 |------------------|------------------------------------------------------------------------------------------------------------------------|
 | **Managed Node** | You want Phoenix to take care of Core for you. *Recommended for almost all users, including miners.*                  |
 | **External Node** | You already run Bitcoin-PoCX Core somewhere and want Phoenix to connect to it via RPC. Configuration follows in Chapter 25. |
+| **Remote Node (Electrum)** | You want no local node — a wallet that syncs over Electrum servers and stores its data on this computer. No sync wait; solo mining unavailable. Configuration follows in Chapter 26. |
 
 Click the card you want; the chosen card is highlighted in blue.
 
@@ -52,7 +54,7 @@ Click **Continue** when you are happy with your choices.
 
 ## Step 2 — Install Bitcoin-PoCX Core (managed mode only)
 
-If you chose **External Node**, the wizard saves your network choice and skips ahead to Chapter 5; the rest of this section does not apply to you. Configuring how Phoenix reaches your existing Core instance is covered in Chapter 25.
+If you chose **External Node** or **Remote Node (Electrum)**, there is no node for Phoenix to download, so the wizard saves your network choice and skips this install step. For external mode, configuring how Phoenix reaches your existing Core instance is covered in Chapter 25; for remote mode, configuring the Electrum servers the wallet syncs through is covered in Chapter 26.
 
 If you chose **Managed Node**, the wizard now fetches information about the latest Bitcoin-PoCX Core release.
 
@@ -92,7 +94,7 @@ When the install screen reports success, click **Get Started**. Phoenix now:
 
 The button label changes briefly to *"Starting Node..."* with a spinning icon. On most machines this takes two to five seconds; on slower computers or first runs after a long shutdown it can take a little longer.
 
-If Core starts but its RPC interface is not yet responsive, Phoenix shows a small warning *"Node started but RPC not ready yet. You may need to wait."* You will be moved on to the next screen anyway, and Phoenix continues to wait for Core in the background. If you see this message frequently, raise it as a Chapter 26 troubleshooting item.
+If Core starts but its RPC interface is not yet responsive, Phoenix shows a small warning *"Node started but RPC not ready yet. You may need to wait."* You will be moved on to the next screen anyway, and Phoenix continues to wait for Core in the background. If you see this message frequently, raise it as a Chapter 27 troubleshooting item.
 
 ## What Bitcoin-PoCX Core does next, in the background
 

--- a/handbook/chapters/ch05-creating-wallet.md
+++ b/handbook/chapters/ch05-creating-wallet.md
@@ -21,7 +21,9 @@ A primary **Open Wallet** button on the right is greyed out for now — it becom
 
 > **Note** — Phoenix supports multiple wallets in parallel. Once you have one, this same screen lists all of them with their balance, encryption status, and a per-row Load/Unload control. We come back to multi-wallet operation at the end of this chapter.
 
-If you ever see a red **Connection failed** state on this screen instead of the welcome card, Bitcoin-PoCX Core is not reachable. The screen offers **Retry**, **Settings**, and **Re-run node setup** buttons to diagnose. Chapter 26 covers this case in detail.
+> **Note — this chapter describes the managed / external (Core-backed) wallet.** If you run Phoenix in **remote mode** (Chapter 26) — or on Android (Chapter 23) — the wallet is not held inside Bitcoin-PoCX Core but lives locally on your machine and syncs over Electrum servers. The choices are the same in spirit (create from a 24-word phrase, restore, or import), but the screens and a few options differ; Chapter 26 covers the nodeless flows, including importing a wallet from its **descriptors** or from a single **WIF** private key.
+
+If you ever see a red **Connection failed** state on this screen instead of the welcome card, Bitcoin-PoCX Core is not reachable. The screen offers **Retry**, **Settings**, and **Re-run node setup** buttons to diagnose. Chapter 27 covers this case in detail.
 
 ## Creating a new wallet
 
@@ -135,6 +137,12 @@ Same encryption choice as for new wallets. Below the encryption section, an info
 Click **Import wallet**. Phoenix imports the keys and starts the rescan. The dashboard opens immediately, balances and history may take some time to appear in full.
 
 > **Tip** — If you are importing a wallet that you know has only ever been used recently, the rescan is fast. If you are importing a wallet that has been around for years, leave Phoenix running until the rescan finishes — interrupting it just means it has to start again next time the wallet is loaded.
+
+#### Restore finds funds on every derivation branch
+
+You do not have to know how your phrase was originally set up. A recovery phrase can hold funds on several *derivation branches* — different address types (SegWit, taproot, legacy) and different *coin types* (see below) — and Phoenix restore imports **all** of them, so no funds stay hidden on a branch you did not know about. When the import finishes, Phoenix shows a short **branch report** — *"Funds found on: …"* — naming which branches held coins (for example *legacy desktop* and *mobile*). You do not need to choose or configure anything; the scan is automatic.
+
+> **Note — the BTCX coin type.** Bitcoin-PoCX has its own registered *coin type* (SLIP-44 `1347371864`), and **new** wallets use it automatically. Older wallets — and wallets from some other tools — were derived under Bitcoin's original coin type `0'`. This is invisible in day-to-day use: you never enter or see a coin type, new wallets simply use the BTCX one, and **restore finds funds under either**. There is nothing for you to do; the distinction is noted only so the *legacy desktop* / *mobile* labels in the branch report make sense.
 
 ## Setting up a watch-only wallet
 

--- a/handbook/chapters/ch06-tour.md
+++ b/handbook/chapters/ch06-tour.md
@@ -89,7 +89,9 @@ Two read-only views of what Bitcoin-PoCX Core sees:
 - **Blocks** — the recent block list, with height, time, and basic block details.
 - **Peers** — the nodes Core is currently connected to, with their addresses, ping times, and direction.
 
-Both are useful for diagnosing sync problems or seeing how well-connected Core is. They are covered briefly in Chapters 12 and 26.
+Both are useful for diagnosing sync problems or seeing how well-connected Core is. They are covered briefly in Chapters 12 and 27.
+
+> **Note** — Blocks and Peers read data only a full node has, so they are **hidden in remote mode** (Chapter 26); navigating to them returns you to the dashboard.
 
 ### Footer
 
@@ -116,7 +118,7 @@ A row of small icons that turn solid (active) when something is running. They ap
 
 | Icon              | Symbol      | Means…                                                                                                       |
 |-------------------|-------------|--------------------------------------------------------------------------------------------------------------|
-| **Node**          | `share`     | Bitcoin-PoCX Core is running. Visible only in managed mode (the icon is not shown if you use an external node). |
+| **Node**          | `share`     | Bitcoin-PoCX Core is running. Visible only in managed mode (the icon is not shown with an external node). In **remote mode** (Chapter 26) it is replaced by an **Electrum status** indicator showing whether the wallet is synced through its server, running on a failover, or disconnected. |
 | **Miner**         | `hardware`  | The miner is running and scanning plots. Visible only after you have configured mining (Chapter 15).         |
 | **Plotter**       | `storage`   | The plotter has work to do. Solid means actively plotting; outlined means a plan exists but is paused.       |
 | **Wallet lock**   | `lock` / `lock_open` | Visible only when at least one encrypted wallet is loaded. The icon shows whether any wallet is currently unlocked for spending. |

--- a/handbook/chapters/ch08-sending.md
+++ b/handbook/chapters/ch08-sending.md
@@ -144,7 +144,7 @@ Most send failures fall into a small handful of categories. Phoenix shows the un
 | *Fee rate too low*                     | Your custom rate is below the network's minimum. Raise it.                       |
 | *Wallet locked*                        | The encrypted-wallet password dialog was cancelled. Re-click **Send** and enter the password. |
 | *Mempool full / replacement-too-low*   | Mempool conditions are unusual. Wait, or try again with a higher fee.            |
-| *Connection error*                     | Phoenix lost the connection to Bitcoin-PoCX Core. Check the node status indicator (Chapter 6) and Chapter 26 for diagnosis. |
+| *Connection error*                     | Phoenix lost the connection to Bitcoin-PoCX Core. Check the node status indicator (Chapter 6) and Chapter 27 for diagnosis. |
 
 A failed send does not consume any funds — nothing is broadcast until Core has built and signed a valid transaction.
 
@@ -198,6 +198,8 @@ A live **summary** shows what you are sending, the estimated fee, and the total.
 
 > **Note** — The fee and change shown while composing are *estimates*. The exact figures are fixed by the node when it builds the PSBT; the fee is paid on top of the output amounts and taken from the change. If a watch-only wallet cannot build the transaction because it holds no key information, Phoenix says so and points you to import it as a descriptor (xpub) instead.
 
+> **Note — remote mode composes with fewer options.** In a nodeless (remote) wallet (Chapter 26), the node-backed compose extras — manual coin control, `OP_RETURN` data, locktime, a custom change address, subtract-fee, and *Join* — are not available yet, and Phoenix greys them out. Ordinary composing, signing, combining, finalizing, and broadcasting all work.
+
 ### The four steps: Create, Sign, Finalize, Broadcast
 
 Once a PSBT exists, a step indicator across the top tracks it through its life: **Create → Sign → Finalize → Broadcast.** The review screen shows the transaction's inputs and outputs — each output tagged **recipient**, **mine**, **change**, or **data** — and a status badge with a one-line explanation of what to do next.
@@ -215,7 +217,7 @@ Once a PSBT exists, a step indicator across the top tracks it through its life: 
 
 **Finalize.** Once all required signatures are present (status *Signed*), **Finalize** seals the inputs. After finalizing, the transaction can no longer be edited.
 
-**Broadcast.** The final step sends the finalized transaction to the network. The only target today is your **local node**; broadcasting through a remote Electrum server is shown but marked *soon*. On success, Phoenix shows a **Transaction broadcast** confirmation with the copyable txid and buttons to view your transactions or start another.
+**Broadcast.** The final step sends the finalized transaction to the network. There are two possible targets: your **local node** (*"bitcoind on this machine"*) when Phoenix runs a managed or external node, and a **remote Electrum server** (*"Broadcast through a remote server — no local node required"*) when a server is configured — the latter is how a nodeless wallet broadcasts without any local node (Chapter 26). On success, Phoenix shows a **Transaction broadcast** confirmation with the copyable txid and buttons to view your transactions or start another.
 
 ![The final step: choosing where to broadcast the finalized transaction.](images/processed/ch08-psbt-broadcast.png){width=98%}
 

--- a/handbook/chapters/ch09-history.md
+++ b/handbook/chapters/ch09-history.md
@@ -168,7 +168,7 @@ Below the priority buttons, a small summary block highlights the **fee increase*
 
 When you click **Confirm**, Phoenix calls Bitcoin-PoCX Core's `bumpfee` RPC. Core constructs the replacement transaction, signs it with your wallet's keys, and broadcasts it. A success notification displays the new transaction's ID; the original transaction's row in the list is replaced by the new one (or marked superseded, depending on your view), and the new fee figure now reflects what you just paid.
 
-If even the bumped transaction will not confirm — fees may have spiked further while you were watching — you can bump again with a higher rate, or wait for mempool conditions to settle. Chapter 26 covers the deeper troubleshooting cases.
+If even the bumped transaction will not confirm — fees may have spiked further while you were watching — you can bump again with a higher rate, or wait for mempool conditions to settle. Chapter 27 covers the deeper troubleshooting cases.
 
 ## Abandoning a stuck transaction
 

--- a/handbook/chapters/ch11-backup.md
+++ b/handbook/chapters/ch11-backup.md
@@ -99,7 +99,7 @@ Two categories matter beyond the recovery phrase.
 
 ### Phoenix's application data
 
-A periodic copy of Phoenix's data directory — onto an external drive, an encrypted USB key, or your normal computer backups — captures contacts, settings, and mining configuration in one go. The exact directory location depends on your operating system, but you do not need to know it: **Settings → Debug & Logs → App Data Directory → Open folder** opens it directly in your file manager. Chapter 26 explains the two data directories and what each subdirectory contains.
+A periodic copy of Phoenix's data directory — onto an external drive, an encrypted USB key, or your normal computer backups — captures contacts, settings, and mining configuration in one go. The exact directory location depends on your operating system, but you do not need to know it: **Settings → Debug & Logs → App Data Directory → Open folder** opens it directly in your file manager. Chapter 27 explains the two data directories and what each subdirectory contains.
 
 > **Note** — Backing up the application data directory is *helpful*, not *essential*. The recovery phrase alone is sufficient to recover funds. Everything else is convenience and is reconstructable in an hour or two. Do this if losing a long contact list would annoy you; do not lose sleep if you do not.
 

--- a/handbook/chapters/ch12-settings.md
+++ b/handbook/chapters/ch12-settings.md
@@ -14,9 +14,9 @@ The most important tab. This is where you choose whether Phoenix manages Bitcoin
 
 ### Connection mode
 
-A pair of radio buttons at the top of the tab switches between **Managed** and **External**. Switching modes does *not* delete any wallet data — it only changes how Phoenix talks to a node. You can flip back and forth as you experiment.
+Radio buttons at the top of the tab switch between **Managed**, **External**, and **Remote (Electrum)**. Switching modes does *not* delete any wallet data — it only changes how Phoenix reaches the network. You can flip between them as you experiment.
 
-The rest of the tab changes depending on which mode is selected.
+The rest of the tab changes depending on which mode is selected. Managed and external are covered below and in Chapter 25; remote mode has its own panel (also below) and its own chapter (Chapter 26).
 
 ### Managed mode panel
 
@@ -99,6 +99,22 @@ The external panel collects the connection details Phoenix needs to reach a Bitc
 
 **Reset to defaults / Save & apply.** Two buttons at the bottom — *Reset* clears the form to the defaults for the selected network; *Save* commits.
 
+### Remote (Electrum) mode panel
+
+In remote mode there is no node to configure — instead this panel manages the **Electrum servers** the local wallet syncs through. (The full story is Chapter 26; this is the settings reference.)
+
+**Network selection.** *Mainnet*, *Testnet*, or *Regtest*. Each network keeps its own server list and its own wallet data.
+
+**Electrum servers.** An ordered list of endpoints — *"The first entry is the primary server; the rest are failovers."*
+
+| Control | What it does |
+|---------|--------------|
+| **Server URL** | Add an endpoint as `tcp://host:port` or `ssl://host:port` (prefer `ssl://`). |
+| **Test connection** | Makes a lightweight query to confirm the server is reachable before you rely on it. |
+| **Remove server** | Deletes an entry; the remaining order is the failover order. |
+
+For mainnet a default Bitcoin-PoCX server is present out of the box; testnet and regtest start empty. Put a server you run first if you have one, and keep a public server below it as a failover.
+
 ## Tab 2 — Notifications
 
 Phoenix can deliver native operating-system notifications for events of interest. This tab toggles which ones.
@@ -152,7 +168,7 @@ Use this when your mining configuration has become tangled (mismatched orphan fi
 
 Wipes Phoenix's view of the active wallet — settings, contacts associated with the wallet, internal caches. This does *not* delete the underlying Bitcoin-PoCX Core wallet or its keys; it removes Phoenix-side bookkeeping only. You can re-add the wallet from the Wallets screen (Chapter 5) afterwards.
 
-> **Warning** — Despite the name, this is a Phoenix-level reset, not a key deletion. To actually destroy the underlying wallet (and its keys), you must remove the wallet from Bitcoin-PoCX Core itself — typically by wiping the node's data directory, which Chapter 26 covers in detail. *Always confirm you have your recovery phrase before any wallet-related reset.*
+> **Warning** — Despite the name, this is a Phoenix-level reset, not a key deletion. To actually destroy the underlying wallet (and its keys), you must remove the wallet from Bitcoin-PoCX Core itself — typically by wiping the node's data directory, which Chapter 27 covers in detail. *Always confirm you have your recovery phrase before any wallet-related reset.*
 
 ### Import WIF private key
 

--- a/handbook/chapters/ch17-gpu-plotting.md
+++ b/handbook/chapters/ch17-gpu-plotting.md
@@ -114,7 +114,7 @@ If the *Plotting device* section shows only the CPU and an info box reading *"No
 4. **On Linux, confirm the OpenCL ICD is installed.** OpenCL on Linux uses an *Installable Client Driver* loader; the vendor's compute package provides the ICD entry. Without it, no devices are enumerated even with working graphics drivers.
 5. **Check the 3 GiB VRAM floor.** A GPU with less than 3 GiB of available memory may be enumerated but fail to plot, or may not pass the detection kernel compile. If it is an APU, raise the firmware memory allocation; if it is a low-VRAM discrete card, see the sub-3 GiB workaround note above.
 
-If the GPU still does not appear after a current driver is installed, CPU plotting remains available — it is slower but works on every machine — and Chapter 26 covers deeper diagnosis.
+If the GPU still does not appear after a current driver is installed, CPU plotting remains available — it is slower but works on every machine — and Chapter 27 covers deeper diagnosis.
 
 ## What's next
 

--- a/handbook/chapters/ch22-benchmarking.md
+++ b/handbook/chapters/ch22-benchmarking.md
@@ -120,4 +120,4 @@ Do the plotting tuning once, properly, before you plot many terabytes — the ga
 
 ## What's next
 
-That completes Part III. Part IV covers special topics that not every miner needs: **Chapter 23 — Mining on Android**, **Chapter 24 — the multi-machine Aggregator**, and **Chapter 25 — Running Your Own Node**. If none of those apply to you, skip ahead to Part V for troubleshooting, the FAQ, and the glossary.
+That completes Part III. Part IV covers special topics that not every miner needs: **Chapter 23 — Phoenix on Android**, **Chapter 24 — the multi-machine Aggregator**, **Chapter 25 — Running Your Own Node**, and **Chapter 26 — Running Without a Local Node (Remote Mode)**. If none of those apply to you, skip ahead to Part V for troubleshooting, the FAQ, and the glossary.

--- a/handbook/chapters/ch23-android.md
+++ b/handbook/chapters/ch23-android.md
@@ -1,24 +1,24 @@
-# Mining on Android
+# Phoenix on Android: Wallet and Miner
 
-Phoenix PoCX runs on Android, but in a deliberately reduced form. The Android build is a **mining-only** client: it contributes storage capacity to the network, but it does not run a node, does not create or hold wallets, and cannot mine solo. This chapter explains what the Android build can and cannot do, and walks through the permissions and settings that keep it mining reliably in the background.
+Earlier versions of Phoenix ran on Android only as a **mining-only** client — no wallet, no keys, dependent on another machine to sign. That is no longer true. **The Android build is now a full Phoenix wallet *and* a miner.** It creates and holds wallets, sends and receives BTCX, keeps a transaction history and contacts, publishes forging assignments — and it can mine your plotted storage straight into a wallet it holds on the device, with no other computer involved.
 
-## What the Android build is — and is not
+It does this without a local Bitcoin-PoCX Core node. Android runs the **nodeless (remote) wallet** described in Chapter 26: a wallet that lives on the phone and reaches the network through Electrum servers. Everything in this chapter builds on that model, so it is worth reading Chapter 26 alongside this one.
 
-The Android app exists for one purpose: to turn a phone or tablet's storage (or attached storage) into mining capacity. Everything that needs a full node or a wallet is intentionally absent.
+This chapter covers the Android app end to end: installing it, creating or restoring a wallet, the one-click "mine to my own wallet" flow that is the point of the whole thing, and the Android-specific mechanics — permissions, background mining, and the seed-safety rules that matter more on a phone than anywhere else.
 
-| The Android build **can**…                  | The Android build **cannot**…                                              |
-|---------------------------------------------|----------------------------------------------------------------------------|
-| Plot drives (CPU, and OpenCL where supported) | Run a Bitcoin-PoCX Core node — Android has no managed node.               |
-| Mine its plots in the background            | Create, import, or hold a wallet — there is no key management on Android.   |
-| Submit to a pool or an aggregator           | Mine **solo** — solo requires a local node, which Android does not have.    |
-| Keep mining with the screen off            | Sign its own blocks — there is no signing wallet on the device.            |
+## What the Android build can do
 
-Because it has no node and no wallet, an Android miner is always part of a *larger* setup. It produces mining solutions and sends them somewhere that *can* sign blocks:
+The phone is now a self-sufficient participant. On its own, with no other machine, it can:
 
-- **To a pool** — the Android device submits to a pool, which forges and pays out. This is the simplest Android setup.
-- **To an aggregator** — the Android device submits to a Phoenix aggregator running on another machine you control (Chapter 24), which signs with its wallet. This is the way to fold a phone into your own farm.
+| Wallet | Mining |
+|--------|--------|
+| Create, restore, and hold multiple named wallets | Plot free storage (CPU, and OpenCL where supported) |
+| Receive BTCX (address + QR) | Mine its plots into a **pool** in the background |
+| Send BTCX (with fee presets and review) | Publish the on-chain **forging assignment** a pool needs |
+| Keep transaction history and contacts | Mine straight into a wallet the phone itself holds |
+| Import wallets by descriptor or single WIF key | Report into your **aggregator** (Chapter 24) as an option |
 
-In both cases, the signing and the rewards happen elsewhere; the phone just contributes capacity. This is the Android expression of the three-pieces architecture from Chapter 13 — Android provides plots and a miner, never the signing wallet.
+The one thing it still cannot do is **solo mine** — forging a block yourself requires a full node, which the nodeless phone does not run. Solo is disabled; pool mining (and your own aggregator) work. This is the same limit every remote-mode wallet has (Chapter 26), not an Android-specific one.
 
 ## Installing on Android
 
@@ -28,21 +28,87 @@ Installation is covered in Chapter 3 and recapped here. The Android build is dis
 2. Open the APK; when Android warns that your browser or file manager is not allowed to install apps, tap **Settings**, enable **Allow from this source**, and return.
 3. Tap **Install**, then open **Phoenix PoCX Wallet** from the app drawer.
 
-On first launch the app goes straight into mining-only mode — there is no node setup wizard and no wallet-creation flow, because neither applies on Android.
+On first launch the app opens straight into wallet onboarding — there is no node-setup wizard, because Android never runs a node.
+
+## Setting up your wallet
+
+The first screen is **Set up your wallet** — *"Create a new wallet or restore an existing one from its recovery phrase."* This is the same fork as the desktop Wallets screen (Chapter 5), sized for a phone.
+
+### Creating a new wallet
+
+- **Name it.** Give the wallet a recognisable name — it appears in the wallet switcher and list.
+- **Write down the 24 words.** Phoenix generates a fresh 24-word recovery phrase and shows it once, with the blunt warning it deserves: *"These 24 words are the only backup of your wallet. Write them down on paper and keep them offline. Anyone who knows them can spend your funds."* There is no cloud backup and never will be (see *Seed safety on a phone*, below) — paper is the backup.
+- **Confirm the backup.** Phoenix asks you to re-enter a few of the words from your written copy, exactly as the desktop create flow does, to prove you wrote them down.
+- **Set a device passphrase (optional but recommended).** A passphrase encrypts the seed stored on the device. It is *not* part of the recovery phrase — the words alone always restore your funds — but on a phone it is what stands between a thief who picks up your unlocked device and your seed. On Android especially, **set one** (the reasoning is in *Seed safety on a phone*).
+
+### Restoring an existing wallet
+
+Choose **Restore wallet** and enter your 12- or 24-word phrase. Because the phone has no local blockchain to rescan, Phoenix instead checks the phrase's history against your configured Electrum server to find the right *derivation branch* — *"Restoring checks the phrase's history on the configured Electrum server to find the right derivation branch."* It then opens the wallet on the branch that holds funds.
+
+If the phrase turns out to have history on **two** address types — the SegWit (BIP-84) branch and the Taproot (BIP-86) branch — Phoenix tells you so and offers to **create the second wallet** over the same phrase, so no funds stay hidden on a branch you did not open. You end up with both wallets, switchable from the header menu.
+
+> **Note** — Restoring needs a configured Electrum server to probe against (Chapter 26). If none is set, Phoenix says so and sends you to the wallet settings to add one first. If a scan comes up empty because the server was still catching up, a **Scan again** action retries.
+
+### Address type: why SegWit is the default
+
+An **Advanced** choice at creation sets the wallet's **address type**. It matters for mining:
+
+| Type | Addresses | Can receive mining rewards? |
+|------|-----------|------------------------------|
+| **SegWit (BIP-84)** *(default, recommended)* | `pocx1q…` | **Yes** — plot addresses are SegWit v0. |
+| **Taproot (BIP-86)** | `pocx1p…` | **No** — taproot addresses can never be plot addresses. |
+| **Legacy (pre-SegWit)** | `1…`-style | **No** — can send and receive ordinary coins only. |
+
+Leave it on **SegWit** unless you have a specific reason not to. Only a SegWit wallet can hold a plot address, so only a SegWit wallet can mine or publish a forging assignment (Chapter 19). If you pick taproot or legacy, the mining screens will tell you to switch to a SegWit wallet before you can plot to your own key.
+
+### Importing a wallet
+
+Two import paths mirror the nodeless imports from Chapter 26:
+
+- **Import a descriptor** — paste one or two private *output descriptors*. One ranged descriptor (ending `/0/*` or `/1/*`) is enough; Phoenix infers the change branch. Watch-only (xpub) descriptors are not supported yet — the private key material is required.
+- **Import a single key (WIF)** — wrap a private key as `wpkh(YOUR_WIF)` to import it as a one-address SegWit wallet. This is the way to bring a vanity address or a stand-alone plotting key onto the phone; change returns to that same address.
+
+## Getting around: the navigation drawer
+
+Once a wallet is open, a **navigation drawer** (the menu icon at the top-left) reaches every part of the app — wallet home, receive, send, history, contacts, forging assignment, mining, and settings. The wallet's name sits at the top of the header with a **switcher**: tap it to jump between your wallets. Switching closes the open wallet and opens the chosen one — *"the open wallet closes first."*
+
+From the same wallet menu you can **rename** or **delete** a wallet (both require switching away from it first — the active wallet cannot be renamed or deleted). Deletion is safe: *"Its files are moved to the trash folder on this device — nothing is destroyed, and the recovery phrase always restores the funds."*
+
+The everyday wallet screens — **Receive** (address and QR), **Send** (recipient, amount, fee presets or custom, and a review step before broadcast), **Transaction history**, and **Contacts** — work as their desktop counterparts do in Chapters 7–10, laid out for a small screen. Sending signs on the device and broadcasts through your Electrum server.
+
+## The point of it all: mine to your own wallet
+
+The reason Android became a full wallet is a single flow: **plot your phone's storage and mine straight into a wallet the phone holds — with no addresses to copy from anywhere else.** On the wallet home a card invites you in — **Mine to this wallet**: *"Plot free storage space and earn mining rewards straight into this wallet."*
+
+Tapping through takes you into the mining setup (Chapter 15). The difference from a manual setup is the plotting address: instead of pasting an address from another machine, you choose **Use wallet address**, and Phoenix fills in an address the phone's own wallet controls. Plot to that address, mine into a pool, and the rewards land in the wallet you are already looking at.
+
+The flow works in both directions. If you open mining setup first without a wallet yet, Phoenix nudges you to **Create wallet**, then returns you to the wizard with the new wallet's address ready to use. If the wallet is locked, an inline unlock appears. A custom address is still first-class — you can always type an address from elsewhere — but for the common case of "a spare phone earning into my own keys," there is nothing to paste.
+
+> **Note** — Because only a SegWit wallet can own a plot address, the *Use wallet address* option requires the active wallet to be SegWit (see above). With a taproot or legacy wallet active, the wizard tells you to switch to a SegWit wallet or enter an address manually.
+
+## Seed safety on a phone
+
+A phone is a small, easily lost, always-online device, so the rules about the recovery phrase — true everywhere in this handbook — bite hardest here.
+
+- **The 24-word phrase is the only backup. There is no cloud backup, by design.** Android's automatic app-data backup is **deliberately disabled** for Phoenix, specifically so that your seed can never be swept up into Google Drive or any other cloud. This is a security decision, not an oversight: a seed that reaches the cloud is a seed outside your control. The consequence is simple and non-negotiable — **if you lose the phone and have not written the words down, the funds are gone.** Write them on paper before you fund the wallet.
+- **Set a device passphrase.** Without one, the seed stored on the device is only lightly obfuscated — adequate against a casual glance, not against someone determined who has your unlocked phone. A device passphrase encrypts the seed at rest. (A hardware-backed Android Keystore option is planned to strengthen this further; until then, the passphrase is your protection.)
+- **The wallet is a hot wallet.** An open, unlocked wallet on the phone can spend, and so can whatever controls the screen. Lock the wallet when you are done (the settings screen has **Lock wallet**), use your device's own screen lock, and do not hold more on a phone than you would carry in a physical wallet. For serious balances, keep the bulk in a wallet on a machine you control more tightly and treat the phone as spending money.
+
+> **Warning** — No legitimate person, and no part of Phoenix, will ever ask for your 24 words. Anyone who does is trying to steal from you. Phoenix shows the phrase exactly once, at creation; after that it never asks for it again.
 
 ## The two permissions Android mining needs
 
-Background mining on a modern Android device requires two permissions that the app will request. Both are essential; mining will not work reliably without them.
+Mining (not the wallet) needs two Android permissions. Both are essential; background mining will not work reliably without them.
 
 ### All files access (storage permission)
 
-To detect and read plot files, Phoenix needs Android's **All files access** permission (formally `MANAGE_EXTERNAL_STORAGE`, introduced with Android 11). Plot files are large and live in ordinary storage; the scoped-storage model Android uses by default does not let an app read arbitrary plot folders, so the broader permission is required.
+To detect and read plot files, Phoenix needs Android's **All files access** permission (formally `MANAGE_EXTERNAL_STORAGE`, introduced with Android 11). Plot files are large and live in ordinary storage; Android's default scoped-storage model does not let an app read arbitrary plot folders, so the broader permission is required.
 
-When Phoenix needs it, it shows a prompt explaining that it needs *"All files access"* to detect and read plot files, and offers to open the system settings where you grant it. Tap through, enable the permission for Phoenix, and return to the app.
+When Phoenix needs it, it shows a prompt explaining that it needs *"All files access"* to detect and read plot files, and offers to open the system settings where you grant it. Tap through, enable the permission for Phoenix, and return.
 
 ![The in-app All files access prompt on Android.](images/processed/ch23-all-files-access.png){width=55%}
 
-> **Note** — Without All files access, Phoenix cannot see your plot files at all — the drive will appear empty even if it is full of plots. If a configured plot folder shows nothing on Android, this permission is the first thing to check.
+> **Note** — Without All files access, Phoenix cannot see your plot files at all — a configured plot folder will appear empty even when it is full. If a plot folder shows nothing on Android, this permission is the first thing to check.
 
 ### Battery optimisation exemption
 
@@ -80,30 +146,28 @@ Desktop Phoenix opens a native folder picker; Android does not have an equivalen
 
 Enter the full path to the folder where your plots live (or should be generated), and Phoenix scans it the same way it scans a desktop drive. External storage — a microSD card or a USB-OTG drive — has its own path, which your device's file manager can show you.
 
-> **Tip — plot on a desktop, then transfer to the phone.** On-device plotting on Android works, but a mobile processor is slow at it; depending on how much capacity you are plotting it can take a while. The smoother approach is to generate the plot files on a desktop machine — fast CPU or GPU plotting (Chapters 16–17) — using the *same plotting address* you will configure on the phone, then copy the finished `.pocx` files onto the device's storage (or onto a microSD card you move into it). Point Android's plot folder at where you placed them, and the phone goes straight to mining with no plotting wait. This keeps the heavy, one-time work on hardware suited to it and leaves the phone to do the light part.
+> **Tip — plot on a desktop, then transfer to the phone.** On-device plotting works, but a mobile processor is slow at it. The smoother approach is to generate the plot files on a desktop machine — fast CPU or GPU plotting (Chapters 16–17) — using the *same plotting address* you will use on the phone, then copy the finished `.pocx` files onto the device (or onto a microSD card you move into it). Point Android's plot folder at where you placed them and the phone goes straight to mining with no plotting wait. Keep the heavy, one-time work on hardware suited to it; leave the phone the light part.
 
-### The plotting address must come from elsewhere
+### The plotting address is now your own
 
-Because Android holds no wallet, it cannot offer you a *"use wallet address"* option for the plotting address. You **enter the address manually** — an address from a wallet you control on another machine (Chapter 7). The plots you generate on Android are tied to that address; the rewards, once the solutions are signed by a pool or your aggregator, flow to it.
-
-This is the natural consequence of Android being mining-only: the phone plots and mines, but the *ownership* lives in a wallet on a device that can hold keys.
+Because Android now holds wallets, the plotting address can come from the phone itself — the **Use wallet address** flow above fills in an address the device controls. You can still **enter an address manually** if you want to mine into a wallet held elsewhere; both are supported. When you plot to your own wallet, the rewards a pool pays out land directly in it.
 
 ### No solo option
 
-The chain configuration omits solo mining on Android — the wizard tells you *"solo mining is not available on mobile devices."* Configure a **pool** chain, or point the device at your **aggregator** (Chapter 24). One of those is required for an Android miner to do anything useful.
+Solo mining is disabled on the nodeless phone (Chapter 26). The chain configuration omits it — *"Solo mining is not available on mobile devices."* Configure a **pool** chain, or point the device at your **aggregator** (Chapter 24). Pool mining also needs a forging assignment (Chapter 19), which the phone publishes for you over Electrum; most pools run a faucet to cover the small assignment fee.
 
 ## Realistic expectations
 
-A phone is not a mining rig, but mining itself is light enough that an Android device handles it comfortably — the realistic limits are about storage and one-time plotting, not about wear.
+A phone is not a mining rig, but mining itself is light enough that an Android device handles it comfortably — the realistic limits are about storage and one-time plotting, not wear.
 
-- **Capacity is whatever storage the device has.** Depending on the device and what you attach to it, that ranges from a couple of gigabytes of spare internal storage up to a terabyte or more on a large microSD card or a USB-OTG drive. You participate with your fraction of network capacity, exactly as any miner does; the phone is simply contributing a smaller share than a full rig would. That is perfectly fine — a phone pointed at a pool earns its proportional keep like any other contributor.
-- **Mining is gentle on the device.** Forging is read-only and low-CPU (Chapter 13): the phone reads a small slice of its plots every couple of minutes and is otherwise idle. Power draw is minimal and ongoing wear is negligible — mining does not stress a phone the way a game or sustained video does. Leaving an old device mining indefinitely is perfectly reasonable.
-- **Plotting is the only heavy part — so do it elsewhere.** The slow, processor-intensive work is *plotting*, not mining. As noted above, generate plots on a desktop and transfer the finished files to the phone; the device then only ever does the light mining work. On-device plotting is available if you prefer it, but it is slow and is the one workload that will actually warm the phone for a while. When you do plot on the device, the setup wizard's memory estimate (Chapter 15) counts the phone's free **swap** (zram / memory-extension) on top of physical RAM, since the plotter can draw on it — an **Available Swap** line appears alongside available RAM.
+- **Capacity is whatever storage the device has** — from a couple of gigabytes of spare internal storage up to a terabyte or more on a large microSD card or a USB-OTG drive. You participate with your fraction of network capacity like any miner; the phone simply contributes a smaller share, which is perfectly fine.
+- **Mining is gentle on the device.** Forging is read-only and low-CPU (Chapter 13): the phone reads a small slice of its plots every couple of minutes and is otherwise idle. Power draw is minimal and ongoing wear is negligible. Leaving an old device mining indefinitely is reasonable.
+- **Plotting is the only heavy part — so do it elsewhere.** The slow, processor-intensive work is *plotting*, not mining. Generate plots on a desktop and transfer them; the phone then only ever does the light mining work. On-device plotting is available if you prefer it, but it is slow and is the one workload that will warm the phone for a while. When you do plot on the device, the wizard's memory estimate (Chapter 15) counts the phone's free **swap** (zram / memory-extension) on top of physical RAM, since the plotter can draw on it — an **Available Swap** line appears alongside available RAM.
 
-The most common Android setup is the simplest one: **a phone mining into a pool, on its own.** It does not need another machine, an aggregator, or anything else on your network — just the pool configuration (and the forging assignment that pool mining requires, Chapter 19). A spare phone with a microSD card, pointed at a pool, is a complete and self-sufficient miner. If you *do* already run a farm, the same device can instead report into your aggregator (Chapter 24) — but that is an option, not a requirement.
+The most self-contained Android setup is now genuinely self-contained: **a spare phone that holds its own wallet, plots a microSD card, and mines into a pool — rewards landing in keys the phone controls, nothing to copy from another machine.** If you already run a farm, the same device can instead report into your aggregator (Chapter 24) — an option, not a requirement.
 
-> **Tip** — An old phone or tablet with a large microSD card or a USB-OTG drive is a tidy way to put retired hardware to work — the same end-of-life-hardware logic from Chapter 14, applied to mobile devices. Pre-load it with plots from your desktop, point it at a pool, and leave it running.
+> **Tip** — An old phone or tablet with a large microSD card or a USB-OTG drive is a tidy way to put retired hardware to work — the end-of-life-hardware logic of Chapter 14 applied to mobile. Create a wallet on it, pre-load plots from your desktop, point it at a pool, and leave it running.
 
 ## What's next
 
-If the Android device — or any of your miners — should report into a central coordinator rather than a pool, the next chapter is for you. **Chapter 24 — Orchestrating Multiple Machines with the Aggregator** covers turning one Phoenix instance into the hub of a multi-machine farm, with the others (Android included) submitting their solutions to it.
+The Android device is a complete wallet-plus-miner in your pocket. If you run several machines and want them coordinated around one hub rather than each pointed at a pool, the next chapter is for you. **Chapter 24 — Orchestrating Multiple Machines with the Aggregator** covers turning one Phoenix instance into the hub of a multi-machine farm, with the others — Android included — submitting their solutions to it.

--- a/handbook/chapters/ch25-external-node.md
+++ b/handbook/chapters/ch25-external-node.md
@@ -82,7 +82,7 @@ External mode is selected and configured in two places: the first-launch wizard 
 
 The external-mode panel has a **Test connection** button. Click it before saving: Phoenix makes a lightweight RPC call and, on success, reports the node's **version**, **chain**, and **block height**. This confirms three things at once — the address and port are right, the credentials work, and the node is on the network you expect.
 
-If the test fails, the common causes are: the node is not running, RPC is not enabled (`server=1` missing), the credentials are wrong, the host or port is mistyped, or a firewall is blocking the connection. Chapter 26 covers diagnosis.
+If the test fails, the common causes are: the node is not running, RPC is not enabled (`server=1` missing), the credentials are wrong, the host or port is mistyped, or a firewall is blocking the connection. Chapter 27 covers diagnosis.
 
 Once the test passes, save. Phoenix connects to your node and behaves exactly as it does in managed mode — the wallet, sending, receiving, mining, and everything else work the same way. The only difference is that Phoenix no longer starts, stops, or updates the node; that is now your responsibility.
 
@@ -105,4 +105,6 @@ In practice this means: if you point Phoenix at an external node for solo mining
 
 ## What's next
 
-That completes Part IV. The remaining chapters are reference material: **Chapter 26 — Troubleshooting** works through the problems you are most likely to hit and how to diagnose them, including where Phoenix keeps its logs and how to wipe data directories cleanly. Chapters 27 to 29 are the FAQ, glossary, and where to get help.
+External mode and managed mode both assume a full Bitcoin-PoCX Core node — Phoenix's, or your own. The final chapter of Part IV covers the third option, which needs no local node at all: **Chapter 26 — Running Without a Local Node (Remote Mode)** connects the wallet to public Electrum servers instead, so it runs on a laptop or a phone with no blockchain to download.
+
+After that, Part V is reference material: **Chapter 27 — Troubleshooting** works through the problems you are most likely to hit and how to diagnose them, including where Phoenix keeps its logs and how to wipe data directories cleanly. Chapters 28 to 30 are the FAQ, glossary, and where to get help.

--- a/handbook/chapters/ch25b-remote-node.md
+++ b/handbook/chapters/ch25b-remote-node.md
@@ -1,0 +1,137 @@
+# Running Without a Local Node (Remote Mode)
+
+Managed mode (Chapter 4) and external mode (Chapter 25) both assume a full **Bitcoin-PoCX Core** node — one Phoenix installs and runs, or one you run yourself. Both download and validate the entire blockchain, which costs disk space, bandwidth, and an initial sync that can take hours.
+
+**Remote mode** is the third option, and it needs no local node at all. Instead of running Core, Phoenix keeps a lightweight wallet *on your own computer* and reaches the network through public **Electrum servers**. There is no blockchain to download and nothing to sync from scratch — the wallet is usable within seconds of being created. This is the mode that makes Phoenix practical on a laptop, on a machine with little spare disk, and (as Chapter 23 describes) on a phone.
+
+This chapter explains what remote mode is, when to choose it, how to configure the servers it talks to, the trust model you are accepting, and the handful of things it deliberately cannot do.
+
+## What remote mode actually is
+
+In remote mode there is no `bitcoind` process anywhere in the picture. Two pieces replace it:
+
+- **A local wallet, on your computer.** Phoenix keeps a self-contained wallet — its keys, addresses, and transaction history — in its own data directory on the machine you are using. The keys never leave the device. Every transaction you send is built and signed *locally*, exactly as a hardware or mobile wallet does.
+- **Electrum servers, on the network.** To learn what has arrived, what has confirmed, and to broadcast the transactions it signs, the wallet talks to one or more Electrum servers — lightweight indexers that answer "what is the history of this address?" and "please relay this transaction." Phoenix ships with a default Bitcoin-PoCX server and lets you add your own.
+
+The result behaves like an ordinary Phoenix wallet — dashboard, receive, send, history, contacts, forging assignments, and the Transaction Builder all work — but with no node to install, sync, or maintain.
+
+> **Note** — Remote mode is sometimes labelled the *nodeless* or *Electrum* wallet in the interface. The three terms mean the same thing: a wallet that runs against remote servers instead of a local Bitcoin-PoCX Core.
+
+## When to choose remote mode
+
+Remote mode is the right choice when running a full node is impractical or unnecessary:
+
+- **You just want a wallet.** To send, receive, and hold BTCX — without mining, and without waiting for a multi-hour blockchain sync — remote mode is the fastest path from install to a usable wallet.
+- **The machine is small.** A laptop, a low-disk desktop, or a phone (Chapter 23) cannot comfortably store and validate the whole chain. Remote mode asks for almost no disk.
+- **You want to pool-mine from a light machine.** Pool mining does not need a local node — the pool signs and forges. Remote mode supports pool mining and the on-chain forging assignment it requires (Chapter 19), so a plotting-and-mining machine can run nodeless.
+
+Choose **managed** or **external** mode instead when you want the strongest trust model, or when you intend to **solo mine** — solo mining forges blocks locally and requires a full node, which remote mode does not provide (see *What remote mode cannot do*, below).
+
+## Choosing remote mode
+
+Remote mode is selected in the same two places as the other node modes: the first-launch wizard (Chapter 4) or, at any time afterwards, **Settings → Node Configuration** (Chapter 12).
+
+In the first-launch wizard, the mode question — *"How would you like to connect to the Bitcoin-PoCX network?"* — offers a third card alongside Managed and External:
+
+> **Remote Node (Electrum)** — *No local blockchain — the wallet connects to Electrum servers and stores wallets locally on this computer. Solo mining is unavailable; pool mining works.*
+
+Pick it and continue. There is no node to download, so the install step (Chapter 4) is skipped entirely; Phoenix goes straight to configuring servers and then to creating or restoring a wallet.
+
+## Configuring Electrum servers
+
+A remote wallet is only as reachable as the servers it can talk to. Phoenix keeps an **ordered list** of Electrum endpoints, edited under **Settings → Node Configuration** (in remote mode) or during first-launch setup.
+
+- **The first server is the primary.** The wallet syncs through it in normal operation.
+- **The rest are failovers.** If the primary becomes unreachable, Phoenix falls over to the next server in the list, and the toolbar indicator (below) shows that it is running on a backup.
+
+Each network keeps its **own** server list and its own wallet data — switching between mainnet, testnet, and regtest switches both.
+
+### Adding and testing a server
+
+Each entry is a URL in one of two forms:
+
+```
+ssl://host:port      (TLS-encrypted — recommended)
+tcp://host:port      (plain TCP)
+```
+
+Prefer `ssl://` where the server offers it: it encrypts the link so a network observer cannot read which addresses you are querying in transit. Type or paste the URL, and use **Test connection** to confirm the server is reachable before you rely on it — Phoenix makes a lightweight query and reports success or failure. **Remove server** deletes an entry; the order of the remaining entries is the failover order.
+
+### The default server
+
+For **mainnet**, Phoenix ships with a default Bitcoin-PoCX Electrum server already in the list, so a fresh remote wallet works out of the box with nothing to configure. You can leave it as the primary, add your own servers ahead of it, or remove it entirely and run only against servers you trust.
+
+For **testnet** and **regtest** the list starts empty — add the URL of the server you are testing against (for regtest, that is typically your own local indexer).
+
+> **Tip** — If you run your own Electrum indexer for Bitcoin-PoCX, put it first in the list and keep the public server below it as a failover. You then get the privacy of querying your own server, with the resilience of a public backup if yours goes down.
+
+## The trust model — what a server can and cannot do
+
+Remote mode trades a little trust for a lot of convenience. It is important to understand exactly where that trust sits, because it is narrower than it first appears.
+
+**A server cannot steal from you.** Your keys never leave your computer, and every transaction is signed locally before it is handed to a server merely to relay. A malicious or compromised server cannot move your funds, redirect a payment, or forge a signature. The worst it can do is *refuse* to broadcast a transaction — at which point Phoenix fails over to another server.
+
+**A server can lie about what it sees — but not convincingly, and not to your cost.** An Electrum server reports address histories and confirmation counts. A dishonest one could *withhold* a transaction (claim you have not been paid when you have) or *misreport* how many confirmations something has. Phoenix verifies the chain's block headers, so a server cannot fabricate a payment that the network never accepted or invent a longer chain than exists. The realistic failure is a server that is stale, buggy, or selectively quiet — an availability and freshness problem, not a theft one. Running more than one server, and preferring one you control, mitigates it.
+
+**A server sees your addresses.** To answer "what is the history of this address?", the server necessarily learns which addresses you are asking about — and can associate them with your network connection. This is the genuine privacy cost of any light wallet. Two things soften it: Bitcoin-PoCX wallets use a distinct coin type (see the glossary), so the same recovery phrase used on another Bitcoin-family chain does not produce publicly linkable addresses; and you can point the wallet at a server *you* run, which removes the third party altogether.
+
+In short: **the chain is verified, the keys are local, so a server can inconvenience you but cannot rob you.** That is the trade you are making when you skip the local node.
+
+## What works in remote mode
+
+Nearly all of Phoenix works unchanged. Because the wallet is a first-class local wallet, the pages you use every day behave exactly as the earlier chapters describe:
+
+- **Receive, send, history, and contacts** (Chapters 7–10) all work. Sending builds and signs the transaction locally, then broadcasts it through your Electrum server — no local node required.
+- **Multiple named wallets** — create, restore, rename, and delete wallets, and switch between them, all covered later in this chapter.
+- **Forging assignments** (Chapter 19) work. Phoenix builds, signs, and broadcasts the assignment transaction itself, using one of your plot address's own coins as proof of ownership, and derives the assignment's status from the address's on-chain history. The same activation and revocation delays apply (about 30 blocks to activate, about 720 to revoke).
+- **The Transaction Builder** (Chapter 8) composes, signs, finalizes, and broadcasts PSBTs. In remote mode the broadcast step targets your Electrum server instead of a local node — *"Broadcast through a remote server — no local node required."*
+- **Pool mining** (Chapters 15, 19) works. The mining setup wizard offers pool and custom chains; combined with a forging assignment, a remote-mode machine can plot and mine into a pool.
+
+## What remote mode cannot do
+
+A few capabilities depend on a full node and are therefore disabled or limited when you run nodeless. Phoenix hides or greys out what does not apply rather than letting it fail:
+
+- **Solo mining is unavailable.** Forging a block yourself means building and validating it locally, which is a full node's job. The mining wizard's **solo** option is disabled in remote mode — *"Solo mining needs a local node — not available in remote (Electrum) mode."* Pool mining, which offloads forging to the pool, works fine.
+- **The Blocks explorer and Peers page are hidden.** Both read data only a full node has (block-by-block detail; the node's peer connections). In remote mode the sidebar does not show them, and navigating to them redirects to the dashboard.
+- **Some advanced Transaction Builder options are not yet available.** Manual coin (UTXO) control, `OP_RETURN` data outputs, custom locktime, a custom change address, subtract-fee, and the *Join* (CoinJoin-style) merge are node-backed features that remote mode does not expose yet — *"Coin control, OP_RETURN data, locktime, custom change and subtract-fee are not available in remote mode yet."* Ordinary composing, signing, combining, finalizing, and broadcasting all work.
+
+Everything else — the wallet, sending and receiving, history, contacts, pool mining, and forging assignments — is fully available.
+
+## The Electrum status indicator
+
+In remote mode the toolbar's node indicator (Chapter 6) is replaced by an **Electrum status** indicator, since there is no local node to report on. Its state tells you at a glance how the wallet's connection to the network is doing:
+
+| State | Means… |
+|-------|--------|
+| **Electrum connected** | The wallet is synced through its primary server. |
+| **Primary Electrum server down — using a failover** | The primary is unreachable; Phoenix has fallen back to a backup server. The wallet still works — consider checking the primary. |
+| **Electrum disconnected** | No configured server is reachable. Balances and history are frozen at the last sync and sending will fail until a server comes back. |
+| **Connecting to Electrum…** | A sync or reconnect is in progress. |
+
+Hovering the indicator shows how recently the wallet last synced (for example *"synced 8s ago"*). The wallet re-checks its servers on a short interval, so a transient blip usually clears itself; a persistent *disconnected* state means every server in your list is unreachable — see the server configuration above and Chapter 27.
+
+## Wallets in remote mode
+
+Because the wallet lives on your computer rather than inside a node, remote mode has its own set of ways to create and acquire one. All of them are reached from the wallet's onboarding and settings; the choices mirror the desktop wallet flows in Chapter 5 but are handled by the local wallet rather than Core.
+
+- **Create a new wallet.** Phoenix generates a fresh 24-word recovery phrase, has you verify it, and creates the wallet. As always, the 24 words are the only backup — write them down offline (Chapter 11).
+- **Restore from a recovery phrase.** Enter an existing 12- or 24-word phrase. Because there is no local chain to rescan, Phoenix instead *probes* your configured Electrum server to find which derivation branch your phrase's history lives on, and opens the wallet on the branch that holds funds. If history turns up on more than one address type, Phoenix offers to create the second wallet too, so nothing stays hidden. (The derivation-branch story — and why a distinct coin type matters — is covered in Chapter 5 and the glossary.)
+- **Import a descriptor.** Paste one or two *output descriptors* (with private key material) to import a wallet described by its descriptors rather than a phrase. One ranged descriptor is enough — Phoenix infers the change branch — or paste the external and internal descriptors together.
+- **Import a single key (WIF).** Wrap a single private key as `wpkh(YOUR_WIF)` to import it as a one-address SegWit wallet — handy for sweeping a vanity address or a stand-alone plotting key. Change returns to the same address.
+
+A **device passphrase** can encrypt the wallet's seed at rest on the machine; on a phone this is strongly recommended (Chapter 23). Named wallets can be switched, renamed, and deleted; deletion is safe — the files move to a trash folder and the recovery phrase always restores the funds. These wallet operations are described in full, with their mobile screens, in Chapter 23; on the desktop they appear in the same wallet menu and Wallets screen as the Core-backed wallets in Chapter 5.
+
+> **Warning — remote-mode wallets are stored on this computer, not in a node.** Wiping Phoenix's data (or a *Reset wallet*, Chapter 12) removes the local wallet. As with any wallet, the recovery phrase is the ultimate backup: without it, a deleted or lost remote wallet cannot be recovered. Back up the 24 words before you fund the wallet.
+
+## Mining in remote mode
+
+Remote mode supports the light half of mining — **plotting and pool mining** — but not solo. The setup is the same three-step wizard as everywhere else (Chapter 15), with two consequences of being nodeless:
+
+- **The solo chain is disabled**, as noted above. Configure a **pool** (or a custom pool-shaped chain) instead.
+- **Forging still needs an assignment.** Pool mining requires an on-chain forging assignment to the pool's address (Chapter 19), and remote mode builds and broadcasts that assignment itself through your Electrum server. You need a small amount of BTCX to pay the assignment fee; most pools run a faucet for exactly this.
+
+This is the same shape as Android (Chapter 23): a nodeless machine that plots, mines into a pool, and delegates forging — with the wallet and the assignment handled locally over Electrum.
+
+## What's next
+
+That completes Part IV. Part V is reference material: **Chapter 27 — Troubleshooting** works through the problems you are most likely to hit — including remote-mode connection failures — and how to diagnose them. Chapters 28 to 30 are the FAQ, glossary, and where to get help.

--- a/handbook/chapters/ch26-troubleshooting.md
+++ b/handbook/chapters/ch26-troubleshooting.md
@@ -14,7 +14,7 @@ That tab gives you one-click access to:
 - **Bitcoin Core log** — the node's `debug.log`. *Open* launches it directly. This is the authoritative place for node-side problems: sync failures, RPC errors, block validation issues.
 - **Config files** — the node, mining, aggregator, and `bitcoin.conf` files, each with an *Open* button, when you need to inspect or compare what Phoenix has actually saved.
 
-> **Tip** — When asking for help (Chapter 29), a recent slice of the relevant log is the single most useful thing you can provide. Take the **last few hundred lines**, not the whole file — logs grow large, and the recent tail almost always contains the error. Be aware that logs can contain your addresses; review before sharing publicly.
+> **Tip** — When asking for help (Chapter 30), a recent slice of the relevant log is the single most useful thing you can provide. Take the **last few hundred lines**, not the whole file — logs grow large, and the recent tail almost always contains the error. Be aware that logs can contain your addresses; review before sharing publicly.
 
 ### The data directories
 
@@ -148,7 +148,7 @@ If a problem resists every check here:
 
 1. **Read the relevant log** (Bitcoin Core log for node/mining/sync issues, App log for interface/connection issues) — the actual error is usually named there.
 2. **Restart cleanly** — stop the miner and aggregator, stop the node, restart Phoenix. A surprising number of transient problems clear with a clean restart.
-3. **Ask for help** with specifics — what you did, what you expected, what happened, and a recent log slice (Chapter 29). "It doesn't work" is hard to help; a log excerpt and a clear sequence of steps is easy.
+3. **Ask for help** with specifics — what you did, what you expected, what happened, and a recent log slice (Chapter 30). "It doesn't work" is hard to help; a log excerpt and a clear sequence of steps is easy.
 
 ## What's next
 

--- a/handbook/chapters/ch27-faq.md
+++ b/handbook/chapters/ch27-faq.md
@@ -17,7 +17,16 @@ No. To use the wallet, you need none of it. To mine, the working model in Chapte
 No. Your keys live inside Bitcoin-PoCX Core, the node program Phoenix drives. Phoenix is the interface; it generates your recovery phrase, hands it to Core, and forgets it. See Chapter 6.
 
 **Which platforms are supported?**
-Windows, macOS, and Linux as full wallets-plus-miners; Android as a mining-only client (no node, no wallet on the device). See Chapters 3 and 23.
+Windows, macOS, and Linux as full wallets-plus-miners; Android as a full wallet *and* miner that runs without a local node (it syncs over Electrum servers). Android cannot solo-mine, but it holds its own wallets and can pool-mine into them. See Chapters 3 and 23.
+
+**Do I need to run a node?**
+No. Choose **remote mode** at first launch and Phoenix keeps a wallet on your computer and syncs over Electrum servers — no blockchain download, nothing to maintain. Run a node (managed or external) if you want the strongest trust model or intend to *solo* mine. See Chapters 4 and 26.
+
+**What is remote (Electrum) mode?**
+A node mode where Phoenix runs no local Bitcoin-PoCX Core. Your keys and wallet live on your computer and every transaction is signed locally; the wallet reaches the network through Electrum servers. A server can inconvenience you (stall a broadcast, report stale data) but cannot steal — the chain is verified and the keys never leave your machine. Solo mining, the block explorer, and the peers page are unavailable in remote mode. See Chapter 26.
+
+**Can I use Phoenix on my phone as a real wallet now?**
+Yes. The Android app is a full wallet — create or restore wallets, send, receive, keep history and contacts — and it can mine your storage straight into a wallet it holds, with nothing to copy from another machine. See Chapter 23.
 
 ## Wallet and funds
 
@@ -37,7 +46,19 @@ No. Confirmed Bitcoin-PoCX transactions are irreversible. Always verify the reci
 If you sent it with Replace-By-Fee enabled, bump its fee (Chapter 9). If not, you generally wait for it to clear or be evicted from mempools. See Chapters 8 and 9.
 
 **Can I have more than one wallet?**
-Yes. Phoenix supports multiple wallets; switch between them from the toolbar. See Chapter 5.
+Yes. Phoenix supports multiple wallets; switch between them from the toolbar (desktop) or the header switcher (Android). You can name, rename, and delete them; deletion is safe — the files move to a trash folder and the recovery phrase always restores the funds. See Chapters 5 and 23.
+
+**A block explorer shows a different balance (or an address I don't recognise). Why?**
+Almost always *change addresses*. When you spend, the leftover comes back to a fresh address your wallet owns but you never see — so any single address on an explorer shows only part of the story. Your wallet's total is the sum across all its addresses, which Phoenix tracks for you; trust the wallet's balance, not one address on an explorer. See Chapters 8 and 9.
+
+**Why does restore find addresses I didn't expect?**
+A recovery phrase can hold funds on several *derivation branches* — different address types and coin types. Phoenix restore scans them all and imports every branch that holds coins, then shows a short branch report of what it found, so nothing stays hidden. You do not choose or configure anything. See Chapter 5.
+
+**What is the BTCX coin type, and do I need to do anything about it?**
+Bitcoin-PoCX has its own registered coin type (SLIP-44 `1347371864`); new wallets use it automatically, and restore still finds funds derived under the older Bitcoin coin type. It is invisible in normal use — there is nothing for you to set. See Chapter 5.
+
+**Can I import a wallet from a descriptor or a single private key?**
+In the nodeless (remote) wallet and on Android, yes — paste one or two output *descriptors*, or wrap a single WIF key as `wpkh(WIF)` to import it as a one-address wallet (handy for a vanity or plotting address). See Chapters 23 and 26.
 
 **Can I create a shared wallet that needs several people to approve a spend?**
 Yes — a *multisig* wallet. Click **Multisig** on the Wallets screen and pick an *M-of-N* policy such as 2-of-3. Every participant runs the same wizard with the same set of public keys. See Chapter 5.
@@ -58,6 +79,9 @@ For an everyday wallet, yes — it protects against local theft. For a *mining* 
 
 **Will anyone from the project ever ask for my recovery phrase?**
 Never. No legitimate person or service will. Anyone who asks is trying to steal from you. See Chapters 1 and 11.
+
+**Is my wallet backed up to the cloud on Android?**
+No — and this is deliberate. Android's automatic app-data backup is disabled for Phoenix specifically so your seed can never reach Google Drive. The 24-word phrase, written on paper, is the only backup. Set a device passphrase to protect the seed stored on the phone, and treat the phone wallet as a hot wallet — spending money, not a vault. See Chapter 23.
 
 **Do my contacts and settings get backed up by my recovery phrase?**
 No. The phrase restores *funds* only. Contacts, settings, and mining configuration live in Phoenix's data directory and are not derived from the phrase. See Chapters 10 and 11.
@@ -119,10 +143,10 @@ No. An assignment delegates *forging only* — the right to sign blocks. It cann
 ## Operations
 
 **My miner looks healthy but never forges. Why?**
-The most common cause is a drifting system clock — Bitcoin-PoCX rejects blocks more than 15 seconds off, so your blocks get rejected even though everything looks fine. Enable NTP. See Chapters 20 and 26.
+The most common cause is a drifting system clock — Bitcoin-PoCX rejects blocks more than 15 seconds off, so your blocks get rejected even though everything looks fine. Enable NTP. See Chapters 20 and 27.
 
 **Mining stopped after my computer restarted.**
-If your signing wallet is encrypted, it came back locked and cannot sign until unlocked. Unlock it, or set up the cold/hot key split so the mining wallet needs no unlock. See Chapters 19, 20, and 26.
+If your signing wallet is encrypted, it came back locked and cannot sign until unlocked. Unlock it, or set up the cold/hot key split so the mining wallet needs no unlock. See Chapters 19, 20, and 27.
 
 **My effective capacity is much lower than my plotted terabytes.**
 Usually one of: plots a PoW scaling level behind the network (each level halves effective size — upgrade them), an I/O bottleneck (scans taking too long), or a drive that went offline. See Chapters 18, 20, and 22.
@@ -131,10 +155,10 @@ Usually one of: plots a PoW scaling level behind the network (each level halves 
 Up to the point where its drive slots and I/O saturate. Beyond that, add machines and coordinate them with the aggregator. See Chapters 14 and 24.
 
 **Where are the logs if I need to diagnose something?**
-Settings → Debug & Logs has one-click access to Phoenix's log and the node's log. See Chapters 12 and 26.
+Settings → Debug & Logs has one-click access to Phoenix's log and the node's log. See Chapters 12 and 27.
 
 **Is the network live? Does BTCX have value?**
-Refer to the official project channels (Chapter 29) for the current network status and any market information — it changes over time and is not something this handbook can state authoritatively.
+Refer to the official project channels (Chapter 30) for the current network status and any market information — it changes over time and is not something this handbook can state authoritatively.
 
 ## What's next
 

--- a/handbook/chapters/ch28-glossary.md
+++ b/handbook/chapters/ch28-glossary.md
@@ -22,6 +22,8 @@ Definitions of the terms used throughout this handbook. Where a term has a dedic
 
 **CMR (Conventional Magnetic Recording).** Hard-drive recording technology with non-overlapping tracks and consistent write performance. The recommended technology for plot storage. *(Chapter 14)*
 
+**Coin type.** A number in the derivation path that separates one chain's addresses from another's. Bitcoin-PoCX has its own registered value (SLIP-44 `1347371864`); new wallets use it, while restore still finds funds under the older Bitcoin coin type `0'`. Invisible in normal use. *(Chapter 5)*
+
 **Coinbase.** The special transaction in each block that pays the block reward. Coinbase rewards must mature before they can be spent. *(Chapters 9, 13)*
 
 **Coinbase maturity.** The waiting period before a newly forged block reward becomes spendable. Until then it shows as *immature*. *(Chapter 9)*
@@ -32,13 +34,17 @@ Definitions of the terms used throughout this handbook. Where a term has a dedic
 
 **Deadline.** The number of seconds a plot would have to wait before being eligible to forge a given block. The smallest deadline on the network wins. Smaller is better. *(Chapter 13)*
 
-**Descriptor (output descriptor).** Bitcoin Core's expression for a whole family of addresses derived from a key, used for watch-only wallets and behind the scenes for ordinary wallets. *(Chapter 5)*
+**Derivation branch.** One of the several address families a single recovery phrase can produce — a combination of address type (SegWit, taproot, legacy) and coin type. Restore scans all of them and imports every branch that holds funds. *(Chapter 5)*
+
+**Descriptor (output descriptor).** A compact expression for a whole family of addresses derived from a key. Used for watch-only wallets, and — in the nodeless wallet — as a way to *import* a wallet by pasting its private descriptors. *(Chapters 5, 26)*
 
 **Difficulty.** A measure of how hard it is to forge a block, adjusted by the network via the base target. *(Chapters 13, 20)*
 
 **Direct I/O.** A setting that bypasses the operating system's file cache when reading or writing plots, often improving performance on large workloads. *(Chapters 15, 22)*
 
 **Effective capacity.** An estimate of how much usable plot space your miner *appears* to have, computed from your recent deadlines rather than from raw drive size. Converges over time toward your true participating capacity. *(Chapters 20, 22)*
+
+**Electrum server.** A lightweight indexer that answers address-history and transaction-broadcast queries for a light wallet. Phoenix's remote mode syncs through an ordered list of Electrum servers (primary plus failovers) instead of a local node. A server can see which addresses you query but cannot spend your funds. *(Chapter 26)*
 
 **External mode.** The node mode in which Phoenix connects to a Bitcoin-PoCX Core instance you run yourself, rather than one it manages. *(Chapter 25)*
 
@@ -70,9 +76,11 @@ Definitions of the terms used throughout this handbook. Where a term has a dedic
 
 **Node.** The Bitcoin-PoCX Core program that connects to the network, downloads and validates the blockchain, and holds the wallet. Phoenix drives a node; it is not itself the node. *(Chapters 2, 6)*
 
+**Nodeless.** See *Remote mode*.
+
 **Nonce.** The smallest meaningful unit of plot data — a 256 KiB structure derived from the plotting address, a seed, and an index. Each nonce contains 4096 scoops. *(Chapter 13)*
 
-**NTP (Network Time Protocol).** The standard service that keeps a computer's clock synchronised. Essential for mining, given Bitcoin-PoCX's 15-second timestamp tolerance. *(Chapters 14, 26)*
+**NTP (Network Time Protocol).** The standard service that keeps a computer's clock synchronised. Essential for mining, given Bitcoin-PoCX's 15-second timestamp tolerance. *(Chapters 14, 27)*
 
 **OpenCL.** The open standard Phoenix's plotter uses to run on GPUs. Requires runtime drivers but no SDK. *(Chapter 17)*
 
@@ -104,6 +112,8 @@ Definitions of the terms used throughout this handbook. Where a term has a dedic
 
 **Regtest.** A local-only test network for development, with instant low-difficulty blocks. Not exposed in Phoenix's wizard; reached via external mode. *(Chapters 4, 25)*
 
+**Remote mode.** The node mode in which Phoenix runs no local node at all — the wallet lives on your computer and syncs over Electrum servers. Fast to start and light on disk; solo mining, the block explorer, and the peers page are unavailable. Also called the *nodeless* or *Electrum* wallet. *(Chapter 26)*
+
 **RPC (Remote Procedure Call).** The interface Phoenix uses to talk to Bitcoin-PoCX Core. *(Chapters 12, 25)*
 
 **Satoshi.** The smallest unit of BTCX; one hundred-millionth of a BTCX. *(Chapter 2)*
@@ -112,11 +122,15 @@ Definitions of the terms used throughout this handbook. Where a term has a dedic
 
 **Seed.** A per-plot value that lets one address have multiple non-overlapping plots without manual coordination. *(Chapter 13)*
 
+**SegWit (Segregated Witness).** The address family Bitcoin-PoCX uses for ordinary and plot addresses. Native SegWit **v0** addresses (BIP-84, `pocx1q…`) are the only kind that can be plot addresses, so only a SegWit wallet can mine or hold a forging assignment. *(Chapters 7, 23)*
+
 **SMART.** Drive self-monitoring data (reallocated sectors, temperature, and so on) used to spot a failing drive early. *(Chapter 14)*
 
 **SMR (Shingled Magnetic Recording).** Hard-drive technology with overlapping tracks that packs more data per platter but collapses under sustained writes. Fine for mining (reads), poison for plotting (writes). *(Chapter 14)*
 
 **Solo mining.** Mining for yourself against the network, keeping the full reward when you win — at the cost of rare, bursty wins for a small miner. *(Chapters 13, 19)*
+
+**Taproot (BIP-86).** A newer address family (`pocx1p…`) that a Phoenix wallet can use for ordinary funds. Taproot addresses can never be plot addresses, so a taproot wallet cannot mine or publish a forging assignment — use a SegWit wallet for mining. *(Chapters 5, 23)*
 
 **Testnet.** A public test network where coins have no value, used for development and experimentation. *(Chapter 4)*
 
@@ -134,7 +148,7 @@ Definitions of the terms used throughout this handbook. Where a term has a dedic
 
 **Watch-only wallet.** A wallet that holds no private keys — it observes addresses or descriptors and reports their balance and history but cannot spend. *(Chapter 5)*
 
-**WIF (Wallet Import Format).** A standard encoding of a single private key, importable into a wallet via Settings. *(Chapter 12)*
+**WIF (Wallet Import Format).** A standard encoding of a single private key. On a Core-backed wallet it can be imported into the active wallet via Settings; in the nodeless wallet, wrapping it as `wpkh(WIF)` imports it as a stand-alone one-address wallet (useful for a vanity or plotting address). *(Chapters 12, 26)*
 
 **Xn.** See *PoW scaling level*.
 

--- a/handbook/chapters/ch29-help.md
+++ b/handbook/chapters/ch29-help.md
@@ -13,7 +13,7 @@ These are the canonical, project-run sources. Bookmark the website — it is the
 | **Whitepaper**     | <https://bitcoin-pocx.org/btcx_whitepaper_eng.pdf>            | The design document behind proof-of-capacity and Bitcoin-PoCX. |
 | **Block explorer** | <https://explorer.bitcoin-pocx.org/>                          | Look up transactions, addresses, and blocks on the live chain. |
 
-> **Tip** — The **block explorer** is the single most useful diagnostic tool outside Phoenix. When a payment seems missing or a transaction is stuck (Chapter 26), looking up the transaction ID on the explorer tells you immediately whether the network has seen it and how many confirmations it has.
+> **Tip** — The **block explorer** is the single most useful diagnostic tool outside Phoenix. When a payment seems missing or a transaction is stuck (Chapter 27), looking up the transaction ID on the explorer tells you immediately whether the network has seen it and how many confirmations it has.
 
 ## Community channels
 
@@ -49,7 +49,7 @@ Whether on a community channel or in a GitHub issue, you will get help faster if
 2. **What you expected to happen.**
 3. **What actually happened** — the exact error message, if any.
 4. **Your platform** — Windows / macOS / Linux / Android, and the Phoenix version (shown in the sidebar).
-5. **A recent log slice** — the last few hundred lines of the relevant log (Chapter 26 explains where to find them via **Settings → Debug & Logs**). The *Copy all* button on the Debug Logs tab gathers your version and platform for you.
+5. **A recent log slice** — the last few hundred lines of the relevant log (Chapter 27 explains where to find them via **Settings → Debug & Logs**). The *Copy all* button on the Debug Logs tab gathers your version and platform for you.
 
 > **Warning** — When sharing logs or screenshots for support, **never include your recovery phrase, and review for anything sensitive.** Logs can contain your addresses (public, but linkable to you); your 24-word phrase must *never* appear anywhere you share. No legitimate helper will ever ask for it, and anyone who does is trying to steal from you (Chapters 1 and 11).
 

--- a/handbook/metadata.yaml
+++ b/handbook/metadata.yaml
@@ -2,7 +2,7 @@
 title: "Phoenix PoCX Wallet"
 subtitle: "User Handbook"
 author: ""
-date: "Version 2.0.5 — July 2026"
+date: "Version 2.1.0 — July 2026"
 
 # Document setup
 documentclass: report


### PR DESCRIPTION
Syncs the user handbook from ~2.0.5 to the 2.1.0 feature set. Docs only — no app code touched. Based on `origin/master` @ `6dd9a77`.

## New chapter
- **Chapter 26 — Running Without a Local Node (Remote Mode)** (`ch25b-remote-node.md`): the nodeless/Electrum wallet — what it is, when to choose it, configuring the ordered Electrum server list (primary + failover, default BTCX server), the trust model (chain verified + keys local ⇒ a server can stall/misreport but cannot steal), the Electrum status indicator, wallet acquisition paths, pool mining, and the remote-mode limits (solo mining, Blocks, Peers disabled; some PSBT compose options unavailable).

## Rewritten
- **Chapter 23 — Phoenix on Android**: from mining-only to a full **wallet + miner**. Nodeless over Electrum, navigation drawer, create/restore/descriptor + `wpkh(WIF)` import, multi-wallet switch/rename/delete, SegWit vs taproot/legacy address types, the one-click "mine to this wallet" flow, and the seed-safety rules (24 words are the only backup; Auto-Backup disabled so the seed never reaches the cloud; device passphrase; hot-wallet model). Mining permissions/foreground-service/wake-lock content retained.

## Updated
- **ch04 / ch12**: remote (Electrum) as a third node mode — first-launch card + settings panel.
- **ch05**: BTCX coin type note; restore branch report (restore imports funds on every derivation branch); pointer to the nodeless flows.
- **ch06**: Electrum status indicator; Blocks/Peers hidden in remote mode.
- **ch08**: Electrum broadcast is now live (was "soon"); remote-mode compose limits.
- **ch02 / ch03**: corrected stale "Android is mining-only" descriptions.
- **ch27 FAQ**: do-I-need-a-node, what is remote mode, phone wallet, why the explorer shows a different balance (change addresses), coin type, descriptor/WIF imports, no cloud backup on Android.
- **ch28 Glossary**: new — Coin type, Derivation branch, Electrum server, Remote mode, SegWit, Taproot, Nodeless; Descriptor and WIF updated.
- **Renumber**: Part V (Troubleshooting/FAQ/Glossary/Help) 26–29 → 27–30 to make room for Chapter 26; all cross-references updated; fixed a pre-existing off-by-one in ch01's help reference. `build.ps1`, `metadata.yaml` (→ 2.1.0), and `BASED-ON.md` updated.

## Notes for the owner
- **Screenshots not captured** for the new remote-mode chapter or the rebuilt Android wallet screens — chapters are prose-only where new. The PDF build is unchanged and still a manual step; not regenerated here.
- `web-wallet/package.json` still reads `2.0.5`; the handbook labels this the 2.1.0 release per the sync brief (noted in `BASED-ON.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp