### PR TITLE
fix(create): verify Next never enables (signal reactivity) + Enter-to-accept on mnemonic entry [2.1.1]

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.spec.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.spec.ts
@@ -1,0 +1,108 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { signal } from '@angular/core';
+
+import { WalletCreateComponent } from './wallet-create.component';
+import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
+
+const WORDS = [
+  'abandon',
+  'ability',
+  'able',
+  'about',
+  'above',
+  'absent',
+  'absorb',
+  'abstract',
+  'absurd',
+  'abuse',
+  'access',
+  'accident',
+];
+
+describe('WalletCreateComponent (verify step Next enable — 2.1.1 regression)', () => {
+  let component: WalletCreateComponent;
+  let fixture: ReturnType<typeof TestBed.createComponent<WalletCreateComponent>>;
+
+  beforeEach(() => {
+    const wallet = {
+      balance: signal(null),
+      network: signal('mainnet'),
+      walletActive: signal(false),
+      initialize: () => Promise.resolve(),
+      refreshWallets: () => Promise.resolve([]),
+      generateMnemonic: () => Promise.resolve(WORDS.join(' ')),
+      create: () => Promise.resolve(undefined),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [WalletCreateComponent],
+      providers: [
+        provideAnimations(),
+        provideRouter([]),
+        { provide: BtcxWalletService, useValue: wallet },
+      ],
+    });
+
+    fixture = TestBed.createComponent(WalletCreateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('enables Next once every verify word is typed (signal recomputes)', async () => {
+    await fixture.whenStable();
+    component.words.set(WORDS);
+
+    // Two positions to confirm, mirroring startVerify()'s output shape.
+    component.checks.set([
+      { index: 0, entered: '' },
+      { index: 2, entered: '' },
+    ]);
+    fixture.detectChanges();
+
+    // Nothing typed yet — the button must be disabled.
+    expect(component.allChecksFilled()).toBeFalse();
+
+    // Simulate the user typing into each field via the change handler that
+    // the template's (ngModelChange) invokes. With the old plain
+    // [(ngModel)]="check.entered" mutation the signal reference never
+    // changed, so allChecksFilled() stayed false forever (the 2.1.0 bug).
+    component.setCheckEntered(0, WORDS[0]);
+    expect(component.allChecksFilled())
+      .withContext('one of two filled — still disabled')
+      .toBeFalse();
+
+    component.setCheckEntered(2, WORDS[2]);
+    expect(component.allChecksFilled()).withContext('both filled — Next enables').toBeTrue();
+  });
+
+  it('verify() reads the words entered through setCheckEntered and advances', async () => {
+    await fixture.whenStable();
+    component.words.set(WORDS);
+    component.checks.set([
+      { index: 1, entered: '' },
+      { index: 4, entered: '' },
+    ]);
+
+    component.setCheckEntered(1, WORDS[1].toUpperCase()); // case/trim tolerated
+    component.setCheckEntered(4, `  ${WORDS[4]}  `);
+    component.verify();
+
+    expect(component.verifyError()).toBeFalse();
+    expect(component.step()).toBe('protect');
+  });
+
+  it('verify() flags a mismatch and does not advance', async () => {
+    await fixture.whenStable();
+    component.words.set(WORDS);
+    component.step.set('verify');
+    component.checks.set([{ index: 0, entered: '' }]);
+
+    component.setCheckEntered(0, 'wrongword');
+    component.verify();
+
+    expect(component.verifyError()).toBeTrue();
+    expect(component.step()).toBe('verify');
+  });
+});

--- a/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.ts
@@ -127,7 +127,8 @@ type CreateStep = 'name' | 'phrase' | 'verify' | 'protect';
               <mat-label>{{ 'word_number' | i18n: { number: check.index + 1 } }}</mat-label>
               <input
                 matInput
-                [(ngModel)]="check.entered"
+                [ngModel]="check.entered"
+                (ngModelChange)="setCheckEntered(check.index, $event)"
                 autocomplete="off"
                 autocapitalize="none"
                 spellcheck="false"
@@ -466,6 +467,17 @@ export class WalletCreateComponent implements OnInit {
     this.checks.set([...indices].sort((a, b) => a - b).map(index => ({ index, entered: '' })));
     this.verifyError.set(false);
     this.step.set('verify');
+  }
+
+  /**
+   * Record a typed verify-word by replacing the checks array with a fresh
+   * copy (new array + new object). Mutating `check.entered` in place would
+   * leave the signal's reference unchanged, so the `allChecksFilled`
+   * computed would never recompute and the Next button would stay disabled
+   * forever — the 2.1.0 create-wallet showstopper.
+   */
+  setCheckEntered(index: number, value: string): void {
+    this.checks.update(arr => arr.map(c => (c.index === index ? { ...c, entered: value } : c)));
   }
 
   verify(): void {

--- a/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
+++ b/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
@@ -1,5 +1,6 @@
-import { Component, inject, input, output } from '@angular/core';
+import { Component, ElementRef, inject, input, output, viewChildren } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import type { MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
@@ -56,17 +57,21 @@ export interface MnemonicEntryState {
         <div class="word-input-chip">
           <span class="word-index">{{ i + 1 }}</span>
           <input
+            #wordInput
+            #trigger="matAutocompleteTrigger"
             class="word-input"
             [(ngModel)]="mnemonicWords[i]"
             [disabled]="disabled()"
             [matAutocomplete]="auto"
             (input)="updateSuggestions(i, mnemonicWords[i])"
+            (keydown.enter)="onWordEnter(i, $event, trigger)"
             (blur)="validateWord(i)"
             autocomplete="off"
             spellcheck="false"
           />
           <mat-autocomplete
             #auto="matAutocomplete"
+            [autoActiveFirstOption]="true"
             (optionSelected)="onWordSelected(i, $event.option.value)"
           >
             @for (suggestion of wordSuggestions[i]; track suggestion) {
@@ -209,6 +214,9 @@ export class MnemonicEntryComponent {
   readonly disabled = input(false);
   readonly changed = output<MnemonicEntryState>();
 
+  /** The per-word `<input>` elements, in grid order, for focus advancing. */
+  private readonly wordInputs = viewChildren<ElementRef<HTMLInputElement>>('wordInput');
+
   wordCount: 12 | 24 = 24;
   mnemonicWords: string[] = new Array(24).fill('');
   wordSuggestions: string[][] = new Array(24).fill(null).map(() => []);
@@ -243,6 +251,47 @@ export class MnemonicEntryComponent {
     this.wordSuggestions[index] = [];
     this.wordErrors[index] = false;
     this.emitState();
+    // Satchel-style: committing a word jumps focus to the next field, so
+    // the whole phrase can be entered without reaching for the mouse.
+    this.focusNext(index);
+  }
+
+  /**
+   * Enter-to-accept (Satchel's SeedForm behaviour). With
+   * `autoActiveFirstOption` the first suggestion is always highlighted, so
+   * Angular Material selects it on Enter and fires `optionSelected`
+   * (→ `onWordSelected`, which advances). This raw handler covers the two
+   * cases Material's selection does NOT: when the autocomplete panel is
+   * closed but the typed value is already an exact BIP39 word, commit it and
+   * advance; otherwise keep Enter from submitting an enclosing form or doing
+   * nothing. It never double-advances — if Material already selected the
+   * highlighted option for this keypress (`defaultPrevented`), or the panel
+   * is open with a highlighted option (Material will select it), we bail.
+   */
+  onWordEnter(index: number, event: Event, trigger: MatAutocompleteTrigger): void {
+    if (event.defaultPrevented) return;
+    if (trigger.panelOpen && trigger.activeOption) return;
+    const typed = this.mnemonicWords[index]?.trim().toLowerCase();
+    if (typed && this.descriptorService.getWordlist().includes(typed)) {
+      event.preventDefault();
+      this.mnemonicWords[index] = typed;
+      this.wordSuggestions[index] = [];
+      this.wordErrors[index] = false;
+      this.emitState();
+      this.focusNext(index);
+    }
+  }
+
+  /** Move focus to the next word input; a no-op on the last field. */
+  private focusNext(index: number): void {
+    const next = this.wordInputs()[index + 1];
+    if (!next) return;
+    // Defer past Material's own post-selection focus handling so our move
+    // to the next field wins instead of snapping back to the current one.
+    setTimeout(() => {
+      next.nativeElement.focus();
+      next.nativeElement.select();
+    });
   }
 
   validateWord(index: number): void {


### PR DESCRIPTION
## 2.1.1 hotfix

### Bug 1 (critical) — create-wallet was impossible
On the create-wallet **verify** step, the Next button never became clickable, even with the words entered correctly — no new wallet could be created in 2.1.0.

**Root cause:** the confirmation inputs used `[(ngModel)]="check.entered"`, mutating a property of an object held *inside* the `checks` signal's array. The array reference never changed, so the signal never notified and the `allChecksFilled` computed never recomputed — Next stayed `disabled` forever.

**Fix:** one-way `[ngModel]` + `(ngModelChange)="setCheckEntered(check.index, $event)"`, where `setCheckEntered` rebuilds the array (new array + new object) via `checks.update(...)`. The computed now recomputes as the user types and Next enables. `verify()` reads from the same signal and sees the typed words.

**Proof:** new `wallet-create.component.spec.ts` — enters the correct words via `setCheckEntered` and asserts `allChecksFilled()` flips to `true`. It **fails** against the old in-place mutation (`Expected false to be true`) and **passes** after the fix. Full suite: 82/82 green.

Swept the codebase for the same pattern (`[(ngModel)]` on a property of an object in a `signal<...[]>` gated by a computed): this was the only instance. The `settings.component.ts` `[(ngModel)]` bindings target a plain getter object / plain field (not a signal-held array element), so they are not affected.

### Bug 2 (UX) — Satchel-style Enter-to-accept on mnemonic entry
In the shared `mnemonic-entry` component (restore + import), pressing **Enter** while typing a word now commits the highlighted BIP39 suggestion and advances focus to the next word field.

- `[autoActiveFirstOption]="true"` highlights the first option; Material selects it on Enter → `optionSelected` → `onWordSelected`, which now advances focus.
- A raw `(keydown.enter)` handler covers what Material's selection doesn't: an exact typed BIP39 word with the panel closed commits + advances; otherwise Enter is prevented from submitting a form / doing nothing. Guards on `event.defaultPrevented` and an open panel with a highlighted option prevent double-advance.
- Focus advance is deferred past Material's own post-selection focus; the last field is a no-op. Works for both 12- and 24-word layouts.

Note: the component had no pre-existing paste-whole-phrase or space-commit behavior to preserve; only Enter-to-accept was added.

### Verification
- `npm ci`, `npm run build` (prod) ✅ (warnings pre-existing, unrelated)
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test:ci` ✅ 82/82 (incl. new regression spec)

Bug 1's fix is proven by the spec (button-enable logic). Bug 2 needs an on-device check (autocomplete/focus behavior can't be driven headlessly here): confirm Enter commits the highlighted word and jumps to the next field, an exact typed word with the panel closed also advances, mouse-click selection advances, and Enter on the last field is a harmless no-op.

No Rust changes. Version intentionally **not** bumped (release cut handled separately). Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp
