### PR TITLE
test(wallet): fix stale DescriptorService coin-type expectations

### DIFF
--- a/web-wallet/src/app/bitcoin/services/wallet/descriptor.service.spec.ts
+++ b/web-wallet/src/app/bitcoin/services/wallet/descriptor.service.spec.ts
@@ -86,15 +86,19 @@ describe('DescriptorService', () => {
     });
   });
 
-  describe('new wallet descriptor set (POCX coin type)', () => {
-    it('generates only 84h and 86h branches, both at the BTCX coin type, on every network', () => {
+  describe('new wallet descriptor set (network coin type)', () => {
+    it('generates only 84h and 86h branches at the network coin type', () => {
+      // Coin type is network-aware (matches the Rust BDK backend's
+      // WalletNetwork::asset_coin_type): the registered BTCX coin type on
+      // mainnet, the shared SLIP-44 testnet coin type 1' on testnet/regtest.
       for (const isTestnet of [false, true]) {
+        const expectedCoin = isTestnet ? 1 : BTCX_COIN_TYPE;
         const { descriptors } = service.generateNewWalletDescriptors(TEST_MNEMONIC, { isTestnet });
         expect(descriptors.length).toBe(4);
         expect(descriptors.map(d => d.type).sort()).toEqual(['tr', 'tr', 'wpkh', 'wpkh']);
         for (const d of descriptors) {
-          expect(d.path).toMatch(new RegExp(`^m/8[46]'/${BTCX_COIN_TYPE}'/0'/[01]/\\*$`));
-          expect(d.descriptor).toContain(`/${BTCX_COIN_TYPE}h/`);
+          expect(d.path).toMatch(new RegExp(`^m/8[46]'/${expectedCoin}'/0'/[01]/\\*$`));
+          expect(d.descriptor).toContain(`/${expectedCoin}h/`);
         }
         // Exactly one receive + one change per purpose.
         expect(descriptors.filter(d => d.internal).length).toBe(2);
@@ -134,10 +138,15 @@ describe('DescriptorService', () => {
       }
     });
 
-    it('legacy + BTCX sets together are unique and checksum-valid', () => {
+    it('mainnet legacy + BTCX sets together are unique and checksum-valid', () => {
+      // On mainnet the legacy branches (coin 0') and the new-wallet branches
+      // (BTCX coin type) are disjoint, so the combined set is fully unique.
+      // (On testnet both sit at coin 1', so the new set is intentionally a
+      // subset of the legacy set — see the network-coin-type test above.)
       const descriptors = [
-        ...service.generateLegacyRestoreDescriptors(TEST_MNEMONIC, { isTestnet: true }).descriptors,
-        ...service.generateNewWalletDescriptors(TEST_MNEMONIC, { isTestnet: true }).descriptors,
+        ...service.generateLegacyRestoreDescriptors(TEST_MNEMONIC, { isTestnet: false })
+          .descriptors,
+        ...service.generateNewWalletDescriptors(TEST_MNEMONIC, { isTestnet: false }).descriptors,
       ];
       const descs = descriptors.map(d => d.descriptor);
       expect(new Set(descs).size).toBe(descs.length);

--- a/web-wallet/src/app/bitcoin/services/wallet/descriptor.service.ts
+++ b/web-wallet/src/app/bitcoin/services/wallet/descriptor.service.ts
@@ -72,11 +72,12 @@ export interface MultisigDescriptors {
 /**
  * Options for descriptor generation.
  *
- * `isTestnet` controls the extended-key serialization (tprv/tpub vs
- * xprv/xpub) only — it no longer selects the BIP32 coin type. New wallets
- * derive at the registered BTCX coin type on every network; restores add
- * the historic coin-0'/1' branches explicitly (see
- * `generateLegacyRestoreDescriptors`).
+ * `isTestnet` drives the extended-key serialization (tprv/tpub vs
+ * xprv/xpub) AND the network's default coin type: new wallets derive at the
+ * registered BTCX coin type (`0x504F4358`) on mainnet and at the shared
+ * SLIP-44 testnet coin type (1') on testnet/regtest — matching the Rust BDK
+ * backend's `WalletNetwork::asset_coin_type`. Restores add the historic
+ * coin-0'/1' branches explicitly (see `generateLegacyRestoreDescriptors`).
  */
 export interface DescriptorOptions {
   passphrase?: string;


### PR DESCRIPTION
## Problem

Two `DescriptorService` unit tests have been failing on every PR (the CI **Test** job), both on their testnet leg:

- `new wallet descriptor set … both at the BTCX coin type, on every network`
- `legacy + BTCX sets together are unique and checksum-valid`

## Root cause

The new-wallet coin type became **network-aware** in #153 — BTCX (`0x504F4358`) on mainnet, the shared SLIP-44 testnet coin type `1'` on testnet/regtest — matching the Rust backend's source of truth, `WalletNetwork::asset_coin_type` (`config.rs`). But the spec (last touched in #118) still asserted the BTCX coin type on *every* network, and was never updated. This is test rot, not a product bug — the service is correct.

## Fix (test-only + one doc comment)

- **`…on every network`** → now expects the network-aware coin type (`1'` on testnet).
- **`…unique and checksum-valid`** → the disjointness invariant only holds on **mainnet** (on testnet the new set intentionally shares coin `1'` with the legacy set, so it's a subset by design). The test now runs on mainnet.
- Corrected the stale `DescriptorOptions` doc comment to describe the network-aware behaviour.

No production code changes.

## Verification

`ng test` locally: **82/82 pass** (was 80/82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)