### PR TITLE
chore: release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,68 +1,11 @@
-# Phoenix PoCX Wallet 2.1.0
+# Phoenix PoCX Wallet 2.1.1
 
-The biggest release since 2.0: Phoenix now runs **without a local node**, and
-**Android becomes a full wallet** — not just a miner.
+A quick fix release on top of 2.1.0.
 
-## Headline features
+## Fixed
+- **Wallet creation was blocked** — on the recovery-phrase confirmation step, the **Next** button stayed disabled even after the words were entered correctly, so new wallets couldn't be created. Fixed. (If you're on 2.1.0, please update.)
 
-### Remote (Electrum) mode — run without a full node
-A third node mode alongside *managed* and *external*: **remote**. Phoenix
-keeps a local wallet (BDK) and syncs over Electrum servers you configure — no
-bitcoind required. Every desktop page works in this mode: send, receive,
-history, fee control, and — client-side, needing no node — **forging
-assignments** and the **Transaction Builder / PSBT** flow. Ships with a
-default BTCX Electrum server so it works out of the box.
+## Improved
+- **Faster phrase entry** — when typing your recovery phrase, pressing **Enter** now accepts the highlighted autocomplete suggestion and jumps to the next word.
 
-### Android: a full wallet, not just a miner
-Android used to be mining-only. Now it's a complete wallet **plus** mining:
-- **One-click mine-to-your-own-wallet**: create a wallet on first launch and
-  the mining setup uses *your* address automatically — no more copy-pasting.
-- Full send / receive / transaction history / contacts / forging assignments,
-  in a Phoenix-styled mobile UI with a navigation drawer.
-- Runs entirely nodeless over Electrum.
-
-### Multiple named wallets
-Create, name, switch, rename, and delete multiple wallets (desktop and
-Android). Delete is trash-based and recoverable from your seed.
-
-### More ways to get your wallet in
-- **Create** — new wallets use a 24-word recovery phrase.
-- **Restore** — checks segwit-v0 and taproot branches (and legacy paths) so
-  funds are found wherever they are; offers to open both when a seed has
-  history on more than one.
-- **Import a descriptor** — paste one or two descriptors (`wpkh`/`tr`); the
-  change branch is derived for you.
-- **Import a `wpkh(WIF)` single-address wallet** — for vanity/plot addresses;
-  change returns to the same address, and it can mine and assign.
-
-### Registered coin type
-BTCX now has a registered **SLIP-44 coin type (1347371864)**. New wallets
-derive at it; restore still finds funds on older (coin-type-0) paths, so
-existing seeds keep working with nothing to do.
-
-## Security
-- **Android backups disabled** — the seed can never reach Google Drive or a
-  device-transfer; your recovery phrase is the sole backup.
-- **Electrum server verification** — the wallet checks a server is on the
-  right chain before trusting it, and refuses to sync history from a pruned
-  server rather than falsely reporting a wallet as empty.
-- **Abnormal-fee guard** — an extra confirmation if a server reports an
-  unusually high fee.
-- A full adversarial security audit of the wallet stack was completed for
-  this release; see `docs/SECURITY-AUDIT-2026-07.md`.
-
-## Also in this release (previously unreleased since 2.0.4)
-- **Transaction Builder (PSBT)** — compose, sign, coordinate, and broadcast
-  partially-signed transactions; broadcast via a local node or Electrum.
-- **N-of-M multisig wallet wizard**.
-- Handbook updates and full localization across 25 languages.
-
-## Under the hood
-The wallet engine was extracted into a shared, reusable Rust stack (the
-`btcx` crates — chain params, keys, seed storage, Electrum client, BDK
-wallet) so desktop, Android, and the Satchel swap app share one audited
-implementation. Faster transaction loading for large wallets. Numerous UI
-refinements across eight iteration rounds.
-
----
-*Draft build for team QA. Not for public distribution until validated.*
+Everything else is unchanged from 2.1.0 — see those notes for the full feature set (remote/Electrum mode, full Android wallet, multi-wallet, PSBT builder, multisig, and more).

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-wallet",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-pocx"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "bdk_wallet",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-pocx"
-version = "2.1.0"
+version = "2.1.1"
 description = "Phoenix PoCX Wallet - Bitcoin-PoCX Desktop Wallet"
 authors = ["The Proof of Capacity Consortium <development@pocx.io>"]
 license = "GPL-3.0"

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phoenix PoCX Wallet",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "identifier": "org.pocx.phoenix",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Patch release: fixes the 2.1.0 blocker where wallet creation could not complete (verify-step Next never enabled), plus Enter-to-accept on mnemonic entry. Merge + tag v2.1.1 to cut the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp