### PR TITLE
fix(dashboard): stop network & recent-tx cards flickering on every refresh

### DIFF
--- a/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -75,7 +75,7 @@ import {
           </mat-card-title>
         </mat-card-header>
         <mat-card-content>
-          @if (isLoadingBlockchain()) {
+          @if (isLoadingBlockchain() && !hasLoadedBlockchain()) {
             <div class="loading-state">
               <mat-spinner diameter="24"></mat-spinner>
               <span>{{ 'loading_blockchain_info' | i18n }}</span>
@@ -226,7 +226,7 @@ import {
           </mat-card-title>
         </mat-card-header>
         <mat-card-content>
-          @if (isLoadingTransactions()) {
+          @if (isLoadingTransactions() && !hasLoadedTransactions()) {
             <div class="loading-state">
               <mat-spinner diameter="24"></mat-spinner>
               <span>{{ 'loading_transactions' | i18n }}</span>
@@ -964,6 +964,13 @@ export class DashboardComponent implements AfterViewInit {
   // Loading states derived from services
   isLoadingBlockchain = computed(() => this.blockchainState.isLoading());
   isLoadingTransactions = computed(() => this.walletService.isLoading());
+
+  // True once each source has completed at least one refresh. Used to gate the
+  // loading spinner so it only shows on the initial load — background refreshes
+  // (15s/30s poll or btcx-wallet:sync) keep the existing content on screen
+  // instead of flashing the spinner and remounting the card body.
+  hasLoadedBlockchain = computed(() => this.blockchainState.lastUpdated() !== null);
+  hasLoadedTransactions = computed(() => this.walletService.lastUpdated() !== null);
 
   // Blockchain info - wrap service signals for template compatibility
   blockchainInfo = computed(() => ({


### PR DESCRIPTION
## Problem

The **network status** and **recent transactions** cards on the Dashboard visibly flicker on every refresh cycle (network poll 15s; tx poll 30s in Core mode, or every `btcx-wallet:sync` ~15s tick in remote mode).

Root cause: each `refresh()` unconditionally toggles `isLoading` `true`→`false` every cycle, and both cards render the spinner in a mutually-exclusive `@if/@else` against the data. So the whole populated card body is unmounted and replaced by the spinner, then remounted, on every tick.

- Network: `dashboard.component.ts` `@if (isLoadingBlockchain())`, toggled at `blockchain-state.service.ts` refresh.
- Tx: `@if (isLoadingTransactions())`, toggled at `wallet.service.ts` refresh.

The `@for` already has a stable `track` (txid+vout+category), so this was **not** a trackBy issue — it was the top-level loading-branch swap.

## Fix

Gate each spinner on the **initial load only** — `isLoading() && !hasLoaded()` — using two new computeds backed by each service's `lastUpdated` signal (null until the first successful refresh):

- `hasLoadedBlockchain = blockchainState.lastUpdated() !== null`
- `hasLoadedTransactions = walletService.lastUpdated() !== null`

Periodic refreshes now update the cards in place instead of flashing the spinner. Empty-wallet case is handled: `lastUpdated` is set after the first refresh even with zero transactions, so the empty state shows steadily rather than re-flickering.

Balance card was never affected and is untouched.

## Test

Verified live via `tauri:dev`: spinner shows once on initial load, then both cards update in place with no flicker across refresh cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)