### PR TITLE
fix(mobile): Send/Receive/Assignment parity fixes for Android

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/pages/assignment/wallet-assignment.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/assignment/wallet-assignment.component.ts
@@ -15,6 +15,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { I18nPipe, I18nService } from '../../../../core/i18n';
 import { HashTruncatePipe } from '../../../../shared/pipes';
+import { DecimalInputDirective } from '../../../../shared/directives';
 import { Contact, ContactsStoreService, NotificationService } from '../../../../shared/services';
 import {
   ConfirmDialogComponent,
@@ -82,6 +83,7 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
     DecimalPipe,
     NgTemplateOutlet,
     HashTruncatePipe,
+    DecimalInputDirective,
     I18nPipe,
     PageHeaderComponent,
   ],
@@ -350,7 +352,8 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
               @if (option.label === 'fee_custom') {
                 <mat-icon class="custom-icon">tune</mat-icon>
               } @else if (option.feeRate !== null) {
-                <span class="fee-rate">{{ option.feeRate | number: '1.3-3' }} sat/vB</span>
+                <!-- Break amount / unit — both don't fit the chip width. -->
+                <span class="fee-rate">{{ option.feeRate | number: '1.3-3' }}<br />sat/vB</span>
               } @else {
                 <span class="fee-rate">--</span>
               }
@@ -363,11 +366,10 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
             <mat-label>{{ 'fee_rate' | i18n }} (sat/vB)</mat-label>
             <input
               matInput
-              type="number"
+              appDecimal
+              inputmode="decimal"
               [(ngModel)]="customFeeRate"
               (ngModelChange)="onCustomFeeChange()"
-              min="0.1"
-              step="0.001"
               autocomplete="off"
             />
           </mat-form-field>
@@ -638,6 +640,7 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
           .fee-rate {
             display: block;
             white-space: nowrap;
+            text-align: center;
             font-size: 10px;
             color: rgba(0, 0, 0, 0.55);
             font-variant-numeric: tabular-nums;

--- a/web-wallet/src/app/features/mobile-wallet/pages/receive/wallet-receive.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/receive/wallet-receive.component.ts
@@ -6,6 +6,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { QRCodeComponent } from 'angularx-qrcode';
 import { I18nPipe } from '../../../../core/i18n';
 import { ClipboardService } from '../../../../shared/services';
+import { buildPaymentUri } from '../../../../bitcoin/utils/payment-uri';
 import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
@@ -32,7 +33,7 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
         @if (address()) {
           <div class="qr-container">
             <qrcode
-              [qrdata]="address()"
+              [qrdata]="paymentUri()"
               [width]="200"
               [errorCorrectionLevel]="'M'"
               [margin]="1"
@@ -45,6 +46,15 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
             <span class="info-label">{{ 'address' | i18n }}</span>
             <div class="info-value-row" (click)="copyAddress()" [matTooltip]="'copy' | i18n">
               <span class="address-value">{{ address() }}</span>
+              <mat-icon class="copy-icon">content_copy</mat-icon>
+            </div>
+          </div>
+
+          <!-- BIP21 payment URI (desktop-parity) — what the QR encodes. -->
+          <div class="info-row">
+            <span class="info-label">{{ 'payment_uri' | i18n }}</span>
+            <div class="info-value-row" (click)="copyPaymentUri()" [matTooltip]="'copy' | i18n">
+              <span class="uri-value">{{ paymentUri() }}</span>
               <mat-icon class="copy-icon">content_copy</mat-icon>
             </div>
           </div>
@@ -151,6 +161,15 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
         flex: 1;
       }
 
+      .uri-value {
+        font-family: monospace;
+        font-size: 12px;
+        color: #1976d2;
+        word-break: break-all;
+        text-align: left;
+        flex: 1;
+      }
+
       .loading-inline {
         display: flex;
         justify-content: center;
@@ -186,6 +205,10 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
           color: #90caf9;
         }
 
+        .uri-value {
+          color: #90caf9;
+        }
+
         .single-hint {
           color: rgba(255, 255, 255, 0.6);
         }
@@ -199,6 +222,11 @@ export class WalletReceiveComponent implements OnInit {
 
   readonly address = signal('');
   readonly loading = signal(false);
+
+  /** Canonical BIP21 URI for the shown address (what the QR encodes). */
+  paymentUri(): string {
+    return buildPaymentUri({ address: this.address() });
+  }
 
   ngOnInit(): void {
     void this.load();
@@ -238,5 +266,10 @@ export class WalletReceiveComponent implements OnInit {
   async copyAddress(): Promise<void> {
     const address = this.address();
     if (address) await this.clipboard.copyAddress(address);
+  }
+
+  async copyPaymentUri(): Promise<void> {
+    const uri = this.paymentUri();
+    if (uri) await this.clipboard.copy(uri, 'payment_uri_copied');
   }
 }

--- a/web-wallet/src/app/features/mobile-wallet/pages/send/wallet-send.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/send/wallet-send.component.ts
@@ -13,6 +13,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { I18nPipe, I18nService } from '../../../../core/i18n';
 import { HashTruncatePipe } from '../../../../shared/pipes';
+import { DecimalInputDirective } from '../../../../shared/directives';
 import { ClipboardService, Contact, ContactsStoreService } from '../../../../shared/services';
 import { validatePocxAddress } from '../../../../bitcoin/utils/address-validation';
 import { parsePaymentUri } from '../../../../bitcoin/utils/payment-uri';
@@ -68,6 +69,7 @@ const SANE_PRESET_MAX_SAT_VB = 200;
     MatCheckboxModule,
     DecimalPipe,
     HashTruncatePipe,
+    DecimalInputDirective,
     I18nPipe,
     PageHeaderComponent,
   ],
@@ -216,17 +218,17 @@ const SANE_PRESET_MAX_SAT_VB = 200;
             @if (addressValid()) {
               <mat-icon matSuffix class="suffix-valid">check_circle</mat-icon>
             }
-            @if (contacts().length > 0) {
-              <button
-                mat-icon-button
-                matSuffix
-                type="button"
-                [matMenuTriggerFor]="contactsMenu"
-                [matTooltip]="'select_contact' | i18n"
-              >
-                <mat-icon>contacts</mat-icon>
-              </button>
-            }
+            <!-- Always shown (desktop-parity), disabled when the book is empty. -->
+            <button
+              mat-icon-button
+              matSuffix
+              type="button"
+              [matMenuTriggerFor]="contactsMenu"
+              [disabled]="contacts().length === 0"
+              [matTooltip]="'select_contact' | i18n"
+            >
+              <mat-icon>contacts</mat-icon>
+            </button>
           </mat-form-field>
           <mat-menu #contactsMenu="matMenu">
             @for (contact of contacts(); track contact.id) {
@@ -251,12 +253,11 @@ const SANE_PRESET_MAX_SAT_VB = 200;
               <mat-label>{{ 'amount' | i18n }} (BTCX)</mat-label>
               <input
                 matInput
-                type="number"
+                appDecimal
+                inputmode="decimal"
                 [(ngModel)]="amount"
                 [disabled]="sendAll"
                 placeholder="0.00000000"
-                step="0.00000001"
-                min="0"
                 autocomplete="off"
               />
             </mat-form-field>
@@ -292,7 +293,8 @@ const SANE_PRESET_MAX_SAT_VB = 200;
                 @if (preset.target !== null) {
                   <span class="fee-rate">
                     @if (presetRate(preset) !== null) {
-                      {{ presetRate(preset) | number: '1.3-3' }} sat/vB
+                      <!-- Break amount / unit — both don't fit the button width. -->
+                      {{ presetRate(preset) | number: '1.3-3' }}<br />sat/vB
                     } @else {
                       --
                     }
@@ -307,10 +309,9 @@ const SANE_PRESET_MAX_SAT_VB = 200;
               <mat-label>{{ 'fee_rate' | i18n }} (sat/vB)</mat-label>
               <input
                 matInput
-                type="number"
+                appDecimal
+                inputmode="decimal"
                 [(ngModel)]="customFeeRate"
-                min="0.1"
-                step="0.001"
                 autocomplete="off"
               />
             </mat-form-field>
@@ -496,6 +497,7 @@ const SANE_PRESET_MAX_SAT_VB = 200;
         .fee-rate {
           display: block;
           white-space: nowrap;
+          text-align: center;
           font-size: 10px;
           color: rgba(0, 0, 0, 0.5);
         }

--- a/web-wallet/src/app/features/mobile-wallet/pages/send/wallet-send.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/send/wallet-send.component.ts
@@ -218,17 +218,17 @@ const SANE_PRESET_MAX_SAT_VB = 200;
             @if (addressValid()) {
               <mat-icon matSuffix class="suffix-valid">check_circle</mat-icon>
             }
-            <!-- Always shown (desktop-parity), disabled when the book is empty. -->
-            <button
-              mat-icon-button
-              matSuffix
-              type="button"
-              [matMenuTriggerFor]="contactsMenu"
-              [disabled]="contacts().length === 0"
-              [matTooltip]="'select_contact' | i18n"
-            >
-              <mat-icon>contacts</mat-icon>
-            </button>
+            @if (contacts().length > 0) {
+              <button
+                mat-icon-button
+                matSuffix
+                type="button"
+                [matMenuTriggerFor]="contactsMenu"
+                [matTooltip]="'select_contact' | i18n"
+              >
+                <mat-icon>contacts</mat-icon>
+              </button>
+            }
           </mat-form-field>
           <mat-menu #contactsMenu="matMenu">
             @for (contact of contacts(); track contact.id) {

--- a/web-wallet/src/app/shared/directives/decimal-input.directive.ts
+++ b/web-wallet/src/app/shared/directives/decimal-input.directive.ts
@@ -1,0 +1,82 @@
+import { Directive, ElementRef, HostListener, Renderer2, forwardRef, inject } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+/**
+ * DecimalInputDirective — a numeric value accessor over a TEXT input that
+ * accepts BOTH `.` and `,` as the decimal separator.
+ *
+ * `<input type="number">` on Android only accepts the platform's own decimal
+ * key (usually `.`); a typed `,` is dropped before Angular ever sees it, so
+ * users on comma-locale keyboards can't enter amounts. This directive drives
+ * a `type="text" inputmode="decimal"` field instead: it normalises `,`→`.`,
+ * strips non-numeric characters, and exposes the parsed `number | null` to
+ * `ngModel` — so every existing numeric calculation is untouched while both
+ * separators work on desktop AND mobile.
+ *
+ * Usage: `<input matInput appDecimal inputmode="decimal" [(ngModel)]="amount" />`
+ * (omit `type="number"` — the directive wants a text field).
+ */
+@Directive({
+  selector: 'input[appDecimal]',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => DecimalInputDirective),
+      multi: true,
+    },
+  ],
+})
+export class DecimalInputDirective implements ControlValueAccessor {
+  private readonly el = inject<ElementRef<HTMLInputElement>>(ElementRef);
+  private readonly renderer = inject(Renderer2);
+
+  private onChange: (value: number | null) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  @HostListener('input', ['$event'])
+  handleInput(event: Event): void {
+    const raw = (event.target as HTMLInputElement).value;
+    // Comma -> dot, drop anything that isn't a digit or dot, and collapse any
+    // extra dots down to the first one ("1.2.3" -> "1.23").
+    let cleaned = raw.replace(',', '.').replace(/[^0-9.]/g, '');
+    const firstDot = cleaned.indexOf('.');
+    if (firstDot >= 0) {
+      cleaned = cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, '');
+    }
+    // Reflect the sanitised text back so the field never shows a rejected
+    // character (a typed `,` visibly becomes `.`).
+    if (cleaned !== raw) {
+      this.renderer.setProperty(this.el.nativeElement, 'value', cleaned);
+    }
+    const num = cleaned === '' || cleaned === '.' ? null : Number(cleaned);
+    this.onChange(Number.isFinite(num as number) ? (num as number) : null);
+  }
+
+  @HostListener('blur')
+  handleBlur(): void {
+    this.onTouched();
+  }
+
+  writeValue(value: number | null): void {
+    // Plain-decimal formatting (never exponential) so a small programmatic
+    // value like 0.00000001 shows as "0.00000001", not "1e-8".
+    const str =
+      value === null || value === undefined || !Number.isFinite(value)
+        ? ''
+        : value.toLocaleString('en-US', { useGrouping: false, maximumFractionDigits: 20 });
+    this.renderer.setProperty(this.el.nativeElement, 'value', str);
+  }
+
+  registerOnChange(fn: (value: number | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.renderer.setProperty(this.el.nativeElement, 'disabled', isDisabled);
+  }
+}

--- a/web-wallet/src/app/shared/directives/index.ts
+++ b/web-wallet/src/app/shared/directives/index.ts
@@ -1,0 +1,2 @@
+// Shared Directives
+export { DecimalInputDirective } from './decimal-input.directive';

--- a/web-wallet/src/app/shared/index.ts
+++ b/web-wallet/src/app/shared/index.ts
@@ -6,5 +6,8 @@ export * from './services';
 // Pipes
 export * from './pipes';
 
+// Directives
+export * from './directives';
+
 // Components
 export * from './components';


### PR DESCRIPTION
Four GUI findings from Android testing, all scoped to the mobile-wallet pages.

## Changes

1. **Send + Forging Assignment · fee buttons** — the fee-preset buttons now break the `sat/vB` unit onto its own line (`0.000` / `sat/vB`), so the rate and unit both fit the button width instead of overflowing.

2. **Send · amount input** and 3. **Send + Forging Assignment · custom-fee inputs** — now accept **both `.` and `,`** as the decimal separator on mobile (desktop already did). A new shared `DecimalInputDirective` drives a `type=text inputmode=decimal` field, normalises `,`→`.`, strips non-numeric characters, and exposes the parsed `number | null` to `ngModel` — so every existing numeric calculation is untouched. `writeValue` uses plain-decimal formatting so a programmatic `0.00000001` never renders as `1e-8`.

4. **Receive · payment URI** — now shows the BIP21 payment URI in a copyable row and encodes it in the QR, matching desktop Receive.

## Notes
- `DecimalInputDirective` lives in `shared/directives/` (new barrel, exported from `shared`).
- No new i18n keys needed — `payment_uri` / `payment_uri_copied` already exist across all locales.
- `ng build` passes (only the two pre-existing NG8102 `??` warnings remain, untouched by this PR).
- A Send contacts-button change was included then reverted — the mobile picker already appears when the address book is non-empty, so no change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)