### PR TITLE
feat(mining): capacity sparkline = live trailing-window time-series (kill left-edge volatility)

### DIFF
--- a/web-wallet/src/app/mining/models/mining.models.ts
+++ b/web-wallet/src/app/mining/models/mining.models.ts
@@ -807,76 +807,47 @@ export interface CapacityCache {
   count: number; // Number of valid deadlines
   qualitySum: number; // Sum of qualityRaw for all valid deadlines
   effectiveCapacity: number; // Calculated TiB (n * GENESIS_BASE_TARGET / qualitySum)
-  history: CapacityDataPoint[]; // Sparkline chart data
   lastDeadlineTimestamp: number; // For detecting new data
 }
 
 /**
- * Generate effective capacity history for sparkline chart
- *
- * Uses cumulative averaging with a sliding window of the last N deadlines.
- * Each chart point shows effective capacity calculated from all data points
- * up to that moment (capped at maxDataPoints).
- *
- * Optimized with prefix sums for O(n) instead of O(n²) complexity.
- *
- * Note: Backend already guarantees one best deadline per chain+height,
- * so no deduplication needed here.
- *
- * @param deadlines Array of DeadlineEntry
- * @param maxDataPoints Maximum deadlines to include in lookback (default 720)
- * @param maxChartPoints Maximum chart points to return (default 50)
- * @returns Array of CapacityDataPoint for sparkline, oldest to newest
+ * Maximum number of points retained in the effective-capacity time-series
+ * that backs the sparkline (the chart "store"). One point is appended per
+ * settled block, so 720 points ≈ 24h with a single chain (proportionally
+ * less with more chains). In-memory only: the series survives navigation but
+ * resets on app restart.
  */
-export function generateEffectiveCapacityHistory(
-  deadlines: DeadlineEntry[],
-  maxDataPoints: number = MAX_CAPACITY_DATAPOINTS,
-  maxChartPoints: number = 50
+export const MAX_CAPACITY_SERIES_POINTS = 720;
+
+/**
+ * Downsample a capacity time-series to at most `maxPoints` for rendering,
+ * preserving chronological order and always keeping the first and last
+ * points.
+ *
+ * Each stored point is already a full trailing-window average (smooth by
+ * construction — that is what removes the old cumulative-curve volatility),
+ * so uniform striding preserves the line's shape without hiding real
+ * movement; no min/max decimation is needed.
+ *
+ * @param points Series oldest→newest
+ * @param maxPoints Maximum points to return (default 60)
+ * @returns Downsampled series, oldest→newest
+ */
+export function downsampleCapacitySeries(
+  points: CapacityDataPoint[],
+  maxPoints = 60
 ): CapacityDataPoint[] {
-  if (deadlines.length === 0) return [];
+  if (points.length <= maxPoints) return points;
 
-  // Sort by timestamp ascending (oldest first)
-  const sorted = [...deadlines].sort((a, b) => a.timestamp - b.timestamp);
-
-  // Cap at maxDataPoints (take most recent)
-  const capped =
-    sorted.length > maxDataPoints ? sorted.slice(sorted.length - maxDataPoints) : sorted;
-
-  if (capped.length === 0) return [];
-
-  // Build prefix sums in single pass: O(n)
-  const prefixQualitySum = new Array<number>(capped.length);
-  let runningSum = 0;
-  for (let i = 0; i < capped.length; i++) {
-    runningSum += capped[i].qualityRaw;
-    prefixQualitySum[i] = runningSum;
-  }
-
-  // Determine which indices to sample for chart points
-  const step = Math.max(1, Math.floor(capped.length / maxChartPoints));
-  const sampledIndices: number[] = [];
-  for (let i = 0; i < capped.length; i += step) {
-    sampledIndices.push(i);
-  }
-  // Always include the last point
-  if (sampledIndices[sampledIndices.length - 1] !== capped.length - 1) {
-    sampledIndices.push(capped.length - 1);
-  }
-
-  // Calculate cumulative capacity at each sampled point using prefix sums: O(1) per point
+  const step = Math.ceil(points.length / maxPoints);
   const result: CapacityDataPoint[] = [];
-
-  for (const idx of sampledIndices) {
-    const count = idx + 1;
-    const qualitySum = prefixQualitySum[idx];
-    if (qualitySum > 0) {
-      const capacity = (count * GENESIS_BASE_TARGET) / qualitySum;
-      result.push({
-        timestamp: capped[idx].timestamp,
-        capacity,
-      });
-    }
+  for (let i = 0; i < points.length; i += step) {
+    result.push(points[i]);
   }
-
+  // Always land the line on the most recent point ("Now").
+  const last = points[points.length - 1];
+  if (result[result.length - 1] !== last) {
+    result.push(last);
+  }
   return result;
 }

--- a/web-wallet/src/app/mining/services/mining.service.ts
+++ b/web-wallet/src/app/mining/services/mining.service.ts
@@ -41,9 +41,11 @@ import {
   MinerRuntimeState,
   // Capacity calculation types
   CapacityCache,
+  CapacityDataPoint,
   GENESIS_BASE_TARGET,
   MAX_CAPACITY_DATAPOINTS,
-  generateEffectiveCapacityHistory,
+  MAX_CAPACITY_SERIES_POINTS,
+  downsampleCapacitySeries,
   formatCapacity,
 } from '../models/mining.models';
 import { PlotPlanService } from './plot-plan.service';
@@ -137,7 +139,6 @@ export class MiningService {
   private _isMinerListening = false;
   private _minerUnlisteners: UnlistenFn[] = [];
   private _minerInitialized = false; // First start flag for miner
-  private readonly _capacityChartVersion = signal(0); // Bumped on scan finish to trigger chart update
   private readonly _capacityDeadlines = signal<DeadlineEntry[]>([]); // Snapshot updated only on scan finish
 
   // Capacity calculation cache (survives navigation, updated incrementally on scan finish)
@@ -145,9 +146,15 @@ export class MiningService {
     count: 0,
     qualitySum: 0,
     effectiveCapacity: 0,
-    history: [],
     lastDeadlineTimestamp: 0,
   });
+
+  // Effective-capacity time-series backing the sparkline (the chart "store").
+  // One point is appended per settled block from the current trailing-window
+  // estimate, so the chart is a real history of the estimate rather than a
+  // per-render cumulative curve — this is what removes the left-edge flicker.
+  // In-memory: survives navigation, resets on app restart.
+  private readonly _capacitySeries = signal<CapacityDataPoint[]>([]);
 
   // Public computed values
   readonly state = this._state.asReadonly();
@@ -178,7 +185,6 @@ export class MiningService {
   readonly minerCurrentBlock = computed(() => this._minerState().currentBlock);
   readonly minerScanProgress = computed(() => this._minerState().scanProgress);
   readonly minerDeadlines = computed(() => this._minerState().recentDeadlines);
-  readonly capacityChartVersion = this._capacityChartVersion.asReadonly();
   readonly capacityDeadlines = this._capacityDeadlines.asReadonly(); // Snapshot for chart (updates on scan finish)
 
   // Cached capacity calculations (survive navigation)
@@ -188,7 +194,7 @@ export class MiningService {
     const tib = this._capacityCache().effectiveCapacity;
     return tib > 0 ? formatCapacity(tib) : '--';
   });
-  readonly capacityHistory = computed(() => this._capacityCache().history);
+  readonly capacityHistory = computed(() => downsampleCapacitySeries(this._capacitySeries()));
 
   // Activity logs (survives navigation, auto-cleanup of entries > 1 day old)
   readonly activityLogs = this._activityLogs.asReadonly();
@@ -1531,32 +1537,37 @@ export class MiningService {
         count: 0,
         qualitySum: 0,
         effectiveCapacity: 0,
-        history: [],
         lastDeadlineTimestamp: latestTimestamp,
       });
       return;
     }
 
-    // Calculate totals (qualityRaw = 0 is valid - instant forge)
+    // Trailing-window estimate over the backend-bounded deadline set
+    // (720/chain). qualityRaw = 0 is valid (instant forge).
     const count = settled.length;
     const qualitySum = settled.reduce((acc, d) => acc + d.qualityRaw, 0);
     const effectiveCapacity = qualitySum > 0 ? (count * GENESIS_BASE_TARGET) / qualitySum : 0;
-
-    // Get enabled chain count for max data points
-    const config = this._state()?.config;
-    const chainCount = Math.max(1, config?.chains.filter(c => c.enabled).length ?? 1);
-    const maxDataPoints = chainCount * MAX_CAPACITY_DATAPOINTS;
-
-    // Generate history (uses optimized prefix sum algorithm)
-    const history = generateEffectiveCapacityHistory(settled, maxDataPoints, 50);
 
     this._capacityCache.set({
       count,
       qualitySum,
       effectiveCapacity,
-      history,
       lastDeadlineTimestamp: latestTimestamp,
     });
+
+    // Append this estimate to the sparkline series. Because the value above is
+    // already a full trailing-window average, every appended point is smooth
+    // from the first — no cumulative-curve volatility. On init this seeds one
+    // point primed from the backend's existing deadlines; live scans grow it.
+    // Bounded in memory at MAX_CAPACITY_SERIES_POINTS.
+    if (effectiveCapacity > 0) {
+      this._capacitySeries.update(series => {
+        const next = [...series, { timestamp: latestTimestamp, capacity: effectiveCapacity }];
+        return next.length > MAX_CAPACITY_SERIES_POINTS
+          ? next.slice(next.length - MAX_CAPACITY_SERIES_POINTS)
+          : next;
+      });
+    }
   }
 
   /**
@@ -2260,9 +2271,8 @@ export class MiningService {
           const deadlines = await this.fetchRecentDeadlines();
           this._minerState.update(s => ({ ...s, recentDeadlines: deadlines }));
           this._capacityDeadlines.set(deadlines);
-          this._capacityChartVersion.update(v => v + 1);
 
-          // Update capacity cache (survives navigation)
+          // Update capacity cache + append a sparkline point (survives navigation)
           this.updateCapacityCache();
 
           // Smart cleanup of activity logs (idle moment after scan)


### PR DESCRIPTION
## Problem

The effective-capacity sparkline on the mining dashboard was drawn by `generateEffectiveCapacityHistory`, which rebuilt a **cumulative-from-window-start** curve on every render: point *i* = capacity computed from deadlines `[0..i]` within the current 720/chain window. So the leftmost sampled points always restarted from ~1 sample — the left edge was **permanently volatile**, not just during ramp-up, no matter how long you'd mined. It also smeared *real* capacity changes (add plots → the old blocks kept dragging the cumulative average) instead of showing them as a step/ramp.

## Approach (agreed in review)

The **headline** effective capacity is already a correct trailing-window average — `updateCapacityCache` averages over the backend-bounded 720/chain deadline set each scan-finished round. Only the chart was wrong. So instead of recomputing a curve, we now **record that estimate as a real time-series** and draw it.

- New in-memory `_capacitySeries` signal (the chart "store"). Each scan-finished round appends one point = the current trailing-window estimate + the newly-settled block's timestamp. Because every point is a full-window average, the line is **smooth from the first point**.
- On init, `updateCapacityCache` seeds one point primed from the backend's existing deadlines, then live scans grow it.
- Capped at `MAX_CAPACITY_SERIES_POINTS` (720). **In-memory only**: survives navigation (root singleton), resets on app restart. No disk persistence and no reconstruction — deliberately, per review: priming from the existing 720 deadlines already makes points smooth, so reconstruction would only buy a cosmetic "long chart at launch."
- `capacityHistory` now downsamples the series to ≤60 points for rendering (`downsampleCapacitySeries`). The dashboard component is **unchanged** — same `CapacityDataPoint[]` shape.

Residual volatility only for a genuinely new miner (<720 lifetime deadlines) during ramp-up, which self-heals as the window fills.

## Cleanup

- Removed the now-dead `generateEffectiveCapacityHistory` (cumulative-curve generator; single caller, no tests).
- Removed the vestigial `_capacityChartVersion` signal — it was bumped every scan-finish but **read nowhere** (the signal chain is already reactive via `capacityHistory`).
- Dropped the unused `history` field from `CapacityCache`.

## Notes / deliberate non-changes

- **O(1) sliding-window** update was considered but not adopted: the headline recompute is a `reduce` over ≤~2160 items once per ~block — negligible — so the existing reduce is kept for clarity.
- **min/max decimation** for downsampling was considered but is unnecessary: the series is smooth by construction, so uniform striding preserves its shape.
- Cap is **count-based** (720 points ≈ 24h single-chain, ~8h with 3 chains). Time-based capping is a possible future tweak.

## Test

`tsc --noEmit`, `ng lint`, `prettier --check`, and `ng test` (82/82) all pass.

Closes the chart half of the mining-dashboard review finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)