### PR TITLE
feat(wallet): v30→v31 coin-type migration + network-aware BTCX coin type

### DIFF
--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "electrum-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=f1e216897bae629a251f4bd83f95bb71b4ffb06e#f1e216897bae629a251f4bd83f95bb71b4ffb06e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
 dependencies = [
  "anyhow",
  "bdk_wallet",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "keys-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=f1e216897bae629a251f4bd83f95bb71b4ffb06e#f1e216897bae629a251f4bd83f95bb71b4ffb06e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
 dependencies = [
  "anyhow",
  "bip39",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "params-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=f1e216897bae629a251f4bd83f95bb71b4ffb06e#f1e216897bae629a251f4bd83f95bb71b4ffb06e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5318,7 +5318,7 @@ dependencies = [
 [[package]]
 name = "seedstore"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=f1e216897bae629a251f4bd83f95bb71b4ffb06e#f1e216897bae629a251f4bd83f95bb71b4ffb06e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
 dependencies = [
  "anyhow",
  "bip39",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "wallet-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=f1e216897bae629a251f4bd83f95bb71b4ffb06e#f1e216897bae629a251f4bd83f95bb71b4ffb06e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
 dependencies = [
  "anyhow",
  "bdk_wallet",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -60,11 +60,11 @@ pocx_aggregator = "1.0.5"
 
 
 # Nodeless BTCX wallet stack (shared btcx crates)
-params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "f1e216897bae629a251f4bd83f95bb71b4ffb06e" }
-keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "f1e216897bae629a251f4bd83f95bb71b4ffb06e" }
-seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "f1e216897bae629a251f4bd83f95bb71b4ffb06e" }
-electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "f1e216897bae629a251f4bd83f95bb71b4ffb06e" }
-wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "f1e216897bae629a251f4bd83f95bb71b4ffb06e" }
+params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
+keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
+seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
+electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
+wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
 bitcoin = { version = "0.32", features = ["serde", "rand-std"] }
 bdk_wallet = { version = "2", features = ["rusqlite"] }
 # bech32 with custom HRPs (pocx/tpocx/rpocx) â€” same version the btcx crates use

--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -19,6 +19,7 @@ use super::config::{
 use super::descriptors::{self, ImportValidation};
 use super::descstore::{self, DescStore, DescriptorPayload};
 use super::manager::{self, BranchHit};
+use super::migrate::{self, V30MigrationPlan};
 use super::state::{BtcxWalletStatus, SharedBtcxWalletState};
 
 /// Run a blocking wallet operation off the async runtime.
@@ -145,7 +146,7 @@ pub fn create_wallet_impl(
     let name = resolve_new_wallet_name(&config, network, name)?;
     let policy = DescriptorPolicy {
         kind: kind.unwrap_or(DescriptorKindCfg::Bip84),
-        ..DescriptorPolicy::default()
+        coin_type: network.asset_coin_type(),
     };
     import_into_named_wallet(state, network, &name, mnemonic, passphrase, policy)?;
     // No Electrum server configured yet is fine — the runtime opens
@@ -249,11 +250,11 @@ pub fn restore_wallet_impl(
     // A pruned server hides older history, so a real seed would probe as
     // "fresh" — verified_probe_chain fails hard (or falls over) instead.
     let chain = state.verified_probe_chain()?;
-    let hits = manager::probe_all_branches(&seed, &chain)
+    let hits = manager::probe_all_branches(&seed, &chain, network)
         .map_err(|e| format!("Restore probing failed: {e:#}"))?;
     let (selected, fresh) = match kind {
-        Some(kind) => manager::select_restore_policy_for_kind(&hits, kind),
-        None => manager::select_restore_policy(&hits),
+        Some(kind) => manager::select_restore_policy_for_kind(&hits, kind, network),
+        None => manager::select_restore_policy(&hits, network),
     };
 
     import_into_named_wallet(state, network, &name, mnemonic, passphrase, selected)?;
@@ -324,13 +325,14 @@ pub async fn btcx_wallet_reprobe(
         // F3: same verified-chain guard as the first restore probe — a pruned
         // or wrong-chain server must not drive a "fresh" verdict.
         let chain = state.verified_probe_chain()?;
-        let hits = manager::probe_all_branches(&seed, &chain)
+        let config = state.get_config();
+        let network = config.network;
+        let hits = manager::probe_all_branches(&seed, &chain, network)
             .map_err(|e| format!("Restore probing failed: {e:#}"))?;
 
-        let config = state.get_config();
         let current = config.policy();
         let current_has_history = hits.iter().any(|h| h.policy == current);
-        let (mut selected, fresh) = manager::select_restore_policy(&hits);
+        let (mut selected, fresh) = manager::select_restore_policy(&hits, network);
         if current_has_history {
             // Never abandon a branch that holds history.
             selected = current;
@@ -369,6 +371,378 @@ pub async fn btcx_wallet_reprobe(
         })
     })
     .await
+}
+
+// ============================================================================
+// v30 → v31 Wallet Migration
+// ============================================================================
+
+/// What one migration pass did (`btcx_wallet_migrate_v30` /
+/// `btcx_wallet_rescan_legacy`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum V30MigrationOutcome {
+    /// Nothing to create; the wallet is recorded as migrated.
+    Noop,
+    /// A v31 (BTCX coin type) counterpart was created and made active.
+    CreatedV31,
+    /// A legacy v30 (coin type 0') counterpart was created; the v31 wallet
+    /// stays active.
+    CreatedV30,
+    /// The pass was skipped because the flag was already set (migrate only).
+    Already,
+    /// The pass could not run WITHOUT weakening the seed at rest (locked, or
+    /// passphrase-encrypted) — the flag is left UNSET so a later pass retries.
+    Deferred,
+}
+
+/// Result of a migration pass: what it did, the wallet left active, any
+/// counterpart created, an optional note, and the post-pass status.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BtcxV30MigrationResult {
+    pub outcome: V30MigrationOutcome,
+    /// The wallet selected after the pass.
+    pub active_wallet: String,
+    /// The counterpart wallet created (v31 or v30), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_wallet: Option<String>,
+    /// Human-readable note — e.g. why the pass deferred.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub status: BtcxWalletStatus,
+}
+
+/// The base (v31) name of a wallet: its own name with a trailing `-v30`
+/// stripped, so `default` and `default-v30` share the base `default`.
+fn base_name(name: &str) -> String {
+    name.strip_suffix("-v30").unwrap_or(name).to_string()
+}
+
+/// The canonical counterpart names of a seed's migration pair: the clean
+/// v31 base name and the `-v30` legacy name. Used to look up whether either
+/// branch already has a registered wallet (existence check only — creation
+/// disambiguates collisions via [`resolve_counterpart_name`]).
+fn counterpart_names(base: &str) -> Vec<String> {
+    vec![base.to_string(), format!("{base}-v30")]
+}
+
+/// A free wallet name for a counterpart being CREATED: `<base><suffix>`,
+/// truncated to the 32-char limit and disambiguated with `-2`, `-3`, … if
+/// the plain form is taken in the registry or holds a leftover on-disk store.
+fn resolve_counterpart_name(
+    state: &SharedBtcxWalletState,
+    network: WalletNetwork,
+    base: &str,
+    suffix: &str,
+) -> Result<String, String> {
+    let config = state.get_config();
+    // Keep within the 32-char wallet-name limit, suffix included.
+    let max_base = 32usize.saturating_sub(suffix.len());
+    let trimmed: String = base.chars().take(max_base).collect();
+    let existing: Vec<String> = config
+        .wallet_names(network)
+        .into_iter()
+        .map(|n| n.to_ascii_lowercase())
+        .collect();
+    let taken = |candidate: &str| {
+        existing.contains(&candidate.to_ascii_lowercase())
+            || has_leftover_store(network, candidate)
+            || config::validate_wallet_name(candidate).is_err()
+    };
+    let plain = format!("{trimmed}{suffix}");
+    if !taken(&plain) {
+        return Ok(plain);
+    }
+    for n in 2..=99 {
+        // Re-trim so the numeric tail also fits the 32-char limit.
+        let tail = format!("{suffix}-{n}");
+        let base_n: String = base
+            .chars()
+            .take(32usize.saturating_sub(tail.len()))
+            .collect();
+        let candidate = format!("{base_n}{tail}");
+        if !taken(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err("Could not find a free counterpart wallet name".into())
+}
+
+/// Build the migration result and read the post-pass status.
+fn migration_result(
+    state: &SharedBtcxWalletState,
+    outcome: V30MigrationOutcome,
+    created_wallet: Option<String>,
+    detail: Option<String>,
+) -> Result<BtcxV30MigrationResult, String> {
+    Ok(BtcxV30MigrationResult {
+        outcome,
+        active_wallet: state.get_config().active_wallet_name(),
+        created_wallet,
+        detail,
+        status: state.status()?,
+    })
+}
+
+/// Read the active wallet's stored mnemonic for a migration pass, or return
+/// `Ok(None)` to DEFER (leaving the flag unset) when the seed cannot be
+/// faithfully reproduced onto a counterpart wallet:
+/// - a locked passphrase seed cannot be read at all;
+/// - an unlocked passphrase-ENCRYPTED seed reads fine, but the counterpart
+///   would have to be re-wrapped WITHOUT the passphrase (an unlocked store
+///   never surrenders its plaintext), a security downgrade of the seed at
+///   rest — so it is deferred rather than silently weakened.
+///
+/// The counterpart is therefore always created from the mnemonic with the
+/// unattended at-rest wrap (never plaintext, same as an unencrypted create).
+fn read_migratable_mnemonic(
+    state: &SharedBtcxWalletState,
+    config: &BtcxWalletConfig,
+) -> (Option<String>, Option<String>) {
+    let Ok(mnemonic) = state.with_seed(|s| s.mnemonic().map_err(|e| format!("{e:#}"))) else {
+        return (
+            None,
+            Some("The wallet seed is locked — unlock it, then retry.".into()),
+        );
+    };
+    let seed_file = std::fs::read_to_string(config.active_wallet_root().join(seedstore::SEED_FILE))
+        .unwrap_or_default();
+    if super::state::seed_needs_passphrase(&seed_file) {
+        return (
+            None,
+            Some(
+                "Passphrase-encrypted seeds are not auto-migrated yet — the counterpart wallet \
+                 cannot inherit the passphrase protection."
+                    .into(),
+            ),
+        );
+    }
+    (Some(mnemonic), None)
+}
+
+/// Create the seed's legacy v30 counterpart from `mnemonic` on `policy` as a
+/// new named wallet, leaving the ORIGINALLY active wallet (`keep_active`)
+/// selected afterwards. `set_flags` records both wallets as migrated (the
+/// one-time pass) — the danger-zone rescan leaves the flag alone. Returns
+/// the created wallet's name.
+#[allow(clippy::too_many_arguments)]
+fn create_v30_counterpart(
+    state: &SharedBtcxWalletState,
+    app: Option<AppHandle>,
+    network: WalletNetwork,
+    keep_active: &str,
+    base: &str,
+    mnemonic: &str,
+    policy: DescriptorPolicy,
+    set_flags: bool,
+) -> Result<String, String> {
+    let legacy_name = resolve_counterpart_name(state, network, base, "-v30")?;
+    // import_into_named_wallet closes the runtime and switches the active
+    // wallet to the newly created legacy one.
+    import_into_named_wallet(state, network, &legacy_name, mnemonic, None, policy)?;
+    if set_flags {
+        state.update_config(|c| {
+            c.set_v30_migrated(network, keep_active, true);
+            c.set_v30_migrated(network, &legacy_name, true);
+        })?;
+    }
+    // The v31 wallet must stay active — switch back to it (which reopens it).
+    select_wallet_impl(state, app, keep_active)?;
+    Ok(legacy_name)
+}
+
+/// The one-time v30→v31 migration for the OPEN wallet's seed. Idempotent via
+/// the `v30Migrated` flag; a locked/encrypted seed defers WITHOUT setting it.
+/// Requires a verified Electrum server (same guard as restore) so a
+/// missing/pruned server is a hard error, never a silent "migrated".
+pub fn migrate_v30_impl(
+    state: &SharedBtcxWalletState,
+    app: Option<AppHandle>,
+) -> Result<BtcxV30MigrationResult, String> {
+    let config = state.get_config();
+    let network = config.network;
+    let active_name = config.active_wallet_name();
+
+    // Already migrated — nothing to do (leave the open runtime untouched).
+    if config.v30_migrated(network, &active_name) {
+        return migration_result(state, V30MigrationOutcome::Already, None, None);
+    }
+    // Descriptor-imported wallets have no seed branches to migrate: record
+    // them done so the pass never re-checks.
+    if state.active_source(&config) == WalletSourceCfg::Descriptor {
+        state.update_config(|c| c.set_v30_migrated(network, &active_name, true))?;
+        return migration_result(state, V30MigrationOutcome::Noop, None, None);
+    }
+
+    // The v30→v31 split only exists on mainnet (coin 0' → BTCX coin type).
+    // Testnet/regtest use coin type 1' for both new and legacy wallets, so
+    // there is nothing to migrate — record it done (skipping the Electrum
+    // probe) and leave the runtime be.
+    if network != WalletNetwork::Mainnet {
+        state.update_config(|c| c.set_v30_migrated(network, &active_name, true))?;
+        return migration_result(state, V30MigrationOutcome::Noop, None, None);
+    }
+
+    let (mnemonic, detail) = read_migratable_mnemonic(state, &config);
+    let Some(mnemonic) = mnemonic else {
+        return migration_result(state, V30MigrationOutcome::Deferred, None, detail);
+    };
+
+    // Probe the seed's branches against a verified server (hard error if none).
+    let seed = WalletSeed::from_mnemonic(mnemonic.trim(), "").map_err(|e| format!("{e:#}"))?;
+    let chain = state.verified_probe_chain()?;
+    let hits = manager::probe_all_branches(&seed, &chain, network)
+        .map_err(|e| format!("Migration probing failed: {e:#}"))?;
+
+    let base = base_name(&active_name);
+    let names = counterpart_names(&base);
+    let existing: Vec<DescriptorPolicy> = names
+        .iter()
+        .filter_map(|n| config.wallet_meta(network, n).map(|m| m.policy))
+        .collect();
+    let active_policy = config.policy();
+
+    match migrate::plan_v30_migration(active_policy, &hits, &existing) {
+        V30MigrationPlan::Noop => {
+            state.update_config(|c| {
+                c.set_v30_migrated(network, &active_name, true);
+                for n in &names {
+                    c.set_v30_migrated(network, n, true);
+                }
+            })?;
+            migration_result(state, V30MigrationOutcome::Noop, None, None)
+        }
+        V30MigrationPlan::CreateV31 { policy } => {
+            // Close the open runtime so the legacy wallet can be renamed off
+            // the clean base name, then hand that name to the new v31 wallet.
+            state.close_runtime();
+            let legacy_name = resolve_counterpart_name(state, network, &base, "-v30")?;
+            rename_wallet_impl(state, &active_name, &legacy_name)?;
+            let v31_name =
+                resolve_new_wallet_name(&state.get_config(), network, Some(base.clone()))?;
+            import_into_named_wallet(state, network, &v31_name, &mnemonic, None, policy)?;
+            state.update_config(|c| {
+                c.set_v30_migrated(network, &v31_name, true);
+                c.set_v30_migrated(network, &legacy_name, true);
+            })?;
+            // import_into_named_wallet already made the v31 wallet active;
+            // open its runtime.
+            state.open_runtime(app)?;
+            migration_result(state, V30MigrationOutcome::CreatedV31, Some(v31_name), None)
+        }
+        V30MigrationPlan::CreateV30Legacy { policy } => {
+            let created = create_v30_counterpart(
+                state,
+                app,
+                network,
+                &active_name,
+                &base,
+                &mnemonic,
+                policy,
+                true,
+            )?;
+            migration_result(state, V30MigrationOutcome::CreatedV30, Some(created), None)
+        }
+    }
+}
+
+/// The danger-zone "check for older (v30) funds" pass: re-probe the open
+/// wallet's seed and create the legacy v30 counterpart if the coin-0' branch
+/// holds history and no v30 wallet exists yet. Unlike the one-time migration
+/// it IGNORES the flag (always re-checks) and never touches it, so the user
+/// can run it again after later legacy activity.
+pub fn rescan_legacy_impl(
+    state: &SharedBtcxWalletState,
+    app: Option<AppHandle>,
+) -> Result<BtcxV30MigrationResult, String> {
+    let config = state.get_config();
+    let network = config.network;
+    let active_name = config.active_wallet_name();
+
+    // No legacy branch to rescan off-mainnet — testnet/regtest are coin
+    // type 1' end to end.
+    if network != WalletNetwork::Mainnet {
+        return migration_result(state, V30MigrationOutcome::Noop, None, None);
+    }
+
+    if state.active_source(&config) == WalletSourceCfg::Descriptor {
+        return migration_result(
+            state,
+            V30MigrationOutcome::Noop,
+            None,
+            Some("Descriptor-imported wallets have no legacy seed branch.".into()),
+        );
+    }
+
+    let (mnemonic, detail) = read_migratable_mnemonic(state, &config);
+    let Some(mnemonic) = mnemonic else {
+        return migration_result(state, V30MigrationOutcome::Deferred, None, detail);
+    };
+
+    let seed = WalletSeed::from_mnemonic(mnemonic.trim(), "").map_err(|e| format!("{e:#}"))?;
+    let chain = state.verified_probe_chain()?;
+    let hits = manager::probe_all_branches(&seed, &chain, network)
+        .map_err(|e| format!("Legacy probing failed: {e:#}"))?;
+
+    let base = base_name(&active_name);
+    let names = counterpart_names(&base);
+    // A v30 counterpart already exists over this seed — nothing to recover.
+    if config.has_wallet_on_coin_type(network, &names, 0) {
+        return migration_result(
+            state,
+            V30MigrationOutcome::Noop,
+            None,
+            Some("A legacy (v30) wallet already exists for this seed.".into()),
+        );
+    }
+    // Recover the highest-priority legacy branch that holds history.
+    match hits.iter().find(|h| h.policy.coin_type == 0) {
+        Some(hit) => {
+            let created = create_v30_counterpart(
+                state,
+                app,
+                network,
+                &active_name,
+                &base,
+                &mnemonic,
+                hit.policy,
+                false,
+            )?;
+            migration_result(state, V30MigrationOutcome::CreatedV30, Some(created), None)
+        }
+        None => migration_result(
+            state,
+            V30MigrationOutcome::Noop,
+            None,
+            Some("No legacy (v30) funds found for this seed.".into()),
+        ),
+    }
+}
+
+/// Run the one-time v30→v31 auto-migration for the open wallet (the frontend
+/// calls this once after opening a wallet). Idempotent: a wallet already
+/// migrated returns `already`, a locked/encrypted seed returns `deferred`
+/// without recording the pass. See [`migrate_v30_impl`].
+#[tauri::command]
+pub async fn btcx_wallet_migrate_v30(
+    app: AppHandle,
+    state: State<'_, SharedBtcxWalletState>,
+) -> Result<BtcxV30MigrationResult, String> {
+    let state = state.inner().clone();
+    blocking(move || migrate_v30_impl(&state, Some(app))).await
+}
+
+/// Danger-zone rescan for older (v30) funds: re-probe the open wallet's seed
+/// and create the legacy counterpart if the coin-0' branch holds history,
+/// ignoring the migration flag (always re-checks). See [`rescan_legacy_impl`].
+#[tauri::command]
+pub async fn btcx_wallet_rescan_legacy(
+    app: AppHandle,
+    state: State<'_, SharedBtcxWalletState>,
+) -> Result<BtcxV30MigrationResult, String> {
+    let state = state.inner().clone();
+    blocking(move || rescan_legacy_impl(&state, Some(app))).await
 }
 
 // ============================================================================
@@ -447,6 +821,9 @@ pub fn import_descriptor_wallet_impl(
                     .map(|d| d.as_secs()),
                 source: WalletSourceCfg::Descriptor,
                 single_address: parsed.single_address(),
+                // Descriptor-imported wallets are never part of the seed
+                // v30→v31 migration — mark them done so it never re-checks.
+                v30_migrated: true,
             },
         );
         c.active = true;
@@ -1823,5 +2200,216 @@ mod tests {
             serde_json::from_str(r#"{"address":"rpocx1qxyz","sendAll":true}"#).unwrap();
         assert!(sweep.send_all);
         assert_eq!(sweep.amount_sat, None);
+    }
+
+    #[test]
+    fn base_and_counterpart_naming() {
+        // A `-v30` suffix folds back to the clean base; anything else is its
+        // own base.
+        assert_eq!(base_name("default"), "default");
+        assert_eq!(base_name("default-v30"), "default");
+        assert_eq!(base_name("savings-v30-2"), "savings-v30-2");
+        assert_eq!(
+            counterpart_names("default"),
+            vec!["default".to_string(), "default-v30".to_string()]
+        );
+    }
+
+    /// 24-word all-zero-entropy BIP39 test vector (shared by the migration
+    /// tests below).
+    const MNEMONIC_24: &str = "abandon abandon abandon abandon abandon abandon abandon \
+         abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon \
+         abandon abandon abandon abandon abandon abandon art";
+
+    /// Spin up a regtest state rooted at a temp data dir with an unreachable
+    /// server — enough to exercise the migration's OFFLINE early-return paths
+    /// (before any probe).
+    fn offline_state(network: WalletNetwork) -> SharedBtcxWalletState {
+        let state = super::super::state::create_btcx_wallet_state();
+        state
+            .update_config(|c| {
+                c.network = network;
+                c.set_servers(network, vec!["tcp://127.0.0.1:1".to_string()]);
+            })
+            .unwrap();
+        state
+    }
+
+    fn offline_regtest_state() -> SharedBtcxWalletState {
+        offline_state(WalletNetwork::Regtest)
+    }
+
+    #[test]
+    fn resolve_counterpart_name_disambiguates_and_fits_limit() {
+        let _guard = DATA_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("PHOENIX_DATA_DIR", dir.path());
+        std::env::set_var("PACT_DISABLE_KEYRING", "1");
+
+        let state = offline_regtest_state();
+        let net = WalletNetwork::Regtest;
+
+        // Free name: the plain `<base>-v30`.
+        assert_eq!(
+            resolve_counterpart_name(&state, net, "default", "-v30").unwrap(),
+            "default-v30"
+        );
+
+        // Register `default-v30`, so the next resolution disambiguates.
+        state
+            .update_config(|c| {
+                c.set_wallet_meta(
+                    net,
+                    "default-v30",
+                    WalletMeta {
+                        policy: DescriptorPolicy::default(),
+                        created_at: Some(1),
+                        source: WalletSourceCfg::Seed,
+                        single_address: false,
+                        v30_migrated: false,
+                    },
+                );
+            })
+            .unwrap();
+        assert_eq!(
+            resolve_counterpart_name(&state, net, "default", "-v30").unwrap(),
+            "default-v30-2"
+        );
+
+        // A 32-char base still yields a valid (<=32) counterpart name.
+        let long = "x".repeat(32);
+        let resolved = resolve_counterpart_name(&state, net, &long, "-v30").unwrap();
+        assert!(resolved.len() <= 32, "{resolved}");
+        assert!(
+            config::validate_wallet_name(&resolved).is_ok(),
+            "{resolved}"
+        );
+
+        std::env::remove_var("PHOENIX_DATA_DIR");
+        std::env::remove_var("PACT_DISABLE_KEYRING");
+    }
+
+    #[test]
+    fn create_wallet_coin_type_is_network_aware() {
+        let _guard = DATA_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("PHOENIX_DATA_DIR", dir.path());
+        std::env::set_var("PACT_DISABLE_KEYRING", "1");
+
+        // A new wallet's persisted coin type follows the network: mainnet
+        // gets the per-asset BTCX coin type, testnet/regtest the shared
+        // SLIP-44 testnet coin type 1'.
+        for (network, expected) in [
+            (WalletNetwork::Mainnet, keys_btcx::COIN_BTCX),
+            (WalletNetwork::Testnet, 1u32),
+            (WalletNetwork::Regtest, 1u32),
+        ] {
+            let state = offline_state(network);
+            create_wallet_impl(&state, None, MNEMONIC_24, None, Some("w".into()), None).unwrap();
+            assert_eq!(
+                state.get_config().policy().coin_type,
+                expected,
+                "new wallet on {network:?} must derive at coin type {expected:#x}",
+            );
+        }
+
+        std::env::remove_var("PHOENIX_DATA_DIR");
+        std::env::remove_var("PACT_DISABLE_KEYRING");
+    }
+
+    #[test]
+    fn migrate_v30_skips_descriptor_wallets() {
+        let _guard = DATA_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("PHOENIX_DATA_DIR", dir.path());
+        std::env::set_var("PACT_DISABLE_KEYRING", "1");
+
+        let state = offline_regtest_state();
+        // A deterministic tprv-based external descriptor (regtest keys).
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let master =
+            bitcoin::bip32::Xpriv::new_master(bitcoin::NetworkKind::Test, &[7u8; 32]).unwrap();
+        let path: Vec<bitcoin::bip32::ChildNumber> = [84u32, 1, 0]
+            .iter()
+            .map(|&i| bitcoin::bip32::ChildNumber::from_hardened_idx(i).unwrap())
+            .collect();
+        let account = master.derive_priv(&secp, &path).unwrap();
+        let fp = master.fingerprint(&secp);
+        let external = format!("wpkh([{fp}/84'/1'/0']{account}/0/*)");
+        import_descriptor_wallet_impl(&state, None, &external, None, Some("imported".into()))
+            .unwrap();
+
+        // Import already flags descriptor wallets as migrated — the pass is
+        // a no-op `already`, needing no (unreachable) Electrum server.
+        assert!(state
+            .get_config()
+            .v30_migrated(WalletNetwork::Regtest, "imported"));
+        assert_eq!(
+            migrate_v30_impl(&state, None).unwrap().outcome,
+            V30MigrationOutcome::Already
+        );
+
+        // Clear the flag to exercise the descriptor-skip branch directly (an
+        // older config predating the import-time flag): a descriptor wallet
+        // has no seed branch, so the pass is a no-op that re-records it —
+        // still without touching the server.
+        state
+            .update_config(|c| c.set_v30_migrated(WalletNetwork::Regtest, "imported", false))
+            .unwrap();
+        let result = migrate_v30_impl(&state, None).unwrap();
+        assert_eq!(result.outcome, V30MigrationOutcome::Noop);
+        assert!(state
+            .get_config()
+            .v30_migrated(WalletNetwork::Regtest, "imported"));
+
+        std::env::remove_var("PHOENIX_DATA_DIR");
+        std::env::remove_var("PACT_DISABLE_KEYRING");
+    }
+
+    #[test]
+    fn migrate_v30_early_returns_already_and_defers_encrypted() {
+        let _guard = DATA_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("PHOENIX_DATA_DIR", dir.path());
+        std::env::set_var("PACT_DISABLE_KEYRING", "1");
+
+        // Mainnet: this exercises the migration's own already/defer branches,
+        // which only run on mainnet (testnet/regtest short-circuit to a
+        // no-op before the seed is ever read).
+        let state = offline_state(WalletNetwork::Mainnet);
+
+        // (1) A passphrase-encrypted (but unlocked) seed wallet DEFERS —
+        // the counterpart can't inherit the passphrase, so the pass must not
+        // silently weaken it, and must NOT set the flag.
+        create_wallet_impl(
+            &state,
+            None,
+            MNEMONIC_24,
+            Some("hunter2"),
+            Some("enc".into()),
+            None,
+        )
+        .unwrap();
+        let result = migrate_v30_impl(&state, None).unwrap();
+        assert_eq!(result.outcome, V30MigrationOutcome::Deferred);
+        assert!(result.detail.is_some());
+        assert!(
+            !state
+                .get_config()
+                .v30_migrated(WalletNetwork::Mainnet, "enc"),
+            "a deferred pass must not record the wallet as migrated"
+        );
+
+        // (2) A wallet already flagged returns `already` without touching the
+        // (unreachable) server.
+        create_wallet_impl(&state, None, MNEMONIC_24, None, Some("plain".into()), None).unwrap();
+        state
+            .update_config(|c| c.set_v30_migrated(WalletNetwork::Mainnet, "plain", true))
+            .unwrap();
+        let result = migrate_v30_impl(&state, None).unwrap();
+        assert_eq!(result.outcome, V30MigrationOutcome::Already);
+
+        std::env::remove_var("PHOENIX_DATA_DIR");
+        std::env::remove_var("PACT_DISABLE_KEYRING");
     }
 }

--- a/web-wallet/src-tauri/src/btcx_wallet/config.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/config.rs
@@ -61,6 +61,27 @@ impl WalletNetwork {
             WalletNetwork::Regtest => &BTCX_REGTEST,
         }
     }
+
+    /// BIP-32 coin type for NEW wallets on this network. Delegates to the
+    /// shared single source of truth (`params_btcx::registry::btcx_coin_type`)
+    /// so Phoenix and Satchel can never drift: mainnet uses the registered
+    /// per-asset BTCX coin type (`0x504F4358`, spec §4.1); testnet and regtest
+    /// use the shared SLIP-44 testnet coin type (1').
+    pub fn asset_coin_type(&self) -> u32 {
+        params_btcx::registry::btcx_coin_type(self.params().network)
+    }
+
+    /// The legacy (pre-v31) coin type probed for drainable history on this
+    /// network. Only mainnet has a distinct legacy branch: v30 wallets sat
+    /// at coin type 0'. Testnet/regtest only ever used 1' — which is also
+    /// the current coin type — so there is no separate legacy branch and
+    /// nothing to migrate there.
+    pub fn legacy_coin_type(&self) -> u32 {
+        match self {
+            WalletNetwork::Mainnet => 0,
+            WalletNetwork::Testnet | WalletNetwork::Regtest => 1,
+        }
+    }
 }
 
 /// Which standard single-key descriptor family a wallet derives —
@@ -146,6 +167,12 @@ pub struct WalletMeta {
     /// drives the UI badge and the receive page's hidden "new address".
     #[serde(default)]
     pub single_address: bool,
+    /// Whether the one-time v30→v31 auto-migration has already run for this
+    /// wallet (see `btcx_wallet_migrate_v30`). Gates the migration so it
+    /// executes at most once per wallet; defaults false on pre-existing
+    /// configs so they get their first pass.
+    #[serde(default)]
+    pub v30_migrated: bool,
 }
 
 /// The `electrum_servers` map of a FRESH config: mainnet starts with the
@@ -385,8 +412,46 @@ impl BtcxWalletConfig {
             created_at: existing.and_then(|m| m.created_at).or_else(now_unix),
             source: existing.map(|m| m.source).unwrap_or_default(),
             single_address: existing.map(|m| m.single_address).unwrap_or(false),
+            // The migration flag is orthogonal to the descriptor policy and
+            // must survive a policy update (a reprobe/branch switch).
+            v30_migrated: existing.map(|m| m.v30_migrated).unwrap_or(false),
         };
         self.set_wallet_meta(network, &name, meta);
+    }
+
+    /// Whether the v30→v31 auto-migration has run for the named wallet on
+    /// `network` (unregistered wallets report false).
+    pub fn v30_migrated(&self, network: WalletNetwork, name: &str) -> bool {
+        self.wallet_meta(network, name)
+            .map(|m| m.v30_migrated)
+            .unwrap_or(false)
+    }
+
+    /// Set the v30-migration flag of the named wallet on `network`,
+    /// preserving the rest of its metadata. No-op if the wallet is not
+    /// registered.
+    pub fn set_v30_migrated(&mut self, network: WalletNetwork, name: &str, value: bool) {
+        if let Some(mut meta) = self.wallet_meta(network, name) {
+            meta.v30_migrated = value;
+            self.set_wallet_meta(network, name, meta);
+        }
+    }
+
+    /// Whether any of the given `names` is a registered wallet on `network`
+    /// whose descriptor policy sits on `coin_type` — the v30 migration uses
+    /// this over the active seed's counterpart-name set to tell whether a
+    /// v31 (`keys_btcx::COIN_BTCX`) or v30 (coin type 0) wallet already
+    /// exists for the seed.
+    pub fn has_wallet_on_coin_type(
+        &self,
+        network: WalletNetwork,
+        names: &[String],
+        coin_type: u32,
+    ) -> bool {
+        names.iter().any(|name| {
+            self.wallet_meta(network, name)
+                .is_some_and(|m| m.policy.coin_type == coin_type)
+        })
     }
 
     /// Root of the wallet stores: `<app data dir>/btcx-wallet`.
@@ -503,6 +568,7 @@ pub fn migrate_legacy_layout_at(
                     created_at: now_unix(),
                     source: WalletSourceCfg::Seed,
                     single_address: false,
+                    v30_migrated: false,
                 },
             );
         }
@@ -729,6 +795,7 @@ mod tests {
             created_at: Some(1),
             source: WalletSourceCfg::Seed,
             single_address: false,
+            v30_migrated: false,
         };
         config.set_wallet_meta(WalletNetwork::Mainnet, "savings", meta);
         config.set_active_wallet(WalletNetwork::Mainnet, "savings");
@@ -777,6 +844,7 @@ mod tests {
             created_at: Some(2),
             source: WalletSourceCfg::Descriptor,
             single_address: false,
+            v30_migrated: false,
         };
         let json = serde_json::to_string(&meta).unwrap();
         assert!(json.contains(r#""source":"descriptor""#), "{json}");
@@ -794,21 +862,30 @@ mod tests {
             created_at: Some(3),
             source: WalletSourceCfg::Descriptor,
             single_address: true,
+            v30_migrated: true,
         };
         let json = serde_json::to_string(&single).unwrap();
         assert!(json.contains(r#""singleAddress":true"#), "{json}");
+        assert!(json.contains(r#""v30Migrated":true"#), "{json}");
         let parsed: WalletMeta = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, single);
+
+        // Older configs have no `v30Migrated` field — defaults false.
+        assert!(!old.v30_migrated);
 
         let mut config = BtcxWalletConfig::default();
         config.set_wallet_meta(WalletNetwork::Mainnet, DEFAULT_WALLET, single);
         config.set_policy(WalletNetwork::Mainnet, DescriptorPolicy::default());
+        let updated = config
+            .wallet_meta(WalletNetwork::Mainnet, DEFAULT_WALLET)
+            .unwrap();
         assert!(
-            config
-                .wallet_meta(WalletNetwork::Mainnet, DEFAULT_WALLET)
-                .unwrap()
-                .single_address,
+            updated.single_address,
             "set_policy must preserve the single-address marker"
+        );
+        assert!(
+            updated.v30_migrated,
+            "set_policy must preserve the v30-migration flag"
         );
 
         // Legacy has no seed-derivation family.
@@ -817,6 +894,48 @@ mod tests {
             DescriptorKindCfg::Bip84.kind(),
             Some(keys_btcx::DescriptorKind::Bip84)
         );
+    }
+
+    #[test]
+    fn v30_migration_flag_get_set_and_coin_type_probe() {
+        let mut config = BtcxWalletConfig::default();
+        let net = WalletNetwork::Mainnet;
+
+        // A v30 (coin type 0) wallet and its v31 (COIN_BTCX) counterpart.
+        let v30 = WalletMeta {
+            policy: DescriptorPolicy {
+                kind: DescriptorKindCfg::Bip84,
+                coin_type: 0,
+            },
+            created_at: Some(1),
+            source: WalletSourceCfg::Seed,
+            single_address: false,
+            v30_migrated: false,
+        };
+        let v31 = WalletMeta {
+            policy: DescriptorPolicy::default(),
+            ..v30
+        };
+        config.set_wallet_meta(net, "acct-v30", v30);
+        config.set_wallet_meta(net, "acct", v31);
+
+        // Unregistered wallets report not-migrated; set/get round-trips.
+        assert!(!config.v30_migrated(net, "acct"));
+        assert!(!config.v30_migrated(net, "missing"));
+        config.set_v30_migrated(net, "acct", true);
+        assert!(config.v30_migrated(net, "acct"));
+        // Setting the flag on a missing wallet is a no-op (no phantom entry).
+        config.set_v30_migrated(net, "missing", true);
+        assert!(config.wallet_meta(net, "missing").is_none());
+
+        // Coin-type probe over the counterpart-name set.
+        let names = vec!["acct".to_string(), "acct-v30".to_string()];
+        assert!(config.has_wallet_on_coin_type(net, &names, keys_btcx::COIN_BTCX));
+        assert!(config.has_wallet_on_coin_type(net, &names, 0));
+        // A name set without a v30 counterpart sees only the v31 branch.
+        let v31_only = vec!["acct".to_string()];
+        assert!(config.has_wallet_on_coin_type(net, &v31_only, keys_btcx::COIN_BTCX));
+        assert!(!config.has_wallet_on_coin_type(net, &v31_only, 0));
     }
 
     /// Some seed-file bytes; the migration never parses them, it only

--- a/web-wallet/src-tauri/src/btcx_wallet/manager.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/manager.rs
@@ -50,10 +50,10 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use electrum_btcx::{ElectrumBackend, WalletEntry, WalletHandle, STOP_GAP};
-use keys_btcx::{WalletSeed, COIN_BTCX};
+use keys_btcx::WalletSeed;
 use params_btcx::params::ChainParams;
 
-use super::config::{DescriptorKindCfg, DescriptorPolicy};
+use super::config::{DescriptorKindCfg, DescriptorPolicy, WalletNetwork};
 
 /// External (receive) addresses checked per restore-probe candidate.
 /// Deliberately DEEPER than `electrum_btcx::STOP_GAP` (25) — hits beyond
@@ -190,26 +190,36 @@ fn open_wallet_with_descriptors(
     Ok(Arc::new(Mutex::new(WalletEntry { wallet, conn })))
 }
 
-/// The restore-probe candidates, in probe order (see module docs).
-pub fn probe_candidates() -> [DescriptorPolicy; 4] {
-    [
+/// The restore-probe candidates for a network, in probe order (see module
+/// docs). The current (asset) coin type is probed first so a wallet with
+/// history on both it and the legacy branch reopens on the modern one; the
+/// distinct legacy branch follows. Testnet/regtest have no separate legacy
+/// branch (current == legacy == 1'), so they probe just the two families
+/// at coin type 1'.
+pub fn probe_candidates(network: WalletNetwork) -> Vec<DescriptorPolicy> {
+    let asset = network.asset_coin_type();
+    let legacy = network.legacy_coin_type();
+    let mut candidates = vec![
         DescriptorPolicy {
             kind: DescriptorKindCfg::Bip84,
-            coin_type: COIN_BTCX,
+            coin_type: asset,
         },
         DescriptorPolicy {
             kind: DescriptorKindCfg::Bip86,
-            coin_type: COIN_BTCX,
+            coin_type: asset,
         },
-        DescriptorPolicy {
+    ];
+    if legacy != asset {
+        candidates.push(DescriptorPolicy {
             kind: DescriptorKindCfg::Bip84,
-            coin_type: 0,
-        },
-        DescriptorPolicy {
+            coin_type: legacy,
+        });
+        candidates.push(DescriptorPolicy {
             kind: DescriptorKindCfg::Bip86,
-            coin_type: 0,
-        },
-    ]
+            coin_type: legacy,
+        });
+    }
+    candidates
 }
 
 /// The first `count` scriptPubKeys of one keychain (`change` 0 = external
@@ -306,10 +316,19 @@ pub fn probe_branch_hits(
 /// (candidate priority order): the first hit, or the fresh-wallet default
 /// (BIP-84 / BTCX coin type) when no branch has history. The second value
 /// is the honest "fresh" verdict for the UI.
-pub fn select_restore_policy(hits: &[BranchHit]) -> (DescriptorPolicy, bool) {
+pub fn select_restore_policy(
+    hits: &[BranchHit],
+    network: WalletNetwork,
+) -> (DescriptorPolicy, bool) {
     match hits.first() {
         Some(hit) => (hit.policy, false),
-        None => (DescriptorPolicy::default(), true),
+        None => (
+            DescriptorPolicy {
+                kind: DescriptorKindCfg::Bip84,
+                coin_type: network.asset_coin_type(),
+            },
+            true,
+        ),
     }
 }
 
@@ -322,13 +341,14 @@ pub fn select_restore_policy(hits: &[BranchHit]) -> (DescriptorPolicy, bool) {
 pub fn select_restore_policy_for_kind(
     hits: &[BranchHit],
     kind: DescriptorKindCfg,
+    network: WalletNetwork,
 ) -> (DescriptorPolicy, bool) {
     match hits.iter().find(|hit| hit.policy.kind == kind) {
         Some(hit) => (hit.policy, false),
         None => (
             DescriptorPolicy {
                 kind,
-                coin_type: COIN_BTCX,
+                coin_type: network.asset_coin_type(),
             },
             true,
         ),
@@ -339,8 +359,12 @@ pub fn select_restore_policy_for_kind(
 /// scripthash-history call covering the first
 /// [`PROBE_EXTERNAL_ADDRESSES`] external plus [`PROBE_INTERNAL_ADDRESSES`]
 /// internal addresses.
-pub fn probe_all_branches(seed: &WalletSeed, chain: &ElectrumBackend) -> Result<Vec<BranchHit>> {
-    probe_branch_hits(&probe_candidates(), |candidate| {
+pub fn probe_all_branches(
+    seed: &WalletSeed,
+    chain: &ElectrumBackend,
+    network: WalletNetwork,
+) -> Result<Vec<BranchHit>> {
+    probe_branch_hits(&probe_candidates(network), |candidate| {
         let mut spks = candidate_spks(seed, candidate, 0, PROBE_EXTERNAL_ADDRESSES)?;
         spks.extend(candidate_spks(
             seed,
@@ -391,6 +415,7 @@ pub fn ensure_probe_reach(entry: &mut WalletEntry, hit: &BranchHit) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+    use keys_btcx::COIN_BTCX;
     use std::str::FromStr;
 
     /// The standard BIP39 test mnemonic (public test vectors).
@@ -406,17 +431,35 @@ mod tests {
 
     #[test]
     fn probe_candidate_ordering() {
-        // New-standard branches first, legacy Phoenix coin-0 branches after
-        // — the order decides which history a mixed seed restores to.
+        // Mainnet: new-standard (BTCX coin type) branches first, legacy
+        // Phoenix coin-0 branches after — the order decides which history a
+        // mixed seed restores to.
         assert_eq!(
-            probe_candidates(),
-            [
+            probe_candidates(WalletNetwork::Mainnet),
+            vec![
                 policy(DescriptorKindCfg::Bip84, COIN_BTCX),
                 policy(DescriptorKindCfg::Bip86, COIN_BTCX),
                 policy(DescriptorKindCfg::Bip84, 0),
                 policy(DescriptorKindCfg::Bip86, 0),
             ]
         );
+    }
+
+    #[test]
+    fn probe_candidates_testnet_is_coin_type_1_only() {
+        // Testnet/regtest use the shared SLIP-44 coin type 1' for both new
+        // and legacy — there is no distinct legacy branch, so only the two
+        // families at 1' are probed (no COIN_BTCX, no coin-0).
+        for network in [WalletNetwork::Testnet, WalletNetwork::Regtest] {
+            assert_eq!(
+                probe_candidates(network),
+                vec![
+                    policy(DescriptorKindCfg::Bip84, 1),
+                    policy(DescriptorKindCfg::Bip86, 1),
+                ],
+                "{network:?} must probe only coin type 1'",
+            );
+        }
     }
 
     #[test]
@@ -455,7 +498,7 @@ mod tests {
         // History on the legacy BIP-84/coin-0 branch AND the BIP-86/BTCX
         // branch: both are collected, priority order preserved, and the
         // selection opens the higher-priority BIP-86/BTCX branch.
-        let hits = probe_branch_hits(&probe_candidates(), |cand| {
+        let hits = probe_branch_hits(&probe_candidates(WalletNetwork::Mainnet), |cand| {
             let external = if cand == policy(DescriptorKindCfg::Bip84, 0) {
                 used_at(PROBE_EXTERNAL_ADDRESSES, &[3])
             } else if cand == policy(DescriptorKindCfg::Bip86, COIN_BTCX) {
@@ -472,7 +515,7 @@ mod tests {
         assert_eq!(hits[1].policy, policy(DescriptorKindCfg::Bip84, 0));
         assert_eq!(hits[1].deepest_external, Some(3));
 
-        let (selected, fresh) = select_restore_policy(&hits);
+        let (selected, fresh) = select_restore_policy(&hits, WalletNetwork::Mainnet);
         assert_eq!(selected, policy(DescriptorKindCfg::Bip86, COIN_BTCX));
         assert!(!fresh);
     }
@@ -481,7 +524,7 @@ mod tests {
     fn probe_detects_change_only_history() {
         // A swept / change-only wallet: history exclusively on the internal
         // keychain still counts as a hit.
-        let hits = probe_branch_hits(&probe_candidates(), |cand| {
+        let hits = probe_branch_hits(&probe_candidates(WalletNetwork::Mainnet), |cand| {
             let internal = if cand == policy(DescriptorKindCfg::Bip84, 0) {
                 used_at(PROBE_INTERNAL_ADDRESSES, &[2])
             } else {
@@ -511,11 +554,13 @@ mod tests {
             hit(policy(DescriptorKindCfg::Bip86, 0)),
         ];
 
-        let (selected, fresh) = select_restore_policy_for_kind(&hits, DescriptorKindCfg::Bip86);
+        let (selected, fresh) =
+            select_restore_policy_for_kind(&hits, DescriptorKindCfg::Bip86, WalletNetwork::Mainnet);
         assert_eq!(selected, policy(DescriptorKindCfg::Bip86, 0));
         assert!(!fresh);
 
-        let (selected, fresh) = select_restore_policy_for_kind(&hits, DescriptorKindCfg::Bip84);
+        let (selected, fresh) =
+            select_restore_policy_for_kind(&hits, DescriptorKindCfg::Bip84, WalletNetwork::Mainnet);
         assert_eq!(selected, policy(DescriptorKindCfg::Bip84, COIN_BTCX));
         assert!(!fresh);
 
@@ -525,21 +570,23 @@ mod tests {
             hit(policy(DescriptorKindCfg::Bip86, COIN_BTCX)),
             hit(policy(DescriptorKindCfg::Bip86, 0)),
         ];
-        let (selected, fresh) = select_restore_policy_for_kind(&hits, DescriptorKindCfg::Bip86);
+        let (selected, fresh) =
+            select_restore_policy_for_kind(&hits, DescriptorKindCfg::Bip86, WalletNetwork::Mainnet);
         assert_eq!(selected, policy(DescriptorKindCfg::Bip86, COIN_BTCX));
         assert!(!fresh);
 
         // No hit of the forced family anywhere: fresh default of THAT
         // family at the BTCX coin type, with an honest fresh verdict.
         let hits = [hit(policy(DescriptorKindCfg::Bip84, COIN_BTCX))];
-        let (selected, fresh) = select_restore_policy_for_kind(&hits, DescriptorKindCfg::Bip86);
+        let (selected, fresh) =
+            select_restore_policy_for_kind(&hits, DescriptorKindCfg::Bip86, WalletNetwork::Mainnet);
         assert_eq!(selected, policy(DescriptorKindCfg::Bip86, COIN_BTCX));
         assert!(fresh);
     }
 
     #[test]
     fn select_restore_policy_defaults_to_fresh_bip84_btcx() {
-        let (selected, fresh) = select_restore_policy(&[]);
+        let (selected, fresh) = select_restore_policy(&[], WalletNetwork::Mainnet);
         assert!(fresh, "no hits anywhere is an honest fresh verdict");
         assert_eq!(selected, DescriptorPolicy::default());
         assert_eq!(selected, policy(DescriptorKindCfg::Bip84, COIN_BTCX));
@@ -549,7 +596,7 @@ mod tests {
     fn probe_branch_hits_propagates_probe_errors() {
         // A dead server must fail the restore honestly, not silently open
         // a fresh wallet over a seed that may have history elsewhere.
-        let result = probe_branch_hits(&probe_candidates(), |_| {
+        let result = probe_branch_hits(&probe_candidates(WalletNetwork::Mainnet), |_| {
             anyhow::bail!("electrum unreachable")
         });
         assert!(result.is_err());
@@ -591,7 +638,7 @@ mod tests {
 
     #[test]
     fn candidate_spks_are_disjoint_across_candidates_and_keychains() {
-        let all: Vec<Vec<ScriptBuf>> = probe_candidates()
+        let all: Vec<Vec<ScriptBuf>> = probe_candidates(WalletNetwork::Mainnet)
             .into_iter()
             .flat_map(|c| {
                 [

--- a/web-wallet/src-tauri/src/btcx_wallet/migrate.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/migrate.rs
@@ -1,0 +1,211 @@
+//! One-time v30 → v31 wallet auto-migration (decision core)
+//!
+//! Phoenix desktop's legacy (v30) seeds derive at BIP32 coin type `0'`,
+//! while the current standard (v31) derives at the BTCX coin type
+//! (`keys_btcx::COIN_BTCX` = `0x504F4358`). A restored seed can therefore
+//! carry history on BOTH branches, but a single wallet only opens ONE
+//! policy. This migration gives a v30 wallet its v31 counterpart (and vice
+//! versa when the legacy branch holds funds) as SEPARATE named wallets over
+//! the SAME stored seed, so nothing is stranded on an invisible branch.
+//!
+//! This module is the PURE decision half: [`plan_v30_migration`] maps the
+//! open wallet's policy, the restore-style branch probe, and the seed's
+//! already-existing counterpart wallets onto a [`V30MigrationPlan`]. The
+//! command layer (`commands::migrate_v30_impl`) executes the plan (name
+//! resolution, seed re-derivation, `import_into_named_wallet`, flag
+//! setting) — none of which lives here, so the trigger table is unit-tested
+//! without a wallet, a seed or an Electrum server.
+
+use super::config::DescriptorPolicy;
+use super::manager::BranchHit;
+use keys_btcx::COIN_BTCX;
+
+/// A v31 wallet: derived at the BTCX coin type.
+fn is_v31(policy: &DescriptorPolicy) -> bool {
+    policy.coin_type == COIN_BTCX
+}
+
+/// A v30 (legacy Phoenix) wallet: derived at BIP32 coin type `0'`.
+fn is_v30(policy: &DescriptorPolicy) -> bool {
+    policy.coin_type == 0
+}
+
+/// What the one-time v30↔v31 migration should do for the OPEN wallet's seed.
+///
+/// The decision is over three inputs: the open wallet's own policy, the
+/// restore-style branch probe of its seed, and the policies of the seed's
+/// already-registered counterpart wallets (the active wallet plus, by name,
+/// its `<base>` / `<base>-v30` sibling). Names and policy values the command
+/// needs to CREATE a wallet are resolved there — this only says WHICH branch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum V30MigrationPlan {
+    /// Nothing to create — either both counterparts already exist, the
+    /// legacy branch carries no funds, or the wallet is on neither coin
+    /// type. The command still records the migration as done.
+    Noop,
+    /// The open wallet is a legacy v30 wallet with no v31 counterpart yet.
+    /// Create the v31 wallet on `policy` under the clean base name, move the
+    /// legacy wallet to the `-v30` name, and make the v31 wallet active.
+    CreateV31 { policy: DescriptorPolicy },
+    /// The open wallet is a v31 wallet, has no v30 counterpart, and the
+    /// seed's legacy (coin type `0'`) branch DOES hold history: create the
+    /// `-v30` counterpart on `policy` (the highest-priority legacy hit),
+    /// leaving the v31 wallet active.
+    CreateV30Legacy { policy: DescriptorPolicy },
+}
+
+/// Decide the migration for the open wallet's seed — the pure trigger table.
+///
+/// - both counterparts already registered → [`V30MigrationPlan::Noop`];
+/// - only the v30 wallet exists (open wallet on coin type `0'`) → create the
+///   v31 counterpart at BIP-84 / `COIN_BTCX` ([`V30MigrationPlan::CreateV31`]);
+/// - only the v31 wallet exists (open wallet on `COIN_BTCX`) → create the
+///   legacy v30 counterpart ONLY if the seed's coin-0' branch has history
+///   ([`V30MigrationPlan::CreateV30Legacy`], highest-priority legacy hit),
+///   else [`V30MigrationPlan::Noop`].
+pub fn plan_v30_migration(
+    active_policy: DescriptorPolicy,
+    hits: &[BranchHit],
+    existing_policies: &[DescriptorPolicy],
+) -> V30MigrationPlan {
+    let has_v31 = existing_policies.iter().any(is_v31);
+    let has_v30 = existing_policies.iter().any(is_v30);
+
+    // Both branches already have their own named wallet — done.
+    if has_v31 && has_v30 {
+        return V30MigrationPlan::Noop;
+    }
+
+    // Only the legacy v30 wallet exists: give the seed its v31 wallet
+    // unconditionally (v31 is the branch the user should be defaulting to,
+    // whether or not it already has on-chain history).
+    if is_v30(&active_policy) && !has_v31 {
+        return V30MigrationPlan::CreateV31 {
+            // BIP-84 @ COIN_BTCX — the new-wallet default.
+            policy: DescriptorPolicy::default(),
+        };
+    }
+
+    // Only the v31 wallet exists: recover legacy funds by creating the v30
+    // counterpart, but ONLY when the coin-0' branch actually holds history —
+    // never manufacture an empty legacy wallet. The first coin-0' hit wins
+    // (probe/candidate priority: BIP-84 before BIP-86).
+    if is_v31(&active_policy) && !has_v30 {
+        if let Some(hit) = hits.iter().find(|h| is_v30(&h.policy)) {
+            return V30MigrationPlan::CreateV30Legacy { policy: hit.policy };
+        }
+    }
+
+    V30MigrationPlan::Noop
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::btcx_wallet::config::DescriptorKindCfg;
+
+    fn policy(kind: DescriptorKindCfg, coin_type: u32) -> DescriptorPolicy {
+        DescriptorPolicy { kind, coin_type }
+    }
+
+    fn hit(policy: DescriptorPolicy) -> BranchHit {
+        BranchHit {
+            policy,
+            deepest_external: Some(0),
+            deepest_internal: None,
+        }
+    }
+
+    const V31: DescriptorPolicy = DescriptorPolicy {
+        kind: DescriptorKindCfg::Bip84,
+        coin_type: COIN_BTCX,
+    };
+    const V30: DescriptorPolicy = DescriptorPolicy {
+        kind: DescriptorKindCfg::Bip84,
+        coin_type: 0,
+    };
+
+    #[test]
+    fn both_counterparts_exist_is_noop() {
+        // v30 active, but both wallets already registered → nothing to do,
+        // regardless of what the probe reports.
+        let plan = plan_v30_migration(V30, &[hit(V30), hit(V31)], &[V30, V31]);
+        assert_eq!(plan, V30MigrationPlan::Noop);
+        // Same verdict with the v31 wallet active.
+        let plan = plan_v30_migration(V31, &[hit(V31), hit(V30)], &[V31, V30]);
+        assert_eq!(plan, V30MigrationPlan::Noop);
+    }
+
+    #[test]
+    fn only_v30_creates_the_v31_counterpart() {
+        // The classic upgrade: the seed only has its legacy v30 wallet. The
+        // v31 wallet is created at BIP-84 / COIN_BTCX even when the v31
+        // branch itself has no history yet (only the v30 branch is a hit).
+        let plan = plan_v30_migration(V30, &[hit(V30)], &[V30]);
+        assert_eq!(plan, V30MigrationPlan::CreateV31 { policy: V31 });
+
+        // No probe hits anywhere (a never-synced legacy wallet) still gets
+        // its v31 counterpart — v31 creation does not depend on history.
+        let plan = plan_v30_migration(V30, &[], &[V30]);
+        assert_eq!(plan, V30MigrationPlan::CreateV31 { policy: V31 });
+
+        // A BIP-86 legacy wallet still gets the standard BIP-84 v31 default.
+        let v30_tr = policy(DescriptorKindCfg::Bip86, 0);
+        let plan = plan_v30_migration(v30_tr, &[hit(v30_tr)], &[v30_tr]);
+        assert_eq!(plan, V30MigrationPlan::CreateV31 { policy: V31 });
+    }
+
+    #[test]
+    fn only_v31_with_legacy_history_creates_the_v30_counterpart() {
+        // The v31 wallet is open, no v30 sibling, and the seed's coin-0'
+        // branch holds history → recover it as the v30 counterpart.
+        let plan = plan_v30_migration(V31, &[hit(V31), hit(V30)], &[V31]);
+        assert_eq!(plan, V30MigrationPlan::CreateV30Legacy { policy: V30 });
+    }
+
+    #[test]
+    fn only_v31_without_legacy_history_is_noop() {
+        // v31 open, no v30 sibling, and the probe finds NO coin-0' history →
+        // never manufacture an empty legacy wallet.
+        let plan = plan_v30_migration(V31, &[hit(V31)], &[V31]);
+        assert_eq!(plan, V30MigrationPlan::Noop);
+        // Not even when the probe is completely empty.
+        let plan = plan_v30_migration(V31, &[], &[V31]);
+        assert_eq!(plan, V30MigrationPlan::Noop);
+    }
+
+    #[test]
+    fn legacy_hit_selection_prefers_bip84_over_bip86() {
+        // Two coin-0' hits: the BIP-84 branch (candidate priority) is chosen
+        // for the recovered v30 wallet.
+        let v30_wpkh = policy(DescriptorKindCfg::Bip84, 0);
+        let v30_tr = policy(DescriptorKindCfg::Bip86, 0);
+        let plan = plan_v30_migration(V31, &[hit(v30_wpkh), hit(v30_tr)], &[V31]);
+        assert_eq!(plan, V30MigrationPlan::CreateV30Legacy { policy: v30_wpkh });
+
+        // Only a BIP-86 legacy hit present → that one is recovered.
+        let plan = plan_v30_migration(V31, &[hit(v30_tr)], &[V31]);
+        assert_eq!(plan, V30MigrationPlan::CreateV30Legacy { policy: v30_tr });
+    }
+
+    #[test]
+    fn does_not_re_create_an_existing_counterpart() {
+        // v31 open, the v30 sibling ALREADY exists, and the legacy branch
+        // has history: no duplicate is created (has_v30 short-circuits).
+        let plan = plan_v30_migration(V31, &[hit(V31), hit(V30)], &[V31, V30]);
+        assert_eq!(plan, V30MigrationPlan::Noop);
+
+        // v30 open, the v31 sibling already exists: no duplicate v31.
+        let plan = plan_v30_migration(V30, &[hit(V30)], &[V30, V31]);
+        assert_eq!(plan, V30MigrationPlan::Noop);
+    }
+
+    #[test]
+    fn wallet_on_neither_coin_type_is_noop() {
+        // A wallet on some other coin type (defensive — the command already
+        // scopes migration to seed wallets) triggers nothing.
+        let other = policy(DescriptorKindCfg::Bip84, 42);
+        let plan = plan_v30_migration(other, &[hit(other)], &[other]);
+        assert_eq!(plan, V30MigrationPlan::Noop);
+    }
+}

--- a/web-wallet/src-tauri/src/btcx_wallet/mod.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/mod.rs
@@ -48,6 +48,7 @@ pub mod config;
 pub mod descriptors;
 pub mod descstore;
 pub mod manager;
+pub mod migrate;
 pub mod psbt;
 pub mod state;
 

--- a/web-wallet/src-tauri/src/lib.rs
+++ b/web-wallet/src-tauri/src/lib.rs
@@ -946,6 +946,8 @@ pub fn run() {
             btcx_wallet::commands::btcx_wallet_create,
             btcx_wallet::commands::btcx_wallet_restore,
             btcx_wallet::commands::btcx_wallet_reprobe,
+            btcx_wallet::commands::btcx_wallet_migrate_v30,
+            btcx_wallet::commands::btcx_wallet_rescan_legacy,
             btcx_wallet::commands::btcx_wallet_import_descriptor,
             btcx_wallet::commands::btcx_wallet_validate_import,
             btcx_wallet::commands::btcx_wallet_unlock,

--- a/web-wallet/src-tauri/tests/btcx_wallet_regtest.rs
+++ b/web-wallet/src-tauri/tests/btcx_wallet_regtest.rs
@@ -337,12 +337,17 @@ fn regtest_restore_probe_selects_funded_branch() {
 
     // 1. Brand-new seed: no branch has history — the probe must say so
     //    honestly and the selection must fall back to the fresh default.
-    let hits = probe_all_branches(&seed, &chain).expect("probe against live electrs");
+    // Probe the mainnet (BTCX) candidate set explicitly: electrs serves by
+    // scripthash regardless of network, so the regtest node is valid infra
+    // for exercising the real mainnet coin-0'/BTCX probe path even though
+    // the wallet config elsewhere runs on regtest (coin type 1').
+    let hits = probe_all_branches(&seed, &chain, WalletNetwork::Mainnet)
+        .expect("probe against live electrs");
     assert!(
         hits.is_empty(),
         "a fresh seed cannot have history: {hits:?}"
     );
-    let (selected, fresh) = select_restore_policy(&hits);
+    let (selected, fresh) = select_restore_policy(&hits, WalletNetwork::Mainnet);
     assert!(fresh);
     assert_eq!(selected, DescriptorPolicy::default());
 
@@ -397,7 +402,8 @@ fn regtest_restore_probe_selects_funded_branch() {
 
     // 3. The probe now finds EXACTLY the funded branch, selects it, and
     //    reports the funded index in the hit list.
-    let hits = probe_all_branches(&seed, &chain).expect("probe against live electrs");
+    let hits = probe_all_branches(&seed, &chain, WalletNetwork::Mainnet)
+        .expect("probe against live electrs");
     assert_eq!(
         hits.len(),
         1,
@@ -406,7 +412,7 @@ fn regtest_restore_probe_selects_funded_branch() {
     assert_eq!(hits[0].policy, funded_policy);
     assert_eq!(hits[0].deepest_external, Some(0));
     assert_eq!(hits[0].deepest_internal, None);
-    let (selected, fresh) = select_restore_policy(&hits);
+    let (selected, fresh) = select_restore_policy(&hits, WalletNetwork::Mainnet);
     assert!(!fresh);
     assert_eq!(selected, funded_policy);
 
@@ -611,8 +617,11 @@ fn regtest_named_dual_kind_wallets() {
     );
     assert_eq!(
         result.selected,
-        DescriptorPolicy::default(),
-        "priority order opens BIP-84 / BTCX"
+        DescriptorPolicy {
+            kind: DescriptorKindCfg::Bip84,
+            coin_type: WalletNetwork::Regtest.asset_coin_type(),
+        },
+        "priority order opens BIP-84 at the regtest coin type (1')"
     );
     assert_eq!(result.status.wallet_name, "gamma");
     wait_for_balance(&state, 30_000_000, "gamma (restored BIP-84 branch)");
@@ -630,7 +639,10 @@ fn regtest_named_dual_kind_wallets() {
     .expect("kind-forced restore");
     assert!(!result.fresh);
     assert_eq!(result.selected.kind, DescriptorKindCfg::Bip86);
-    assert_eq!(result.selected.coin_type, keys_btcx::COIN_BTCX);
+    assert_eq!(
+        result.selected.coin_type,
+        WalletNetwork::Regtest.asset_coin_type()
+    );
     assert_eq!(result.status.wallet_name, "gamma-taproot");
     wait_for_balance(&state, 20_000_000, "gamma-taproot (restored BIP-86 branch)");
     let gamma_taproot_addr = state.backend().unwrap().wallet_new_address().unwrap();

--- a/web-wallet/src/app/bitcoin/services/wallet/descriptor.service.ts
+++ b/web-wallet/src/app/bitcoin/services/wallet/descriptor.service.ts
@@ -149,8 +149,32 @@ export class DescriptorService {
   }
 
   /**
-   * The descriptor set for a NEW wallet: BIP-84 (wpkh) + BIP-86 (tr) at
-   * the BTCX coin type, on every network.
+   * Master key fingerprint (8 hex chars) for a mnemonic (+ optional BIP39
+   * passphrase). Network-independent — the fingerprint hashes the master
+   * public key, not the extended-key serialization.
+   *
+   * Used by the v30→v31 upgrade path to prove a re-entered seed matches the
+   * seed a Core wallet's descriptors were derived from before importing the
+   * BTCX-coin-type branch.
+   */
+  getMasterFingerprint(mnemonic: string, passphrase = ''): string {
+    if (!this.validateMnemonic(mnemonic)) {
+      throw new Error('Invalid mnemonic phrase');
+    }
+    const seed = bip39.mnemonicToSeedSync(mnemonic.trim().toLowerCase(), passphrase);
+    const masterKey = HDKey.fromMasterSeed(seed);
+    return this.getFingerprint(masterKey);
+  }
+
+  /**
+   * The descriptor set for a NEW wallet: BIP-84 (wpkh) + BIP-86 (tr).
+   *
+   * Coin type is per-network: mainnet uses the registered per-asset BTCX
+   * coin type (spec §4.1); testnet/regtest use the shared SLIP-44 testnet
+   * coin type 1', matching Bitcoin Core and the Rust BDK backend
+   * (`WalletNetwork::asset_coin_type`). It keys off the same `isTestnet`
+   * flag that drives key serialization, so a wallet's coin type and its
+   * tprv/tpub encoding always agree.
    *
    * Deliberately NO 44'/49' branches: a freshly generated seed cannot have
    * history at any legacy purpose, and Phoenix never hands out legacy or
@@ -164,7 +188,7 @@ export class DescriptorService {
   ): WalletDescriptors {
     return this.generateDescriptors(mnemonic, {
       ...options,
-      coinType: BTCX_COIN_TYPE,
+      coinType: options.isTestnet ? 1 : BTCX_COIN_TYPE,
       enableLegacy: false,
       enableNestedSegwit: false,
       enableNativeSegwit: true,

--- a/web-wallet/src/app/bitcoin/services/wallet/wallet-manager.service.ts
+++ b/web-wallet/src/app/bitcoin/services/wallet/wallet-manager.service.ts
@@ -463,12 +463,15 @@ export class WalletManagerService {
         return { importLegacy: true, report: null };
       }
 
+      // The "current" coin type is per-network (mainnet: BTCX; testnet/
+      // regtest: 1'). A UTXO on the current branch is not legacy.
+      const currentCoinType = this.nodeService.network() === 'mainnet' ? BTCX_COIN_TYPE : 1;
       const legacy = new Set<string>();
       const pocx = new Set<string>();
       for (const unspent of result.unspents) {
         const branch = parseBranchFromDescriptor(unspent.desc);
         if (!branch) continue;
-        (branch.coinType === BTCX_COIN_TYPE ? pocx : legacy).add(branch.label);
+        (branch.coinType === currentCoinType ? pocx : legacy).add(branch.label);
       }
       return {
         importLegacy: legacy.size > 0,
@@ -608,6 +611,191 @@ export class WalletManagerService {
     } finally {
       this.isLoadingSubject.next(false);
     }
+  }
+
+  // ============================================================
+  // v30 → v31 Upgrade (BTCX coin-type migration)
+  // ============================================================
+  //
+  // OLD ("v30") Core wallets imported only the coin-type-0' descriptors.
+  // NEW ("v31") wallets import the BTCX coin type (0x504F4358) branch. Since
+  // Phoenix never persists a Core wallet's mnemonic, bitcoind cannot derive
+  // the BTCX branch on its own — upgrading an old wallet to see (and generate)
+  // v31 funds requires the user to RE-ENTER the seed, which is verified
+  // against the wallet's existing descriptors before anything is imported.
+
+  /**
+   * True only for a Core wallet that is both upgradeable AND not yet upgraded:
+   *
+   * - has at least one HD descriptor on a legacy (non-BTCX) coin type, AND
+   * - has NO active descriptor on the BTCX coin type, AND
+   * - has private keys (`getwalletinfo.private_keys_enabled`), AND
+   * - is not multisig.
+   *
+   * The private-keys gate excludes watch-only AND descriptor-imported wallets
+   * (Phoenix imports those with private keys disabled), and the "must have a
+   * legacy HD origin" gate excludes single-address (wpkh(WIF)) wallets, whose
+   * descriptors carry no `[fp/purpose'/coin'/…]` key origin. Together these
+   * enforce the product rule that a wallet created WITHOUT a mnemonic has no
+   * upgrade path and never shows an upgrade badge.
+   *
+   * Remote (local BDK) wallets always derive at the BTCX coin type — nothing
+   * to upgrade — so this is always false in remote mode.
+   */
+  async needsV31Upgrade(walletName: string): Promise<boolean> {
+    if (this.nodeService.isRemote()) return false;
+    // The v30→v31 split only exists on mainnet (coin 0' → BTCX coin type).
+    // Testnet/regtest use coin type 1' end to end, so their non-BTCX
+    // descriptors are the CURRENT branch, not a legacy one to upgrade.
+    if (this.nodeService.network() !== 'mainnet') return false;
+
+    let info: WalletInfo;
+    let descriptors: Array<{ desc: string; active: boolean }>;
+    try {
+      info = await this.walletRpc.getWalletInfo(walletName);
+      descriptors = (await this.walletRpc.listDescriptors(walletName)).descriptors;
+    } catch {
+      // Non-descriptor (legacy) wallet, or listing failed — no upgrade path.
+      return false;
+    }
+
+    // No keys → watch-only or descriptor-import → not upgradeable.
+    if (!info.private_keys_enabled) return false;
+
+    // Multisig descriptors embed their full original paths — excluded.
+    if (descriptors.some(d => parseMultisigDescriptor(d.desc) !== null)) return false;
+
+    let hasLegacyHd = false;
+    let hasActiveBtcx = false;
+    for (const d of descriptors) {
+      const branch = parseBranchFromDescriptor(d.desc);
+      // Skip raw-key / single-address descriptors (no BIP32 key origin).
+      if (!branch) continue;
+      if (branch.coinType === BTCX_COIN_TYPE) {
+        if (d.active) hasActiveBtcx = true;
+      } else {
+        hasLegacyHd = true;
+      }
+    }
+
+    return hasLegacyHd && !hasActiveBtcx;
+  }
+
+  /**
+   * Safety gate for the upgrade: confirm a re-entered mnemonic (+ optional
+   * BIP39 passphrase) actually derives the wallet's existing descriptors.
+   *
+   * Compares the mnemonic's master fingerprint against the master fingerprint
+   * carried in the wallet descriptors' key origins (`[fp/…]`), case-insensitive.
+   * A wrong seed must be rejected here before any BTCX descriptor is imported.
+   */
+  async verifyMnemonicMatchesWallet(
+    walletName: string,
+    mnemonic: string,
+    passphrase?: string
+  ): Promise<boolean> {
+    if (!this.descriptorService.validateMnemonic(mnemonic)) return false;
+
+    const walletFingerprint = await this.getWalletMasterFingerprint(walletName);
+    if (!walletFingerprint) return false;
+
+    const mnemonicFingerprint = this.descriptorService.getMasterFingerprint(
+      mnemonic,
+      passphrase ?? ''
+    );
+    return walletFingerprint.toLowerCase() === mnemonicFingerprint.toLowerCase();
+  }
+
+  /**
+   * Upgrade an old (coin-type-0') Core wallet to v31 by importing the BTCX
+   * coin-type branch, using a re-entered mnemonic.
+   *
+   * - Rejects a mismatched seed up front (`upgrade_seed_mismatch`).
+   * - Imports the BTCX 84'+86' branches ACTIVE and rescanned from genesis
+   *   (timestamp 0) so any v31-derivation history received on another install
+   *   of the same seed is discovered.
+   * - Re-imports the legacy branch INACTIVE (`active: false`) so bitcoind stops
+   *   handing out new addresses from it but keeps watching/spending the coins
+   *   already there; those coins drain into the BTCX branch as change over time.
+   *
+   * After success the wallet hands out v31 addresses and `needsV31Upgrade`
+   * becomes false.
+   */
+  async upgradeWalletToV31(
+    walletName: string,
+    mnemonic: string,
+    passphrase?: string
+  ): Promise<void> {
+    this.isLoadingSubject.next(true);
+
+    try {
+      if (!(await this.verifyMnemonicMatchesWallet(walletName, mnemonic, passphrase))) {
+        throw new Error('upgrade_seed_mismatch');
+      }
+
+      const isTestnet = this.nodeService.network() !== 'mainnet';
+      const descriptorOptions = {
+        passphrase,
+        isTestnet,
+        account: 0,
+        addressRange: [0, 999] as [number, number],
+      };
+
+      // BTCX branch: ACTIVE + rescan from genesis to pick up existing history.
+      const pocxSet = this.descriptorService.generateNewWalletDescriptors(
+        mnemonic,
+        descriptorOptions
+      );
+      const pocxEntries = this.descriptorService
+        .formatForImport(pocxSet)
+        .map(entry => ({ ...entry, active: true, timestamp: 0 as number | 'now' }));
+
+      // Legacy branch: re-import INACTIVE to deactivate address generation
+      // while keeping the funds watched/spendable. Already tracked, so no
+      // rescan is needed (timestamp 'now').
+      const legacySet = this.descriptorService.generateLegacyRestoreDescriptors(
+        mnemonic,
+        descriptorOptions
+      );
+      const legacyEntries = this.descriptorService
+        .formatForImport(legacySet)
+        .map(entry => ({ ...entry, active: false, timestamp: 'now' as number | 'now' }));
+
+      const importResults = await this.walletRpc.importDescriptors(walletName, [
+        ...pocxEntries,
+        ...legacyEntries,
+      ]);
+
+      const errors = importResults
+        .filter(r => !r.success)
+        .map(r => r.error?.message || 'Unknown import error');
+      if (errors.length > 0) {
+        throw new Error(errors.join(', '));
+      }
+
+      await this.refreshLoadedWallets();
+      this.walletsChangedSubject.next();
+    } finally {
+      this.isLoadingSubject.next(false);
+    }
+  }
+
+  /**
+   * Master-key fingerprint (8 hex) carried in a wallet's descriptor key
+   * origins (`[fp/…]`). Returns null for wallets whose descriptors have no
+   * origin (e.g. single-address / raw-key imports) or cannot be listed.
+   */
+  private async getWalletMasterFingerprint(walletName: string): Promise<string | null> {
+    try {
+      const { descriptors } = await this.walletRpc.listDescriptors(walletName);
+      for (const d of descriptors) {
+        const match = /\[([0-9a-fA-F]{8})\//.exec(d.desc);
+        if (match) return match[1];
+      }
+    } catch {
+      // Legacy wallet or listing failed.
+    }
+    return null;
   }
 
   // ============================================================

--- a/web-wallet/src/app/bitcoin/services/wallet/wallet-manager.service.ts
+++ b/web-wallet/src/app/bitcoin/services/wallet/wallet-manager.service.ts
@@ -137,6 +137,15 @@ export interface WalletSummary {
 export const SESSION_UNLOCK_SECONDS = 2_147_483_647;
 
 /**
+ * Earliest moment a v31 (BTCX coin type) address could hold funds: the
+ * `importdescriptors` rescan floor for the v30→v31 upgrade. The v31 coin type
+ * shipped 2026-07-09, so nothing can exist on a v31 branch before this — a
+ * rescan from here (2026-07-01 UTC, a safe margin) catches any v31 funds
+ * received on the same seed via another install without a full genesis rescan.
+ */
+export const V31_BIRTHDAY_TIMESTAMP = 1782864000;
+
+/**
  * WalletManagerService handles wallet lifecycle operations.
  *
  * Responsibilities:
@@ -665,20 +674,29 @@ export class WalletManagerService {
     // Multisig descriptors embed their full original paths — excluded.
     if (descriptors.some(d => parseMultisigDescriptor(d.desc) !== null)) return false;
 
-    let hasLegacyHd = false;
-    let hasActiveBtcx = false;
+    // New receives only ever come from the address types Phoenix hands out —
+    // wpkh (84', bech32) and tr (86', taproot). Needs upgrade iff one of THOSE
+    // is still active on a legacy (non-BTCX) coin type; importing the v31
+    // branch active auto-deactivates them (one active descriptor per output
+    // type). This also catches a PARTIAL upgrade, so the badge stays until the
+    // legacy 84'/86' branches are actually inactive.
+    //
+    // Bitcoin Core's default pkh(44') and sh(wpkh)(49') descriptors are NEVER
+    // used by Phoenix and hold no history, so an active one is harmless and
+    // must NOT keep the badge lit.
+    let hasActiveLegacyReceiveBranch = false;
     for (const d of descriptors) {
+      if (!d.active) continue;
       const branch = parseBranchFromDescriptor(d.desc);
       // Skip raw-key / single-address descriptors (no BIP32 key origin).
       if (!branch) continue;
-      if (branch.coinType === BTCX_COIN_TYPE) {
-        if (d.active) hasActiveBtcx = true;
-      } else {
-        hasLegacyHd = true;
+      const isPhoenixAddressType = branch.purpose === 84 || branch.purpose === 86;
+      if (isPhoenixAddressType && branch.coinType !== BTCX_COIN_TYPE) {
+        hasActiveLegacyReceiveBranch = true;
       }
     }
 
-    return hasLegacyHd && !hasActiveBtcx;
+    return hasActiveLegacyReceiveBranch;
   }
 
   /**
@@ -708,18 +726,28 @@ export class WalletManagerService {
 
   /**
    * Upgrade an old (coin-type-0') Core wallet to v31 by importing the BTCX
-   * coin-type branch, using a re-entered mnemonic.
+   * coin-type branch ACTIVE, using a re-entered mnemonic.
    *
-   * - Rejects a mismatched seed up front (`upgrade_seed_mismatch`).
-   * - Imports the BTCX 84'+86' branches ACTIVE and rescanned from genesis
-   *   (timestamp 0) so any v31-derivation history received on another install
-   *   of the same seed is discovered.
-   * - Re-imports the legacy branch INACTIVE (`active: false`) so bitcoind stops
-   *   handing out new addresses from it but keeps watching/spending the coins
-   *   already there; those coins drain into the BTCX branch as change over time.
+   * Importing the v31 84'(wpkh) + 86'(tr) branches active is the ENTIRE job:
+   * Bitcoin Core allows one active descriptor per output type, so this
+   * automatically deactivates the previously-active legacy wpkh(84'/0') and
+   * tr(86'/0') branches. They stay watched/spendable — funds intact, draining
+   * into the v31 branch as change — but stop handing out new addresses. No
+   * explicit legacy re-import (or range juggling) is needed.
    *
-   * After success the wallet hands out v31 addresses and `needsV31Upgrade`
-   * becomes false.
+   * Bitcoin Core's default pkh(44') and sh(wpkh)(49') descriptors are a
+   * different output type, so they stay active — but Phoenix only ever
+   * requests bech32/taproot addresses, so they're never used and hold no
+   * history. We deliberately leave them alone (`needsV31Upgrade` ignores
+   * them, so the badge still clears).
+   *
+   * The v31 branch is new to this wallet (it never handed out v31 addresses),
+   * so its only possible history is funds received on the SAME seed via
+   * another install (mobile/BDK) after the v31 coin type shipped — hence a
+   * rescan from the v31 birthday rather than genesis.
+   *
+   * Rejects a mismatched seed up front (`upgrade_seed_mismatch`). After
+   * success the wallet hands out v31 addresses and `needsV31Upgrade` is false.
    */
   async upgradeWalletToV31(
     walletName: string,
@@ -733,38 +761,19 @@ export class WalletManagerService {
         throw new Error('upgrade_seed_mismatch');
       }
 
-      const isTestnet = this.nodeService.network() !== 'mainnet';
-      const descriptorOptions = {
+      const pocxSet = this.descriptorService.generateNewWalletDescriptors(mnemonic, {
         passphrase,
-        isTestnet,
+        isTestnet: this.nodeService.network() !== 'mainnet',
         account: 0,
-        addressRange: [0, 999] as [number, number],
-      };
+        addressRange: [0, 999],
+      });
+      const pocxEntries = this.descriptorService.formatForImport(pocxSet).map(entry => ({
+        ...entry,
+        active: true,
+        timestamp: V31_BIRTHDAY_TIMESTAMP as number | 'now',
+      }));
 
-      // BTCX branch: ACTIVE + rescan from genesis to pick up existing history.
-      const pocxSet = this.descriptorService.generateNewWalletDescriptors(
-        mnemonic,
-        descriptorOptions
-      );
-      const pocxEntries = this.descriptorService
-        .formatForImport(pocxSet)
-        .map(entry => ({ ...entry, active: true, timestamp: 0 as number | 'now' }));
-
-      // Legacy branch: re-import INACTIVE to deactivate address generation
-      // while keeping the funds watched/spendable. Already tracked, so no
-      // rescan is needed (timestamp 'now').
-      const legacySet = this.descriptorService.generateLegacyRestoreDescriptors(
-        mnemonic,
-        descriptorOptions
-      );
-      const legacyEntries = this.descriptorService
-        .formatForImport(legacySet)
-        .map(entry => ({ ...entry, active: false, timestamp: 'now' as number | 'now' }));
-
-      const importResults = await this.walletRpc.importDescriptors(walletName, [
-        ...pocxEntries,
-        ...legacyEntries,
-      ]);
+      const importResults = await this.walletRpc.importDescriptors(walletName, pocxEntries);
 
       const errors = importResults
         .filter(r => !r.success)

--- a/web-wallet/src/app/core/services/btcx-wallet.service.ts
+++ b/web-wallet/src/app/core/services/btcx-wallet.service.ts
@@ -1,6 +1,8 @@
-import { Injectable, signal, computed } from '@angular/core';
+import { Injectable, signal, computed, inject } from '@angular/core';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
+import { NotificationService } from '../../shared/services/notification.service';
+import { I18nService } from '../i18n';
 
 /**
  * BTCX Wallet Service
@@ -232,6 +234,34 @@ export interface BtcxWalletSummary {
   balanceSat?: number;
 }
 
+/**
+ * What one v30→v31 migration pass did (`btcx_wallet_migrate_v30` /
+ * `btcx_wallet_rescan_legacy`):
+ * - `noop` — nothing to create; the seed has no counterpart to build.
+ * - `created-v31` — a v31 (BTCX coin type) counterpart was created + activated.
+ * - `created-v30` — a legacy v30 (coin type 0') counterpart was restored.
+ * - `already` — the migrate flag was already set (migrate pass only).
+ * - `deferred` — skipped without weakening the seed at rest (locked/encrypted).
+ */
+export type BtcxV30MigrationOutcome =
+  | 'noop'
+  | 'created-v31'
+  | 'created-v30'
+  | 'already'
+  | 'deferred';
+
+/** Result of a v30→v31 migration pass (`btcx_wallet_migrate_v30` / rescan). */
+export interface BtcxV30MigrationResult {
+  outcome: BtcxV30MigrationOutcome;
+  /** The wallet selected after the pass. */
+  activeWallet: string;
+  /** The counterpart wallet created (v31 or v30), if any. */
+  createdWallet?: string;
+  /** Human-readable note — e.g. why the pass deferred. */
+  detail?: string;
+  status: BtcxWalletStatus;
+}
+
 /** Persisted wallet configuration (`btcx_wallet_get_config`). */
 export interface BtcxWalletConfig {
   network: BtcxNetwork;
@@ -397,6 +427,9 @@ export function mapWalletTx(dto: BtcxWalletTxDto): BtcxWalletTx {
 
 @Injectable({ providedIn: 'root' })
 export class BtcxWalletService {
+  private readonly notification = inject(NotificationService);
+  private readonly i18n = inject(I18nService);
+
   // Signals for reactive state
   private readonly _status = signal<BtcxWalletStatus | null>(null);
   private readonly _balance = signal<BtcxBalance | null>(null);
@@ -509,6 +542,8 @@ export class BtcxWalletService {
       await Promise.all([this.refreshStatus(), this.refreshConfig()]);
       if (this.walletActive()) {
         await Promise.all([this.refreshBalance(), this.refreshTransactions(RECENT_TX_LIMIT)]);
+        // An already-open wallet on launch may still be a pre-v31 seed.
+        void this.autoMigrateV30();
       }
       this._initialized.set(true);
     } catch (err) {
@@ -678,6 +713,9 @@ export class BtcxWalletService {
     const status = await invoke<BtcxWalletStatus>('btcx_wallet_unlock', { passphrase });
     this._status.set(status);
     await this.refreshAll();
+    // Unlocking is the deferred-migration retry: a seed that could not be
+    // migrated while locked can be now that it is open.
+    void this.autoMigrateV30();
     return status;
   }
 
@@ -735,7 +773,61 @@ export class BtcxWalletService {
     this._lastSync.set(null);
     await this.refreshConfig();
     await this.refreshAll();
+    // A newly-opened wallet may still be a pre-v31 (coin-0') seed — migrate
+    // it (and surface the one-time notice) once it is open.
+    void this.autoMigrateV30();
     return status;
+  }
+
+  // ============================================================================
+  // v30 → v31 Migration
+  // ============================================================================
+
+  /**
+   * Silently upgrade a pre-v31 (legacy coin-0') seed to the new BTCX coin
+   * type: when the open wallet's seed has an unregistered counterpart, the
+   * backend creates it (`created-v31` for the v31 branch, `created-v30` for a
+   * legacy branch with history) and records the pass; a locked/encrypted seed
+   * `deferred`s so a later open retries. Refreshes config/status on success.
+   * Throws on failure — callers decide whether to surface it.
+   */
+  async migrateV30(): Promise<BtcxV30MigrationResult> {
+    const result = await invoke<BtcxV30MigrationResult>('btcx_wallet_migrate_v30');
+    this._status.set(result.status);
+    await this.refreshConfig();
+    return result;
+  }
+
+  /**
+   * Re-run the legacy (v30) probe for the open wallet, ignoring the migrate
+   * flag — the "check for older funds" affordance. Restores a legacy
+   * counterpart when history turns up (`created-v30`), otherwise `noop`.
+   * Refreshes config/status. Throws on failure.
+   */
+  async rescanLegacy(): Promise<BtcxV30MigrationResult> {
+    const result = await invoke<BtcxV30MigrationResult>('btcx_wallet_rescan_legacy');
+    this._status.set(result.status);
+    await this.refreshConfig();
+    return result;
+  }
+
+  /**
+   * Fire-and-forget v30 migration run for the open wallet, showing the calm
+   * one-time notice only when a counterpart was actually created. Naturally
+   * idempotent: once migrated the backend returns `already`/`noop`, and a
+   * locked seed `deferred`s silently — so this is safe to call on every open.
+   */
+  private async autoMigrateV30(): Promise<void> {
+    if (!this.walletActive()) return;
+    try {
+      const result = await this.migrateV30();
+      if (result.outcome === 'created-v31' || result.outcome === 'created-v30') {
+        this.notification.info(this.i18n.get('wallet_v30_migrated_notice'), undefined, 8000);
+      }
+    } catch (err) {
+      // A migration hiccup must never block using the wallet — log and move on.
+      console.warn('v30 auto-migration failed:', err);
+    }
   }
 
   /**

--- a/web-wallet/src/app/features/auth/components/upgrade-wallet-dialog/upgrade-wallet-dialog.component.ts
+++ b/web-wallet/src/app/features/auth/components/upgrade-wallet-dialog/upgrade-wallet-dialog.component.ts
@@ -53,6 +53,11 @@ export interface UpgradeWalletDialogData {
     <mat-dialog-content>
       <p class="dialog-body">{{ 'wallet_upgrade_body' | i18n }}</p>
 
+      <p class="rescan-note">
+        <mat-icon>schedule</mat-icon>
+        {{ 'wallet_upgrade_rescan_warning' | i18n }}
+      </p>
+
       <app-mnemonic-entry [disabled]="upgrading()" (changed)="onMnemonicChange($event)" />
 
       <mat-form-field appearance="outline" class="full-width">
@@ -113,6 +118,27 @@ export interface UpgradeWalletDialogData {
         margin-bottom: 16px;
       }
 
+      .rescan-note {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        color: #b26a00;
+        background: rgba(255, 152, 0, 0.1);
+        border-radius: 6px;
+        padding: 10px 12px;
+        font-size: 13px;
+        line-height: 1.5;
+        margin: 0 0 16px;
+
+        mat-icon {
+          font-size: 18px;
+          width: 18px;
+          height: 18px;
+          margin-top: 1px;
+          flex-shrink: 0;
+        }
+      }
+
       mat-dialog-content {
         max-width: 560px;
       }
@@ -144,6 +170,11 @@ export interface UpgradeWalletDialogData {
       :host-context(.dark-theme) {
         .dialog-body {
           color: rgba(255, 255, 255, 0.8);
+        }
+
+        .rescan-note {
+          color: #ffb74d;
+          background: rgba(255, 152, 0, 0.16);
         }
       }
     `,

--- a/web-wallet/src/app/features/auth/components/upgrade-wallet-dialog/upgrade-wallet-dialog.component.ts
+++ b/web-wallet/src/app/features/auth/components/upgrade-wallet-dialog/upgrade-wallet-dialog.component.ts
@@ -1,0 +1,204 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { I18nPipe, I18nService } from '../../../../core/i18n';
+import { WalletManagerService } from '../../../../bitcoin/services/wallet/wallet-manager.service';
+import {
+  MnemonicEntryComponent,
+  MnemonicEntryState,
+} from '../../../../shared/components/mnemonic-entry/mnemonic-entry.component';
+
+/** Payload of the upgrade dialog: the wallet to upgrade. */
+export interface UpgradeWalletDialogData {
+  walletName: string;
+}
+
+/**
+ * UpgradeWalletDialogComponent — guided v30→v31 upgrade for a Core (desktop
+ * managed/external) wallet.
+ *
+ * A calm explainer, the shared mnemonic-entry grid plus an optional BIP39
+ * passphrase field, and Upgrade/Cancel. On Upgrade it re-verifies the seed
+ * and imports the BTCX coin-type branch via
+ * `WalletManagerService.upgradeWalletToV31`. A mismatched seed
+ * (`upgrade_seed_mismatch`) surfaces inline without closing; the rescan can
+ * take a while, so the actions show a spinner while it runs. Closes with
+ * `true` on success so the caller clears the badge / refreshes the list.
+ */
+@Component({
+  selector: 'app-upgrade-wallet-dialog',
+  standalone: true,
+  imports: [
+    FormsModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    MnemonicEntryComponent,
+    I18nPipe,
+  ],
+  template: `
+    <h2 mat-dialog-title class="dialog-title">
+      <mat-icon class="title-icon">upgrade</mat-icon>
+      {{ 'wallet_upgrade_title' | i18n }}
+    </h2>
+
+    <mat-dialog-content>
+      <p class="dialog-body">{{ 'wallet_upgrade_body' | i18n }}</p>
+
+      <app-mnemonic-entry [disabled]="upgrading()" (changed)="onMnemonicChange($event)" />
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'mwallet_passphrase_optional' | i18n }}</mat-label>
+        <input
+          matInput
+          type="password"
+          [(ngModel)]="passphrase"
+          [disabled]="upgrading()"
+          autocomplete="off"
+          autocapitalize="none"
+          spellcheck="false"
+        />
+      </mat-form-field>
+
+      @if (error()) {
+        <p class="error-text">
+          <mat-icon>error_outline</mat-icon>
+          {{ error() }}
+        </p>
+      }
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      <button mat-button [disabled]="upgrading()" (click)="onCancel()">
+        {{ 'cancel' | i18n }}
+      </button>
+      <button
+        mat-raised-button
+        color="primary"
+        [disabled]="!mnemonicValid() || upgrading()"
+        (click)="onUpgrade()"
+      >
+        @if (upgrading()) {
+          <mat-spinner diameter="20"></mat-spinner>
+        } @else {
+          <mat-icon>upgrade</mat-icon>
+        }
+        {{ 'wallet_upgrade_cta' | i18n }}
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `
+      .dialog-title {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .title-icon {
+        color: #ff9800;
+      }
+
+      .dialog-body {
+        color: rgba(0, 0, 0, 0.7);
+        line-height: 1.6;
+        margin-bottom: 16px;
+      }
+
+      mat-dialog-content {
+        max-width: 560px;
+      }
+
+      .full-width {
+        width: 100%;
+      }
+
+      .error-text {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: #f44336;
+        font-size: 13px;
+        margin: 4px 0 0;
+
+        mat-icon {
+          font-size: 18px;
+          width: 18px;
+          height: 18px;
+        }
+      }
+
+      mat-dialog-actions button mat-spinner {
+        display: inline-block;
+        margin-right: 8px;
+      }
+
+      :host-context(.dark-theme) {
+        .dialog-body {
+          color: rgba(255, 255, 255, 0.8);
+        }
+      }
+    `,
+  ],
+})
+export class UpgradeWalletDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<UpgradeWalletDialogComponent>);
+  private readonly data = inject<UpgradeWalletDialogData>(MAT_DIALOG_DATA);
+  private readonly walletManager = inject(WalletManagerService);
+  private readonly i18n = inject(I18nService);
+
+  /** Latest mnemonic-entry state (phrase + BIP39 validity). */
+  private mnemonic = '';
+  readonly mnemonicValid = signal(false);
+
+  passphrase = '';
+
+  readonly upgrading = signal(false);
+  readonly error = signal<string | null>(null);
+
+  onMnemonicChange(state: MnemonicEntryState): void {
+    this.mnemonic = state.mnemonic;
+    this.mnemonicValid.set(state.valid);
+    // Editing the phrase clears a stale mismatch message.
+    if (this.error()) this.error.set(null);
+  }
+
+  async onUpgrade(): Promise<void> {
+    if (!this.mnemonicValid() || this.upgrading()) return;
+
+    this.upgrading.set(true);
+    this.error.set(null);
+    try {
+      await this.walletManager.upgradeWalletToV31(
+        this.data.walletName,
+        this.mnemonic,
+        this.passphrase || undefined
+      );
+      this.dialogRef.close(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : `${err}`;
+      // The backend throws `upgrade_seed_mismatch` for a wrong seed; any
+      // other failure surfaces its raw message.
+      this.error.set(
+        message === 'upgrade_seed_mismatch'
+          ? this.i18n.get('wallet_upgrade_seed_mismatch')
+          : message
+      );
+    } finally {
+      this.upgrading.set(false);
+    }
+  }
+
+  onCancel(): void {
+    if (this.upgrading()) return;
+    this.dialogRef.close(false);
+  }
+}

--- a/web-wallet/src/app/features/auth/pages/import-wallet/import-wallet.component.ts
+++ b/web-wallet/src/app/features/auth/pages/import-wallet/import-wallet.component.ts
@@ -25,6 +25,7 @@ import {
   BtcxWalletService,
   BtcxRestoreResult,
   BtcxDescriptorPolicy,
+  BTCX_COIN_TYPE,
 } from '../../../../core/services/btcx-wallet.service';
 
 /**
@@ -551,11 +552,13 @@ export class ImportWalletComponent implements OnInit, OnDestroy {
 
   /**
    * Map the remote restore's probe hits onto the same branch-report shape
-   * the Core path renders (legacy = coin type 0', pocx = the BTCX type).
+   * the Core path renders. Only coin type 0' is legacy; the current branch
+   * is the BTCX coin type on mainnet or 1' on testnet/regtest.
    */
   private mapBtcxRestore(result: BtcxRestoreResult): RestoreBranchReport {
+    const coin = (ct: number) => (ct === BTCX_COIN_TYPE ? 'BTCX' : `${ct}'`);
     const label = (p: BtcxDescriptorPolicy) =>
-      `${p.kind === 'bip84' ? "84'" : "86'"}/${p.coinType === 0 ? "0'" : 'BTCX'}`;
+      `${p.kind === 'bip84' ? "84'" : "86'"}/${coin(p.coinType)}`;
     return {
       legacy: result.hits.filter(h => h.policy.coinType === 0).map(h => label(h.policy)),
       pocx: result.hits.filter(h => h.policy.coinType !== 0).map(h => label(h.policy)),

--- a/web-wallet/src/app/features/auth/pages/wallet-select/wallet-select.component.ts
+++ b/web-wallet/src/app/features/auth/pages/wallet-select/wallet-select.component.ts
@@ -9,7 +9,12 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTableModule } from '@angular/material/table';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { I18nPipe, I18nService } from '../../../../core/i18n';
+import {
+  UpgradeWalletDialogComponent,
+  UpgradeWalletDialogData,
+} from '../../components/upgrade-wallet-dialog/upgrade-wallet-dialog.component';
 import {
   WalletManagerService,
   WalletSummary,
@@ -38,6 +43,7 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
     MatTableModule,
     MatProgressSpinnerModule,
     MatSnackBarModule,
+    MatDialogModule,
     I18nPipe,
   ],
   template: `
@@ -161,6 +167,16 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
                         "
                         >group</mat-icon
                       >
+                    }
+                    @if (needsUpgrade(wallet.name)) {
+                      <button
+                        mat-icon-button
+                        class="upgrade-badge"
+                        [matTooltip]="'wallet_upgrade_tooltip' | i18n"
+                        (click)="openUpgradeDialog(wallet, $event)"
+                      >
+                        <mat-icon>system_update_alt</mat-icon>
+                      </button>
                     }
                   </td>
                 </ng-container>
@@ -579,6 +595,23 @@ import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service
           color: #9c27b0;
         }
 
+        /* v30→v31 upgrade affordance: amber, compact, inline after the name. */
+        .upgrade-badge {
+          width: 28px;
+          height: 28px;
+          padding: 0;
+          line-height: 28px;
+          vertical-align: middle;
+          margin-left: 4px;
+          color: #ff9800;
+
+          mat-icon {
+            font-size: 18px;
+            width: 18px;
+            height: 18px;
+          }
+        }
+
         .encryption-icon {
           font-size: 20px;
           width: 20px;
@@ -711,6 +744,7 @@ export class WalletSelectComponent implements OnInit, OnDestroy {
   private readonly walletManager = inject(WalletManagerService);
   private readonly cookieAuth = inject(CookieAuthService);
   private readonly snackBar = inject(MatSnackBar);
+  private readonly dialog = inject(MatDialog);
   private readonly i18n = inject(I18nService);
   private readonly appUpdateService = inject(AppUpdateService);
   private readonly walletUnlock = inject(WalletUnlockService);
@@ -731,6 +765,13 @@ export class WalletSelectComponent implements OnInit, OnDestroy {
   connectionError = signal<string | null>(null);
   wallets = signal<WalletSummary[]>([]);
   selectedWallet = signal<string | null>(null);
+
+  /**
+   * Per-wallet v31-upgrade need, cached from `needsV31Upgrade` (an RPC call —
+   * never invoked from the template). Always empty in remote mode, where the
+   * local BDK wallets already derive at the BTCX coin type.
+   */
+  private readonly upgradeNeeded = signal<Record<string, boolean>>({});
 
   // Computed: are we connected to the node?
   isConnected = computed(() => !this.isConnecting() && !this.connectionError());
@@ -817,9 +858,53 @@ export class WalletSelectComponent implements OnInit, OnDestroy {
           this.selectedWallet.set(firstLoaded.name);
         }
       }
+
+      void this.refreshUpgradeFlags(summaries);
     } finally {
       this.isLoading.set(false);
     }
+  }
+
+  /**
+   * Populate the upgrade-need cache for the listed wallets (one RPC each,
+   * `needsV31Upgrade` is a no-op in remote mode). Runs off the render path so
+   * the table paints immediately; the amber badge appears as answers arrive.
+   */
+  private async refreshUpgradeFlags(summaries: WalletSummary[]): Promise<void> {
+    const entries = await Promise.all(
+      summaries.map(async w => {
+        try {
+          return [w.name, await this.walletManager.needsV31Upgrade(w.name)] as const;
+        } catch {
+          return [w.name, false] as const;
+        }
+      })
+    );
+    this.upgradeNeeded.set(Object.fromEntries(entries));
+  }
+
+  /** Whether the named wallet needs a v31 upgrade (cached; template-safe). */
+  needsUpgrade(walletName: string): boolean {
+    return this.upgradeNeeded()[walletName] === true;
+  }
+
+  /**
+   * Open the guided re-enter upgrade dialog for a wallet. On success the
+   * wallet has been upgraded (badge clears) — reload the list.
+   */
+  openUpgradeDialog(wallet: WalletSummary, event: Event): void {
+    event.stopPropagation();
+    const data: UpgradeWalletDialogData = { walletName: wallet.name };
+    this.dialog
+      .open(UpgradeWalletDialogComponent, { data, width: '560px', disableClose: true })
+      .afterClosed()
+      .subscribe((upgraded: boolean | undefined) => {
+        if (!upgraded) return;
+        this.snackBar.open(this.i18n.get('wallet_upgrade_success'), this.i18n.get('dismiss'), {
+          duration: 4000,
+        });
+        void this.loadWallets();
+      });
   }
 
   retryConnection(): void {

--- a/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
@@ -393,8 +393,16 @@ export class WalletRestoreComponent implements OnInit, OnDestroy {
     const policy = this.result()?.selected ?? this.wallet.descriptorPolicy();
     if (!policy) return '';
     const kind = policy.kind === 'bip86' ? 'BIP-86' : 'BIP-84';
-    const coin =
-      policy.coinType === BTCX_COIN_TYPE ? 'BTCX' : this.i18n.get('mwallet_branch_legacy');
+    // Only coin type 0' is legacy. The current branch is the BTCX coin type
+    // on mainnet, or 1' on testnet/regtest.
+    let coin: string;
+    if (policy.coinType === 0) {
+      coin = this.i18n.get('mwallet_branch_legacy');
+    } else if (policy.coinType === BTCX_COIN_TYPE) {
+      coin = 'BTCX';
+    } else {
+      coin = `${policy.coinType}'`;
+    }
     return `${kind} / ${coin}`;
   });
 

--- a/web-wallet/src/app/features/mobile-wallet/pages/settings/wallet-settings.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/settings/wallet-settings.component.ts
@@ -161,6 +161,11 @@ const DRAG_SLOP_PX = 8;
                         ) | i18n
                       }}
                     </span>
+                    @if (w.policy.coinType === 0) {
+                      <span class="row-badge legacy">
+                        {{ 'wallet_legacy_badge' | i18n }}
+                      </span>
+                    }
                     @if (w.singleAddress) {
                       <span class="row-badge single">
                         {{ 'mwallet_single_badge' | i18n }}
@@ -271,6 +276,26 @@ const DRAG_SLOP_PX = 8;
           <button mat-stroked-button class="full-width" [disabled]="busy()" (click)="lock()">
             <mat-icon>lock</mat-icon>
             {{ 'mwallet_lock_wallet' | i18n }}
+          </button>
+        </div>
+      }
+
+      <!-- Older (v30) funds — re-probe the legacy branch for the open wallet -->
+      @if (wallet.walletActive()) {
+        <div class="card">
+          <h3>{{ 'wallet_rescan_legacy' | i18n }}</h3>
+          <button
+            mat-stroked-button
+            class="full-width"
+            [disabled]="busy() || rescanning()"
+            (click)="rescanLegacy()"
+          >
+            @if (rescanning()) {
+              <mat-spinner diameter="18"></mat-spinner>
+            } @else {
+              <mat-icon>manage_search</mat-icon>
+            }
+            {{ 'wallet_rescan_legacy' | i18n }}
           </button>
         </div>
       }
@@ -646,6 +671,9 @@ export class WalletSettingsComponent implements OnInit {
   readonly networks: BtcxNetwork[] = ['mainnet', 'testnet', 'regtest'];
   readonly busy = signal(false);
 
+  /** True while a legacy (v30) re-probe is in flight. */
+  readonly rescanning = signal(false);
+
   /** App version (e.g. "2.1.1") from the Tauri shell; null until loaded. */
   readonly appVersion = signal<string | null>(null);
 
@@ -924,6 +952,29 @@ export class WalletSettingsComponent implements OnInit {
       this.notification.success(this.i18n.get('mwallet_locked_title'));
     } finally {
       this.busy.set(false);
+    }
+  }
+
+  /**
+   * Re-probe the legacy (v30) branch for the open wallet and restore a
+   * counterpart if older funds turn up — the manual "check for older funds"
+   * lever (the silent auto-migration is a no-op once already migrated).
+   */
+  async rescanLegacy(): Promise<void> {
+    if (this.busy() || this.rescanning()) return;
+    this.rescanning.set(true);
+    try {
+      const result = await this.wallet.rescanLegacy();
+      this.notification.success(
+        this.i18n.get(
+          result.outcome === 'created-v30' ? 'wallet_rescan_found' : 'wallet_rescan_none'
+        )
+      );
+    } catch (err) {
+      console.error('Failed to rescan legacy funds:', err);
+      this.notification.error(`${err}`);
+    } finally {
+      this.rescanning.set(false);
     }
   }
 }

--- a/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
+++ b/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
@@ -679,6 +679,49 @@ function withListenPort(listenAddress: string, port: number): string {
                     />
                   </div>
 
+                  <!-- Wallets (the remote-mode switcher's list) — carries the
+                       "Legacy v30" badge on pre-v31 (coin-0') wallets, and the
+                       manual re-probe for older funds on the open wallet. -->
+                  @if (btcxWallet.wallets().length > 0) {
+                    <div class="config-section">
+                      <h3 class="section-title">{{ 'wallets' | i18n }}</h3>
+                      <div class="remote-wallet-list">
+                        @for (w of btcxWallet.wallets(); track w.name) {
+                          <div class="remote-wallet-row" [class.active]="w.isActive">
+                            <mat-icon class="remote-wallet-icon" [class.active]="w.isActive"
+                              >account_balance_wallet</mat-icon
+                            >
+                            <span class="remote-wallet-name">{{ w.name }}</span>
+                            @if (w.policy.coinType === 0) {
+                              <span class="remote-wallet-badge legacy">{{
+                                'wallet_legacy_badge' | i18n
+                              }}</span>
+                            }
+                            @if (w.isActive) {
+                              <mat-icon class="remote-wallet-check">check</mat-icon>
+                            }
+                          </div>
+                        }
+                      </div>
+
+                      @if (btcxWallet.walletActive()) {
+                        <button
+                          mat-stroked-button
+                          class="rescan-legacy-button"
+                          [disabled]="rescanningLegacy()"
+                          (click)="rescanLegacy()"
+                        >
+                          @if (rescanningLegacy()) {
+                            <mat-spinner diameter="18"></mat-spinner>
+                          } @else {
+                            <mat-icon>manage_search</mat-icon>
+                          }
+                          {{ 'wallet_rescan_legacy' | i18n }}
+                        </button>
+                      }
+                    </div>
+                  }
+
                   <!-- Action Buttons -->
                   <div class="action-buttons">
                     <button
@@ -1364,6 +1407,76 @@ function withListenPort(listenAddress: string, port: number): string {
         }
       }
 
+      /* Remote-mode wallet list (the switcher's list in settings) */
+      .remote-wallet-list {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 12px;
+      }
+
+      .remote-wallet-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 10px;
+        border-radius: 6px;
+        background: rgba(0, 0, 0, 0.03);
+
+        &.active {
+          background: rgba(25, 118, 210, 0.08);
+        }
+
+        .remote-wallet-icon {
+          font-size: 20px;
+          width: 20px;
+          height: 20px;
+          color: rgba(0, 0, 0, 0.4);
+
+          &.active {
+            color: #1976d2;
+          }
+        }
+
+        .remote-wallet-name {
+          flex: 1;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .remote-wallet-badge {
+          font-size: 10px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.4px;
+          border: 1px solid currentColor;
+          border-radius: 8px;
+          padding: 0 6px;
+          flex-shrink: 0;
+
+          /* v30 legacy wallets: amber hue (the kind-badge legacy family). */
+          &.legacy {
+            color: #b26a00;
+          }
+        }
+
+        .remote-wallet-check {
+          font-size: 18px;
+          width: 18px;
+          height: 18px;
+          color: #1976d2;
+          flex-shrink: 0;
+        }
+      }
+
+      .rescan-legacy-button {
+        mat-spinner {
+          display: inline-block;
+          margin-right: 8px;
+        }
+      }
+
       /* Notifications Styles */
       .notifications-container {
         max-width: 500px;
@@ -1885,8 +1998,11 @@ export class SettingsComponent implements OnInit, OnDestroy {
   readonly nodeService = inject(NodeService);
   protected readonly aggregatorService = inject(AggregatorService);
   private readonly appMode = inject(AppModeService);
-  private readonly btcxWallet = inject(BtcxWalletService);
+  protected readonly btcxWallet = inject(BtcxWalletService);
   private readonly destroy$ = new Subject<void>();
+
+  /** True while a remote-mode legacy (v30) re-probe is in flight. */
+  readonly rescanningLegacy = signal(false);
 
   // Managed node state
   nodeMode = signal<NodeMode>('managed');
@@ -2491,6 +2607,28 @@ export class SettingsComponent implements OnInit, OnDestroy {
   onRemoteNetworkChange(network: 'mainnet' | 'testnet' | 'regtest'): void {
     this.remoteNetwork.set(network);
     this.remoteServers.set(this.btcxWallet.serversFor(network));
+  }
+
+  /**
+   * Remote-mode "check for older (v30) funds": re-probe the legacy branch for
+   * the open BDK wallet and restore a counterpart if history turns up.
+   */
+  async rescanLegacy(): Promise<void> {
+    if (this.rescanningLegacy()) return;
+    this.rescanningLegacy.set(true);
+    try {
+      const result = await this.btcxWallet.rescanLegacy();
+      this.notification.success(
+        this.i18n.get(
+          result.outcome === 'created-v30' ? 'wallet_rescan_found' : 'wallet_rescan_none'
+        )
+      );
+    } catch (err) {
+      console.error('Failed to rescan legacy funds:', err);
+      this.notification.error(`${err}`);
+    } finally {
+      this.rescanningLegacy.set(false);
+    }
   }
 
   async startManagedNode(): Promise<void> {

--- a/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
+++ b/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
@@ -72,6 +72,7 @@ export interface MnemonicEntryState {
           <mat-autocomplete
             #auto="matAutocomplete"
             [autoActiveFirstOption]="true"
+            panelWidth="auto"
             (optionSelected)="onWordSelected(i, $event.option.value)"
           >
             @for (suggestion of wordSuggestions[i]; track suggestion) {

--- a/web-wallet/src/assets/locales/bg.json
+++ b/web-wallet/src/assets/locales/bg.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Публичен ключ разкрит",
   "address_exposed_hint": "Вече сте харчили от този адрес, затова публичният му ключ вече е видим в блокчейна. Това е нормално и монетите ви са в безопасност — използването на нов адрес всеки път просто запазва най-силната поверителност и защита.",
   "add_wallet": "Добави портфейл",
-  "coins_col": "Монети"
+  "coins_col": "Монети",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/bg.json
+++ b/web-wallet/src/assets/locales/bg.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/ca.json
+++ b/web-wallet/src/assets/locales/ca.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Clau pública coneguda",
   "address_exposed_hint": "Ja heu gastat des d'aquesta adreça abans, així que la seva clau pública ara és visible a la cadena de blocs. Això és normal i les vostres monedes estan segures — utilitzar una adreça nova cada vegada simplement manté la privadesa i protecció més fortes.",
   "add_wallet": "Afegeix cartera",
-  "coins_col": "Monedes"
+  "coins_col": "Monedes",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/ca.json
+++ b/web-wallet/src/assets/locales/ca.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/cs.json
+++ b/web-wallet/src/assets/locales/cs.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Veřejný klíč znám",
   "address_exposed_hint": "Z této adresy jste již dříve utráceli, takže její veřejný klíč je nyní viditelný v blockchainu. To je normální a vaše mince jsou v bezpečí — použití vždy nové adresy jen zachovává nejsilnější soukromí a ochranu.",
   "add_wallet": "Přidat peněženku",
-  "coins_col": "Mince"
+  "coins_col": "Mince",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/cs.json
+++ b/web-wallet/src/assets/locales/cs.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/de-de.json
+++ b/web-wallet/src/assets/locales/de-de.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Öffentlicher Schlüssel bekannt",
   "address_exposed_hint": "Du hast von dieser Adresse bereits einmal Geld ausgegeben, daher ist ihr öffentlicher Schlüssel jetzt On-Chain sichtbar. Das ist normal und deine Coins sind sicher — die Verwendung einer neuen Adresse bei jeder Transaktion sorgt lediglich für den stärksten Schutz deiner Privatsphäre.",
   "add_wallet": "Wallet hinzufügen",
-  "coins_col": "Coins"
+  "coins_col": "Coins",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/de-de.json
+++ b/web-wallet/src/assets/locales/de-de.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/el.json
+++ b/web-wallet/src/assets/locales/el.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Γνωστό δημόσιο κλειδί",
   "address_exposed_hint": "Έχετε ξοδέψει από αυτή τη διεύθυνση στο παρελθόν, επομένως το δημόσιο κλειδί της είναι πλέον ορατό on-chain. Αυτό είναι φυσιολογικό και τα νομίσματά σας είναι ασφαλή — η χρήση μιας νέας διεύθυνσης κάθε φορά απλώς διατηρεί την ισχυρότερη δυνατή ιδιωτικότητα και προστασία.",
   "add_wallet": "Προσθήκη πορτοφολιού",
-  "coins_col": "Νομίσματα"
+  "coins_col": "Νομίσματα",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/el.json
+++ b/web-wallet/src/assets/locales/el.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/en.json
+++ b/web-wallet/src/assets/locales/en.json
@@ -1263,5 +1263,17 @@
   "address_exposed": "Public key known",
   "address_exposed_hint": "You have spent from this address before, so its public key is now visible on-chain. This is normal and your coins are safe — using a fresh address each time just keeps the strongest privacy and protection.",
   "add_wallet": "Add wallet",
-  "coins_col": "Coins"
+  "coins_col": "Coins",
+  "upgrade_seed_mismatch": "This recovery phrase does not match this wallet. Enter the exact seed this wallet was created from.",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/en.json
+++ b/web-wallet/src/assets/locales/en.json
@@ -1268,6 +1268,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/es-es.json
+++ b/web-wallet/src/assets/locales/es-es.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Clave pública conocida",
   "address_exposed_hint": "Ha gastado desde esta dirección anteriormente, por lo que su clave pública ahora es visible en la cadena de bloques. Esto es normal y sus monedas están seguras — usar una dirección nueva cada vez simplemente mantiene la mayor privacidad y protección.",
   "add_wallet": "Añadir billetera",
-  "coins_col": "Monedas"
+  "coins_col": "Monedas",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/es-es.json
+++ b/web-wallet/src/assets/locales/es-es.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/fi.json
+++ b/web-wallet/src/assets/locales/fi.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Julkinen avain tunnettu",
   "address_exposed_hint": "Olet aiemmin lähettänyt varoja tästä osoitteesta, joten sen julkinen avain on nyt näkyvissä lohkoketjussa. Tämä on normaalia ja kolikkosi ovat turvassa — tuoreen osoitteen käyttäminen joka kerta säilyttää vain vahvimman yksityisyyden ja suojan.",
   "add_wallet": "Lisää lompakko",
-  "coins_col": "Kolikot"
+  "coins_col": "Kolikot",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/fi.json
+++ b/web-wallet/src/assets/locales/fi.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/fr.json
+++ b/web-wallet/src/assets/locales/fr.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/fr.json
+++ b/web-wallet/src/assets/locales/fr.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Clé publique connue",
   "address_exposed_hint": "Vous avez déjà dépensé depuis cette adresse, sa clé publique est donc désormais visible sur la chaîne. C'est normal et vos pièces sont en sécurité — utiliser une nouvelle adresse à chaque fois offre simplement la meilleure confidentialité et protection.",
   "add_wallet": "Ajouter un portefeuille",
-  "coins_col": "Pièces"
+  "coins_col": "Pièces",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/gl.json
+++ b/web-wallet/src/assets/locales/gl.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/gl.json
+++ b/web-wallet/src/assets/locales/gl.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Clave pública coñecida",
   "address_exposed_hint": "Xa gastaches desde este enderezo antes, polo que a súa clave pública é agora visible na cadea. Isto é normal e as túas moedas están seguras — usar un enderezo novo cada vez simplemente mantén a máxima privacidade e protección.",
   "add_wallet": "Engadir carteira",
-  "coins_col": "Moedas"
+  "coins_col": "Moedas",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/hi.json
+++ b/web-wallet/src/assets/locales/hi.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/hi.json
+++ b/web-wallet/src/assets/locales/hi.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "सार्वजनिक कुंजी ज्ञात",
   "address_exposed_hint": "आपने पहले इस पते से खर्च किया है, इसलिए इसकी सार्वजनिक कुंजी अब ऑन-चेन दिखाई देती है। यह सामान्य है और आपके कॉइन सुरक्षित हैं — हर बार एक नया पता उपयोग करना बस सबसे मजबूत गोपनीयता और सुरक्षा बनाए रखता है।",
   "add_wallet": "वॉलेट जोड़ें",
-  "coins_col": "कॉइन"
+  "coins_col": "कॉइन",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/hr.json
+++ b/web-wallet/src/assets/locales/hr.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Javni ključ poznat",
   "address_exposed_hint": "Ranije ste trošili s ove adrese, pa je njezin javni ključ sada vidljiv na blockchainu. To je normalno i vaše kovanice su sigurne — korištenje nove adrese svaki put samo održava najjaču moguću privatnost i zaštitu.",
   "add_wallet": "Dodaj novčanik",
-  "coins_col": "Kovanice"
+  "coins_col": "Kovanice",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/hr.json
+++ b/web-wallet/src/assets/locales/hr.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/id.json
+++ b/web-wallet/src/assets/locales/id.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Kunci publik diketahui",
   "address_exposed_hint": "Anda pernah membelanjakan dari alamat ini sebelumnya, sehingga kunci publiknya kini terlihat di on-chain. Ini normal dan koin Anda aman — menggunakan alamat baru setiap kali hanya menjaga privasi dan perlindungan yang paling kuat.",
   "add_wallet": "Tambah dompet",
-  "coins_col": "Koin"
+  "coins_col": "Koin",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/id.json
+++ b/web-wallet/src/assets/locales/id.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/it.json
+++ b/web-wallet/src/assets/locales/it.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Chiave pubblica nota",
   "address_exposed_hint": "Hai già speso da questo indirizzo, quindi la sua chiave pubblica è ora visibile on-chain. È normale e le tue monete sono al sicuro — usare un indirizzo nuovo ogni volta garantisce semplicemente la massima privacy e protezione.",
   "add_wallet": "Aggiungi portafoglio",
-  "coins_col": "Monete"
+  "coins_col": "Monete",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/it.json
+++ b/web-wallet/src/assets/locales/it.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/ja.json
+++ b/web-wallet/src/assets/locales/ja.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "公開鍵が判明",
   "address_exposed_hint": "以前このアドレスから送金したことがあるため、公開鍵がすでにオンチェーンで確認できる状態になっています。これは正常な状態であり、コインは安全です — 毎回新しいアドレスを使用することで、最も高いプライバシーと保護を維持できます。",
   "add_wallet": "ウォレットを追加",
-  "coins_col": "コイン"
+  "coins_col": "コイン",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/ja.json
+++ b/web-wallet/src/assets/locales/ja.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/lt.json
+++ b/web-wallet/src/assets/locales/lt.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Viešasis raktas žinomas",
   "address_exposed_hint": "Anksčiau išleidote lėšas iš šio adreso, todėl jo viešasis raktas dabar matomas grandinėje. Tai normalu ir jūsų monetos saugios — kaskart naudojant naują adresą tiesiog užtikrinama stipriausia apsauga ir privatumas.",
   "add_wallet": "Pridėti piniginę",
-  "coins_col": "Monetos"
+  "coins_col": "Monetos",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/lt.json
+++ b/web-wallet/src/assets/locales/lt.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/nl.json
+++ b/web-wallet/src/assets/locales/nl.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Publieke sleutel bekend",
   "address_exposed_hint": "U heeft eerder vanaf dit adres besteed, waardoor de publieke sleutel ervan nu zichtbaar is on-chain. Dit is normaal en uw munten zijn veilig — door telkens een nieuw adres te gebruiken behoudt u de sterkste privacy en bescherming.",
   "add_wallet": "Portemonnee toevoegen",
-  "coins_col": "Munten"
+  "coins_col": "Munten",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/nl.json
+++ b/web-wallet/src/assets/locales/nl.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/pl.json
+++ b/web-wallet/src/assets/locales/pl.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/pl.json
+++ b/web-wallet/src/assets/locales/pl.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Klucz publiczny znany",
   "address_exposed_hint": "Środki z tego adresu były już wcześniej wydawane, więc jego klucz publiczny jest teraz widoczny na blockchainie. To normalne, a Twoje monety są bezpieczne — używanie za każdym razem świeżego adresu po prostu zapewnia najsilniejszą prywatność i ochronę.",
   "add_wallet": "Dodaj portfel",
-  "coins_col": "Monety"
+  "coins_col": "Monety",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/pt-br.json
+++ b/web-wallet/src/assets/locales/pt-br.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/pt-br.json
+++ b/web-wallet/src/assets/locales/pt-br.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Chave pública conhecida",
   "address_exposed_hint": "Você já gastou a partir deste endereço antes, então sua chave pública agora está visível na blockchain. Isso é normal e suas moedas estão seguras — usar um endereço novo a cada vez apenas mantém a privacidade e proteção mais fortes.",
   "add_wallet": "Adicionar carteira",
-  "coins_col": "Moedas"
+  "coins_col": "Moedas",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/ro.json
+++ b/web-wallet/src/assets/locales/ro.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Cheie publică cunoscută",
   "address_exposed_hint": "Ați mai cheltuit de la această adresă, așa că cheia sa publică este acum vizibilă on-chain. Acest lucru este normal, iar monedele dvs. sunt în siguranță — folosirea unei adrese noi de fiecare dată păstrează doar cel mai puternic nivel de confidențialitate și protecție.",
   "add_wallet": "Adaugă portofel",
-  "coins_col": "Monede"
+  "coins_col": "Monede",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/ro.json
+++ b/web-wallet/src/assets/locales/ro.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/ru.json
+++ b/web-wallet/src/assets/locales/ru.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/ru.json
+++ b/web-wallet/src/assets/locales/ru.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Публичный ключ известен",
   "address_exposed_hint": "Вы уже тратили с этого адреса, поэтому его публичный ключ теперь виден в блокчейне. Это нормально, и ваши монеты в безопасности — использование нового адреса каждый раз просто сохраняет наивысший уровень конфиденциальности и защиты.",
   "add_wallet": "Добавить кошелек",
-  "coins_col": "Монеты"
+  "coins_col": "Монеты",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/sk.json
+++ b/web-wallet/src/assets/locales/sk.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/sk.json
+++ b/web-wallet/src/assets/locales/sk.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Verejný kľúč známy",
   "address_exposed_hint": "Z tejto adresy ste už v minulosti minuli prostriedky, takže jej verejný kľúč je teraz viditeľný na blockchaine. Je to normálne a vaše mince sú v bezpečí — používanie novej adresy zakaždým len zachováva najsilnejšie súkromie a ochranu.",
   "add_wallet": "Pridať peňaženku",
-  "coins_col": "Mince"
+  "coins_col": "Mince",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/sr.json
+++ b/web-wallet/src/assets/locales/sr.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Јавни кључ познат",
   "address_exposed_hint": "Раније сте трошили са ове адресе, тако да је њен јавни кључ сада видљив на блокчејну. Ово је нормално и ваши новчићи су безбедни — коришћење нове адресе сваки пут само одржава најјачу приватност и заштиту.",
   "add_wallet": "Додај новчаник",
-  "coins_col": "Новчићи"
+  "coins_col": "Новчићи",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/sr.json
+++ b/web-wallet/src/assets/locales/sr.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/tr.json
+++ b/web-wallet/src/assets/locales/tr.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Açık anahtar biliniyor",
   "address_exposed_hint": "Bu adresten daha önce harcama yaptınız, bu yüzden açık anahtarı artık zincir üzerinde görünür durumda. Bu normaldir ve coinleriniz güvendedir — her seferinde yeni bir adres kullanmak yalnızca en güçlü gizlilik ve korumayı sağlar.",
   "add_wallet": "Cüzdan ekle",
-  "coins_col": "Coinler"
+  "coins_col": "Coinler",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/tr.json
+++ b/web-wallet/src/assets/locales/tr.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/uk.json
+++ b/web-wallet/src/assets/locales/uk.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "Публічний ключ відомий",
   "address_exposed_hint": "Ви вже витрачали з цієї адреси, тому її публічний ключ тепер видимий у блокчейні. Це нормально, і ваші монети в безпеці — використання нової адреси щоразу лише зберігає найвищий рівень приватності та захисту.",
   "add_wallet": "Додати гаманець",
-  "coins_col": "Монети"
+  "coins_col": "Монети",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/uk.json
+++ b/web-wallet/src/assets/locales/uk.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",

--- a/web-wallet/src/assets/locales/zh-cn.json
+++ b/web-wallet/src/assets/locales/zh-cn.json
@@ -1263,5 +1263,16 @@
   "address_exposed": "公钥已公开",
   "address_exposed_hint": "您此前曾从该地址支出过资金，因此其公钥现已在链上可见。这属于正常情况，您的币是安全的 — 每次使用新地址只是为了保持最强的隐私和保护。",
   "add_wallet": "添加钱包",
-  "coins_col": "币"
+  "coins_col": "币",
+  "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
+  "wallet_upgrade_title": "Upgrade this wallet",
+  "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_cta": "Upgrade",
+  "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
+  "wallet_upgrade_success": "Wallet upgraded.",
+  "wallet_legacy_badge": "Legacy v30",
+  "wallet_v30_migrated_notice": "Your wallet was upgraded — older coins are under '…-v30' and move to your main wallet as you spend.",
+  "wallet_rescan_legacy": "Check for older (v30) funds",
+  "wallet_rescan_found": "Found and restored older funds",
+  "wallet_rescan_none": "No older funds found"
 }

--- a/web-wallet/src/assets/locales/zh-cn.json
+++ b/web-wallet/src/assets/locales/zh-cn.json
@@ -1267,6 +1267,7 @@
   "wallet_upgrade_tooltip": "To stay compatible with v31 wallets, this wallet needs to upgrade.",
   "wallet_upgrade_title": "Upgrade this wallet",
   "wallet_upgrade_body": "A quick, safe update keeps this wallet compatible with v31. Re-enter this wallet's recovery phrase to confirm it's yours — your coins stay exactly where they are, and nothing is sent anywhere.",
+  "wallet_upgrade_rescan_warning": "This re-imports the wallet and runs a blockchain rescan, which can take several minutes. Your funds stay safe throughout.",
   "wallet_upgrade_cta": "Upgrade",
   "wallet_upgrade_seed_mismatch": "That recovery phrase doesn't match this wallet.",
   "wallet_upgrade_success": "Wallet upgraded.",


### PR DESCRIPTION
## Summary

Two related pieces of coin-type correctness for the BTCX wallet.

### v30 → v31 migration (mainnet)
New wallets move from the legacy coin type `0'` (v30) to the registered per-asset BTCX coin type `0x504F4358` (v31), and existing v30 wallets get a fund-safe path to the new branch:

- **BDK / remote + mobile**: one-time auto-migrate on wallet open (seed is stored → silent). Renames the legacy wallet `<base>-v30`, creates the v31 wallet on the clean name, drains legacy funds as spent. Danger-zone "check for older (v30) funds" re-runs it.
- **Core (managed/external)**: seed isn't stored, so a wallet still on the legacy branch shows an amber upgrade badge; the user re-enters the mnemonic (fingerprint-verified) to import the v31 branch active. Importing v31 active auto-deactivates the legacy `wpkh`/`tr` branches (Core allows one active descriptor per output type); Core-default `pkh 44'`/`sh(wpkh) 49'` are left alone (never used by Phoenix, no history). Rescan runs from the v31 birthday, not genesis.
- **Gating**: migration is mainnet-only; multisig, watch-only, descriptor-imported and single-address wallets never migrate / never show the badge.

### Network-aware coin type
- mainnet → `COIN_BTCX`; testnet/regtest → SLIP-44 testnet coin type `1'` (matches Bitcoin Core). Routed through the shared `params_btcx::registry::btcx_coin_type` (btcx workspace bumped to `292fcc3`) so Phoenix and Satchel can't drift.
- probe_candidates / select_restore_policy are network-aware; frontend derivation, restore categorisation and branch labels treat only `0'` as legacy.

## Tests / verification
- Rust: 81 unit tests pass (incl. new `create_wallet_coin_type_is_network_aware`, `probe_candidates_testnet_is_coin_type_1_only`); clippy + fmt clean.
- Web: build + `ng lint` + prettier clean; new i18n keys across all 26 locales.
- Manually verified on live mainnet Core wallets ("Miner", "JohnnyFFM"): v31 active, legacy `84'`/`86'` auto-deactivated, funds preserved, badge clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp