### PR TITLE
feat(dev): --mobile desktop launch for the full Android view

### DIFF
--- a/web-wallet/src-tauri/src/lib.rs
+++ b/web-wallet/src-tauri/src/lib.rs
@@ -275,9 +275,10 @@ fn is_dev() -> bool {
 }
 
 /// Get the launch mode (wallet, mining, mobile, or wallet-mobile)
-/// Desktop: "mining" if --mining-only or -m is passed, "wallet-mobile" if
-/// --wallet-only is passed (dev-testing the wallet-only flavor without a
-/// device), otherwise "wallet"
+/// Desktop: "mining" if --mining-only or -m is passed, "mobile" if
+/// --mobile is passed (dev-testing the FULL Android flavor: mining + the
+/// nodeless wallet), "wallet-mobile" if --wallet-only is passed (the
+/// wallet-only Android flavor), otherwise "wallet"
 /// Android: "mobile" (nodeless BTCX wallet + mining, no local node), or
 /// "wallet-mobile" when built with the `wallet-only` cargo feature (the
 /// wallet-only app flavor: nodeless BTCX wallet only, no mining either)
@@ -297,6 +298,10 @@ fn get_launch_mode() -> String {
     {
         if std::env::args().any(|arg| arg == "--mining-only" || arg == "-m") {
             "mining".to_string()
+        } else if std::env::args().any(|arg| arg == "--mobile") {
+            // Dev-testing the full Android flavor on desktop: mining + the
+            // nodeless BTCX wallet (the mobile layout + /miner routes).
+            "mobile".to_string()
         } else if std::env::args().any(|arg| arg == "--wallet-only") {
             "wallet-mobile".to_string()
         } else {

--- a/web-wallet/src/app/core/guards/node-setup.guard.ts
+++ b/web-wallet/src/app/core/guards/node-setup.guard.ts
@@ -27,9 +27,8 @@ export const nodeSetupGuard: CanActivateFn = async () => {
   const appModeService = inject(AppModeService);
 
   if (
-    appModeService.isMobile() ||
+    appModeService.isNodeless() ||
     appModeService.isMiningOnly() ||
-    appModeService.isWalletOnly() ||
     !electronService.isDesktop
   ) {
     return true;

--- a/web-wallet/src/app/core/services/app-mode.service.ts
+++ b/web-wallet/src/app/core/services/app-mode.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject, signal } from '@angular/core';
+import { Injectable, inject, signal, computed } from '@angular/core';
 import { ElectronService } from './electron.service';
 
 /**
@@ -34,6 +34,18 @@ export class AppModeService {
 
   /** Whether running on a mobile platform (Android) - no local node support */
   readonly isMobile = signal(false);
+
+  /**
+   * Whether this run has NO local bitcoind — the Android platform, or a
+   * mobile launch flavor used to dev-test the Android experience on
+   * desktop (`--mobile` / `--wallet-only`). The node-mode gates key on
+   * this so the desktop mobile view behaves like Android (always remote /
+   * Electrum), not by the persisted desktop node mode. On real Android
+   * `isMobile` is already true, so this is a no-op there.
+   */
+  readonly isNodeless = computed(
+    () => this.isMobile() || this.isMobileMode() || this.isWalletOnly()
+  );
 
   /** Whether the mode has been initialized (internal guard) */
   private readonly _isInitialized = signal(false);

--- a/web-wallet/src/app/node/services/node.service.ts
+++ b/web-wallet/src/app/node/services/node.service.ts
@@ -69,22 +69,25 @@ export class NodeService {
   readonly initialized = this._initialized.asReadonly();
 
   // Computed values (mode values are lowercase to match Rust serde serialization)
-  // Android has no local bitcoind, so it is ALWAYS remote regardless of the
-  // persisted node mode — otherwise the backend seam would route wallet ops to
-  // the (nonexistent) Core RPC. isMobile() is a reactive signal, so these stay
+  // A nodeless run (Android, or a desktop --mobile/--wallet-only dev launch)
+  // has no local bitcoind, so it is ALWAYS remote regardless of the persisted
+  // node mode — otherwise the backend seam would route wallet ops to the
+  // (nonexistent) Core RPC. isNodeless() is a reactive signal, so these stay
   // correct even if it resolves after the config loads.
   readonly isManaged = computed(
-    () => !this.appMode.isMobile() && this._config().mode === 'managed'
+    () => !this.appMode.isNodeless() && this._config().mode === 'managed'
   );
   readonly isExternal = computed(
-    () => !this.appMode.isMobile() && this._config().mode === 'external'
+    () => !this.appMode.isNodeless() && this._config().mode === 'external'
   );
   /**
    * Remote mode: no local bitcoind at all — the wallet runs over Electrum
    * (the nodeless btcx stack). THE signal every remote-mode branch keys on.
-   * Always true on Android (which cannot run a node).
+   * Always true on Android and in the desktop mobile-view dev launches.
    */
-  readonly isRemote = computed(() => this.appMode.isMobile() || this._config().mode === 'remote');
+  readonly isRemote = computed(
+    () => this.appMode.isNodeless() || this._config().mode === 'remote'
+  );
   readonly isRunning = computed(() => this._status().running);
   readonly isInstalled = computed(() => this._status().installed);
   readonly isSynced = computed(() => this._status().synced);
@@ -92,7 +95,7 @@ export class NodeService {
   readonly currentVersion = computed(() => this._config().installedVersion);
   readonly network = computed(() => this._config().network);
   readonly mode = computed<NodeMode>(() =>
-    this.appMode.isMobile() ? 'remote' : this._config().mode
+    this.appMode.isNodeless() ? 'remote' : this._config().mode
   );
 
   // Download progress computed values


### PR DESCRIPTION
Adds a `--mobile` launch flag (desktop) that runs the full Android flavor — the mobile layout + `/miner` routes + the nodeless BTCX wallet — alongside the existing `--mining-only` and `--wallet-only`. Lets the Android experience be reviewed on desktop via `tauri:dev` without an APK.

Also introduces `AppModeService.isNodeless()` (Android platform **or** a mobile launch flavor) and keys the node-mode gates (`isRemote`/`isManaged`/`isExternal`/`mode`, and the node-setup guard) on it, so the desktop mobile-view launches force remote/Electrum like a real device instead of falling back to the persisted desktop node mode.

On real Android `isMobile()` is already true, so this is a **no-op there** — the change only affects the desktop `--mobile` / `--wallet-only` dev launches.

Verified: launched `tauri:dev -- -- -- --mobile` — mining active (plots loaded, deadlines accepted) and the nodeless wallet opened in remote mode. `ng build` + `ng lint` green; Rust compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
