### PR TITLE
fix(fees): 0.001 sat/vB resolution + always-3-decimal display across all fee surfaces (#110)

### DIFF
--- a/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
+++ b/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
@@ -626,7 +626,7 @@ interface WalletAddress {
                 @if (option.label === 'fee_custom') {
                   <mat-icon class="custom-icon">tune</mat-icon>
                 } @else if (option.feeRate !== null) {
-                  <span class="fee-rate">{{ option.feeRate }} sat/vB</span>
+                  <span class="fee-rate">{{ option.feeRate | number: '1.3-3' }} sat/vB</span>
                   <span class="fee-time">{{ option.timeEstimate }}</span>
                 } @else {
                   <span class="fee-rate">--</span>
@@ -646,7 +646,7 @@ interface WalletAddress {
                 [(ngModel)]="customFeeRate"
                 (ngModelChange)="onCustomFeeChange()"
                 min="1"
-                step="1"
+                step="0.001"
                 autocomplete="off"
               />
             </mat-form-field>
@@ -1529,15 +1529,16 @@ export class ForgingAssignmentComponent implements OnInit, OnDestroy {
         for (const option of this.feeOptions) {
           if (option.label === 'fee_custom') continue;
           const rate = bySpeed[option.label];
-          option.feeRate = rate != null ? Math.max(1, Math.round(rate)) : null;
+          // floor stays (hard-coded 1); apply it at 0.001 resolution, no integer rounding
+          option.feeRate = rate != null ? Math.max(1, Math.round(rate * 1000) / 1000) : null;
         }
       } else {
         for (const option of this.feeOptions) {
           if (option.label === 'fee_custom') continue;
           const result = await this.blockchainRpc.estimateSmartFee(option.blocks);
           if (result.feerate) {
-            // feerate is in BTC/kvB, convert to sat/vB
-            option.feeRate = Math.round((result.feerate * 100000000) / 1000);
+            // feerate is in BTC/kvB, convert to sat/vB (0.001 resolution)
+            option.feeRate = Math.round(result.feerate * 100000000) / 1000;
           }
         }
       }

--- a/web-wallet/src/app/features/mobile-wallet/pages/assignment/wallet-assignment.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/assignment/wallet-assignment.component.ts
@@ -350,7 +350,7 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
               @if (option.label === 'fee_custom') {
                 <mat-icon class="custom-icon">tune</mat-icon>
               } @else if (option.feeRate !== null) {
-                <span class="fee-rate">{{ option.feeRate }} sat/vB</span>
+                <span class="fee-rate">{{ option.feeRate | number: '1.3-3' }} sat/vB</span>
               } @else {
                 <span class="fee-rate">--</span>
               }
@@ -367,7 +367,7 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
               [(ngModel)]="customFeeRate"
               (ngModelChange)="onCustomFeeChange()"
               min="1"
-              step="1"
+              step="0.001"
               autocomplete="off"
             />
           </mat-form-field>
@@ -847,7 +847,8 @@ export class WalletAssignmentComponent implements OnInit {
       for (const option of this.feeOptions) {
         if (option.label === 'fee_custom') continue;
         const rate = byLabel[option.label];
-        option.feeRate = rate != null ? Math.max(1, Math.round(rate)) : null;
+        // floor stays (hard-coded 1); apply it at 0.001 resolution, no integer rounding
+        option.feeRate = rate != null ? Math.max(1, Math.round(rate * 1000) / 1000) : null;
       }
     } catch (error) {
       console.error('Failed to load fee estimates:', error);

--- a/web-wallet/src/app/features/mobile-wallet/pages/send/wallet-send.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/send/wallet-send.component.ts
@@ -291,7 +291,7 @@ const SANE_PRESET_MAX_SAT_VB = 200;
                 @if (preset.target !== null) {
                   <span class="fee-rate">
                     @if (presetRate(preset) !== null) {
-                      {{ presetRate(preset) | number: '1.0-2' }} sat/vB
+                      {{ presetRate(preset) | number: '1.3-3' }} sat/vB
                     } @else {
                       --
                     }
@@ -309,7 +309,7 @@ const SANE_PRESET_MAX_SAT_VB = 200;
                 type="number"
                 [(ngModel)]="customFeeRate"
                 [min]="minFeeRate()"
-                step="0.1"
+                step="0.001"
                 autocomplete="off"
               />
             </mat-form-field>

--- a/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
@@ -427,7 +427,7 @@ const UTXO_PAGE_SIZE = 10;
                   <span><mat-icon class="tune-icon">tune</mat-icon></span>
                 } @else {
                   <span>{{
-                    chip.rate !== null ? (chip.rate | number: '1.0-1') + ' sat/vB' : '--'
+                    chip.rate !== null ? (chip.rate | number: '1.3-3') + ' sat/vB' : '--'
                   }}</span>
                 }
               </button>
@@ -436,7 +436,7 @@ const UTXO_PAGE_SIZE = 10;
           @if (selectedFee?.custom) {
             <mat-form-field appearance="outline" class="custom-fee-field">
               <mat-label>{{ 'fee_rate' | i18n }} (sat/vB)</mat-label>
-              <input matInput type="number" min="0.1" step="0.1" [(ngModel)]="customFeeRate" />
+              <input matInput type="number" min="0.1" step="0.001" [(ngModel)]="customFeeRate" />
             </mat-form-field>
           }
         </div>
@@ -1633,15 +1633,15 @@ export class PsbtComposeComponent implements OnInit {
         this.feeChips.forEach((chip, i) => {
           if (chip.custom) return;
           const rate = bySpeed[i];
-          chip.rate = rate != null ? Math.round(rate * 10) / 10 : null;
+          chip.rate = rate != null ? Math.round(rate * 1000) / 1000 : null;
         });
       } else {
         for (const chip of this.feeChips) {
           if (chip.custom) continue;
           const result = await this.blockchainRpc.estimateSmartFee(chip.blocks);
           if (result.feerate) {
-            // BTC/kvB → sat/vB, one decimal
-            chip.rate = Math.round((result.feerate * 1e8) / 100) / 10;
+            // BTC/kvB → sat/vB, 0.001 resolution
+            chip.rate = Math.round(result.feerate * 1e8) / 1000;
           }
         }
       }

--- a/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
+++ b/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
@@ -270,7 +270,7 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
                 <div class="stat-key">{{ 'psbt_fee_rate' | i18n }}</div>
                 <div class="stat-value mono">
                   @if (document.feeRate !== undefined) {
-                    {{ document.feeRate | number: '1.0-1' }}
+                    {{ document.feeRate | number: '1.3-3' }}
                     <small>sat/vB · {{ document.vsize }} vB</small>
                   } @else {
                     — <small>{{ 'psbt_unknown' | i18n }}</small>

--- a/web-wallet/src/app/features/send/pages/send/send.component.ts
+++ b/web-wallet/src/app/features/send/pages/send/send.component.ts
@@ -254,7 +254,7 @@ const SANE_PRESET_MAX_SAT_VB = 200;
                       @if (option.label === 'fee_custom') {
                         <mat-icon class="custom-icon">tune</mat-icon>
                       } @else if (option.feeRate !== null) {
-                        <span class="fee-rate">{{ option.feeRate | number: '1.0-1' }} sat/vB</span>
+                        <span class="fee-rate">{{ option.feeRate | number: '1.3-3' }} sat/vB</span>
                         <span class="fee-time">{{ option.timeEstimate }}</span>
                       } @else {
                         <span class="fee-rate">--</span>
@@ -275,7 +275,7 @@ const SANE_PRESET_MAX_SAT_VB = 200;
                       [(ngModel)]="customFeeRate"
                       (ngModelChange)="onCustomFeeChange()"
                       min="0.1"
-                      step="0.1"
+                      step="0.001"
                       autocomplete="off"
                     />
                   </mat-form-field>
@@ -1146,15 +1146,15 @@ export class SendComponent implements OnInit, OnDestroy {
         this.feeOptions.forEach((option, i) => {
           const rate = bySpeed[i];
           if (rate != null) {
-            option.feeRate = Math.round(rate * 10) / 10;
+            option.feeRate = Math.round(rate * 1000) / 1000;
           }
         });
       } else {
         for (const option of this.feeOptions) {
           const result = await this.blockchainRpc.estimateSmartFee(option.blocks);
           if (result.feerate) {
-            // feerate is in BTC/kvB, convert to sat/vB (one decimal)
-            option.feeRate = Math.round((result.feerate * 100000000) / 100) / 10;
+            // feerate is in BTC/kvB, convert to sat/vB (0.001 resolution)
+            option.feeRate = Math.round(result.feerate * 100000000) / 1000;
           }
         }
       }

--- a/web-wallet/src/app/features/transactions/components/fee-bump-dialog/fee-bump-dialog.component.ts
+++ b/web-wallet/src/app/features/transactions/components/fee-bump-dialog/fee-bump-dialog.component.ts
@@ -107,7 +107,7 @@ interface FeeOption {
                   @if (option.label === 'fee_custom') {
                     <mat-icon class="custom-icon">tune</mat-icon>
                   } @else if (option.feeRate !== null) {
-                    <span class="fee-rate">{{ option.feeRate | number: '1.0-0' }} sat/vB</span>
+                    <span class="fee-rate">{{ option.feeRate | number: '1.3-3' }} sat/vB</span>
                     <span class="fee-time">{{ option.timeEstimate }}</span>
                   } @else {
                     <span class="fee-rate">--</span>
@@ -128,7 +128,7 @@ interface FeeOption {
                   [(ngModel)]="customFeeRate"
                   (ngModelChange)="onCustomFeeChange()"
                   min="1"
-                  step="1"
+                  step="0.001"
                   autocomplete="off"
                 />
               </mat-form-field>
@@ -448,8 +448,8 @@ export class FeeBumpDialogComponent implements OnInit {
         if (option.label === 'fee_custom') continue;
         const result = await this.blockchainRpc.estimateSmartFee(option.blocks);
         if (result.feerate) {
-          // feerate is in BTC/kvB, convert to sat/vB
-          option.feeRate = Math.round((result.feerate * 100000000) / 1000);
+          // feerate is in BTC/kvB, convert to sat/vB (0.001 resolution)
+          option.feeRate = Math.round(result.feerate * 100000000) / 1000;
         }
       }
       // Default to normal fee


### PR DESCRIPTION
Closes #110.

## Problem

Bitcoin Core's `estimatesmartfee` and the Electrum/BDK backend both carry fractional sat/vB precision (0.001 sat/vB resolution), but every fee surface was rounding it away to 0.1 or whole sat/vB. An estimate of `1.053 sat/vB` was shown/used as `1`, `1.0`, or `1.1` depending on the screen — up to ~4.5% overpay on Send/PSBT, and fee-bump/assignment rates that could land **below** the estimate (enough to fail `bumpfee`'s incremental-fee check). Desktop and mobile also disagreed on decimals and floor handling.

## Changes

Aligns **Send + forging assignments + PSBT + fee-bump**, desktop **and** mobile:

- **Conversion (8 sites)** — 0.001 resolution on both paths:
  - Core-RPC: `Math.round(feerate * 1e8) / 1000` (lossless — sat/kvB is an integer count)
  - Electrum: `Math.round(rate * 1000) / 1000`
  - The two assignment sites keep their hard-coded floor of `1` but apply it at 0.001 resolution without integer rounding.
- **Display** — always 3 decimals via `number: '1.3-3'` (the two assignment chips were rendering the raw value).
- **Custom inputs** — `step="0.001"`, keeping `type="number"` to match the amount field (`min`/floor unchanged). Includes the fee-bump dialog's custom input, which the issue's Section-C table omitted but which would otherwise show a 3-decimal rate under a whole-number stepper.

## Out of scope (unchanged, per issue)

- Floor **values** and **semantics** (incl. the assignment floor of `1` vs `minSatPerVb`).
- App-wide locale number formatting (German `1,000`) — no `LOCALE_ID`/`registerLocaleData` today, so pipes render `1.000` with a dot; tracked separately.

## Notes

- **Rust verified, no change needed:** `btcx_wallet_fee_estimates` already returns fractional sat/vB (`sat_per_kvb as f64 / 1000.0`).
- The high-fee **warning** strings (`send-confirm-dialog`, mobile `wallet-send`) were intentionally left at `1.0-2` — not in the issue's inventory, and 0.001 precision is meaningless on a "fee is unusually high" warning.

## Test

- `ng build` passes clean (no errors; only pre-existing NG8102 warnings on the untouched high-fee-warning lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)