### PR TITLE
feat(coins): mobile stacked-card layout + drop debug panel

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/pages/coins/wallet-coins.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/coins/wallet-coins.component.ts
@@ -42,19 +42,7 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
 
     <div class="page">
       <div class="card">
-        <app-address-coins-list [rows]="rows()" [loading]="loading()" />
-      </div>
-
-      <!-- TEMP on-screen diagnostic (Android has no devtools) -->
-      <div class="coins-debug">
-        <div>wallet: {{ wallet.walletName() }}</div>
-        <div>
-          runtime active: {{ wallet.status()?.walletActive }} · height:
-          {{ wallet.status()?.syncedHeight ?? '—' }}
-        </div>
-        <div>balanceSat: {{ wallet.balance()?.totalSat ?? '—' }}</div>
-        <div>rows: {{ rows().length }} · loading: {{ loading() }}</div>
-        <div>err: {{ loadError() ?? '—' }}</div>
+        <app-address-coins-list [rows]="rows()" [loading]="loading()" [compact]="true" />
       </div>
     </div>
   `,
@@ -94,30 +82,15 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
       :host-context(.dark-theme) .card {
         background: #424242;
       }
-
-      /* TEMP diagnostic panel */
-      .coins-debug {
-        margin-top: 12px;
-        padding: 10px 12px;
-        border-radius: 8px;
-        background: rgba(255, 152, 0, 0.12);
-        color: #b26a00;
-        font-family: monospace;
-        font-size: 12px;
-        line-height: 1.5;
-        word-break: break-all;
-      }
     `,
   ],
 })
 export class WalletCoinsComponent {
   private readonly backend = inject(BackendRouterService);
-  protected readonly wallet = inject(BtcxWalletService);
+  private readonly wallet = inject(BtcxWalletService);
 
   readonly rows = signal<AddressBalance[]>([]);
   readonly loading = signal(false);
-  /** TEMP diagnostic — last listCoins error, surfaced on-screen. */
-  readonly loadError = signal<string | null>(null);
 
   constructor() {
     // The coins/UTXO set is populated by the background sync, so a one-shot
@@ -144,10 +117,8 @@ export class WalletCoinsComponent {
     try {
       const coins = await this.backend.wallet().listCoins(this.wallet.walletName());
       this.rows.set(aggregateCoins(coins));
-      this.loadError.set(null);
     } catch (error) {
       console.error('Failed to load coins:', error);
-      this.loadError.set(`${error}`);
     } finally {
       this.loading.set(false);
     }

--- a/web-wallet/src/app/shared/components/address-coins-list/address-coins-list.component.ts
+++ b/web-wallet/src/app/shared/components/address-coins-list/address-coins-list.component.ts
@@ -88,6 +88,34 @@ export function aggregateCoins(coins: WalletCoin[]): AddressBalance[] {
       </div>
     } @else if (rows().length === 0) {
       <app-empty-state icon="account_balance_wallet" [message]="'coins_empty' | i18n" />
+    } @else if (compact()) {
+      <div class="coins-cards">
+        @for (row of pagedRows(); track row.address) {
+          <div class="coin-card">
+            <app-address-display [address]="row.address" [showCopyButton]="true" [inline]="false" />
+            <div class="coin-card-meta">
+              <span class="coin-card-balance">{{ row.balanceBtc | btcx }} BTCX</span>
+              <span class="coin-card-count">{{ row.coinCount }} {{ 'coins_col' | i18n }}</span>
+              @if (row.exposed) {
+                <mat-icon class="flag-icon" [matTooltip]="'address_exposed_hint' | i18n"
+                  >key</mat-icon
+                >
+              }
+            </div>
+          </div>
+        }
+      </div>
+
+      @if (rows().length > pageSizeOptions[0]) {
+        <mat-paginator
+          [length]="rows().length"
+          [pageSize]="pageSize()"
+          [pageIndex]="pageIndex()"
+          [pageSizeOptions]="pageSizeOptions"
+          (page)="onPageChange($event)"
+          [showFirstLastButtons]="true"
+        ></mat-paginator>
+      }
     } @else {
       <div class="coins-scroll">
         <table class="coins-table">
@@ -242,6 +270,41 @@ export function aggregateCoins(coins: WalletCoin[]): AddressBalance[] {
         background: transparent;
       }
 
+      /* Compact (mobile) layout: one stacked card per address. */
+      .coins-cards {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .coin-card {
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        border-radius: 8px;
+        padding: 10px 12px;
+        background: rgba(0, 0, 0, 0.015);
+      }
+
+      .coin-card-meta {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-top: 8px;
+        font-size: 13px;
+      }
+
+      .coin-card-balance {
+        font-weight: 600;
+        color: #1976d2;
+      }
+
+      .coin-card-count {
+        color: #5a6b7a;
+      }
+
+      .coin-card-meta .flag-icon {
+        margin-left: auto;
+      }
+
       :host-context(.dark-theme) {
         .coins-intro {
           color: #9fb0bf;
@@ -258,6 +321,19 @@ export function aggregateCoins(coins: WalletCoin[]): AddressBalance[] {
         .td-balance {
           color: #90caf9;
         }
+
+        .coin-card {
+          border-color: rgba(255, 255, 255, 0.12);
+          background: #333;
+        }
+
+        .coin-card-balance {
+          color: #90caf9;
+        }
+
+        .coin-card-count {
+          color: #9fb0bf;
+        }
       }
     `,
   ],
@@ -267,6 +343,12 @@ export class AddressCoinsListComponent {
   readonly rows = input.required<AddressBalance[]>();
   /** Whether the source query is still loading. */
   readonly loading = input(false);
+  /**
+   * Compact (transposed) layout: each address becomes a stacked card instead
+   * of a wide table row — for narrow / mobile viewports where the 4 columns
+   * don't fit.
+   */
+  readonly compact = input(false);
 
   readonly pageSize = signal(10);
   readonly pageIndex = signal(0);


### PR DESCRIPTION
Adds a `compact` (transposed) card layout to the Coins & Addresses list for mobile (the 4-column table overflows a phone); desktop keeps the table. Removes the temporary on-screen diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)