### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
-# Phoenix Wallet 2.1.1
+# Phoenix Wallet 2.2.0
 
-A quick fix release on top of 2.1.0.
+The biggest update since 2.1 — a redesigned wallet model built around **pockets**, more reliable balance syncing, and full translations across every supported language.
 
-## Fixed
-- **Wallet creation was blocked** — on the recovery-phrase confirmation step, the **Next** button stayed disabled even after the words were entered correctly, so new wallets couldn't be created. Fixed. (If you're on 2.1.0, please update.)
+## Wallet pockets
 
-## Improved
-- **Faster phrase entry** — when typing your recovery phrase, pressing **Enter** now accepts the highlighted autocomplete suggestion and jumps to the next word.
+Your wallet is now organized around a single recovery phrase with switchable **pockets**, instead of a cluster of separate sibling wallets and upgrade/recover buttons:
 
-Everything else is unchanged from 2.1.0 — see those notes for the full feature set (remote/Electrum mode, full Android wallet, multi-wallet, PSBT builder, multisig, and more).
+- **One wallet, one recovery phrase.** Each wallet shows as a single entry, and inside it are its pockets — **SegWit** (recommended; the one that receives mining rewards), **Taproot**, and, if you hold older coins, a **legacy (v30)** pocket. Switch pockets from the wallet selector, or from the pocket chip next to the wallet name in the toolbar.
+- **Restoring is simpler.** Restore your recovery phrase and all of its pockets are set up for you automatically — no more "Upgrade to v31", "recover old funds", or create-both prompts.
+- **Older (v30) coins are spend-only.** They show up as a spend-only pocket you can drain into your current SegWit or Taproot pocket. Receiving into a legacy pocket is blocked, so no new funds ever land back in the retired branch.
+- **Rename or delete** a wallet and all its pockets together — swipe a wallet in the selector on mobile, or use the selector on desktop.
+
+## Balances that stay correct
+
+- **Funds sent to another device's address now show up.** If you use the same recovery phrase on more than one device, money sent to an address a *different* device handed out is now discovered automatically — no more balance appearing "stuck" at an older value while the block height keeps climbing.
+- **Incoming payments appear right away** instead of waiting for the next block to confirm.
+
+## Now fully translated
+
+The app is now translated across all 25 supported languages. Previously many screens — including much of the wallet and settings — fell back to English.
+
+## Also improved
+
+- **Coins** page: a cleaner stacked-card layout on mobile.
+- **Mining**: the network-capacity chart is now a live trailing-window graph.
+- **Fees**: more reliable first-attempt fee bumping, and finer fee-rate control and display.
+- Numerous **Android / mobile** fixes for Send, Receive, and forging assignments.

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-wallet",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-pocx"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "bdk_wallet",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-pocx"
-version = "2.1.2"
+version = "2.2.0"
 description = "Phoenix Wallet - Bitcoin-PoCX Desktop Wallet"
 authors = ["The Proof of Capacity Consortium <development@pocx.io>"]
 license = "GPL-3.0"

--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -156,7 +156,8 @@ pub fn create_wallet_impl(
         DescriptorKindCfg::Bip86 => DescriptorKindCfg::Bip84,
         _ => DescriptorKindCfg::Bip86,
     };
-    let sibling = resolve_counterpart_name(state, network, &name, compartment_suffix(other_kind, true))?;
+    let sibling =
+        resolve_counterpart_name(state, network, &name, compartment_suffix(other_kind, true))?;
     register_sibling_wallet(
         state,
         network,
@@ -590,8 +591,7 @@ fn register_sibling_wallet(
             },
         );
     })?;
-    let seed =
-        WalletSeed::from_mnemonic(mnemonic.trim(), "").map_err(|e| format!("{e:#}"))?;
+    let seed = WalletSeed::from_mnemonic(mnemonic.trim(), "").map_err(|e| format!("{e:#}"))?;
     let handle = manager::open_wallet(
         &BtcxWalletConfig::wallet_db_path_for(network, name),
         network.params(),
@@ -1109,9 +1109,7 @@ fn compartment_rank(policy: DescriptorPolicy, network: WalletNetwork) -> u8 {
 
 /// The grouped wallet list of the active network — group rows + compartments
 /// + Σ, snapshot-sourced (NO store opens). See `btcx_wallet_list_grouped`.
-pub fn list_grouped_impl(
-    state: &SharedBtcxWalletState,
-) -> Result<Vec<BtcxWalletGroup>, String> {
+pub fn list_grouped_impl(state: &SharedBtcxWalletState) -> Result<Vec<BtcxWalletGroup>, String> {
     let config = state.get_config();
     let network = config.network;
     let mut groups: std::collections::BTreeMap<String, Vec<BtcxCompartment>> = Default::default();
@@ -1189,10 +1187,7 @@ pub fn group_sync_impl(
     let network = config.network;
     let members = config.group_members(network, group);
     if members.is_empty() {
-        return Err(format!(
-            "No wallet group '{group}' on {}",
-            network.as_str()
-        ));
+        return Err(format!("No wallet group '{group}' on {}", network.as_str()));
     }
     let mut sync_errors = Vec::new();
     for name in &members {
@@ -1488,10 +1483,7 @@ pub fn rename_group_impl(
     let network = config.network;
     let members = config.group_members(network, group);
     if members.is_empty() {
-        return Err(format!(
-            "No wallet group '{group}' on {}",
-            network.as_str()
-        ));
+        return Err(format!("No wallet group '{group}' on {}", network.as_str()));
     }
     let open_member = state
         .open_wallet_name()
@@ -1501,7 +1493,7 @@ pub fn rename_group_impl(
     }
     // Another group already answering to the new id would merge two seeds'
     // compartments in the selector — refuse.
-    let case_only = group.to_ascii_lowercase() == new_group.to_ascii_lowercase();
+    let case_only = group.eq_ignore_ascii_case(new_group);
     if !case_only
         && config
             .wallet_names(network)
@@ -1531,7 +1523,7 @@ pub fn rename_group_impl(
         let taken_by_non_member = config
             .wallet_names(network)
             .iter()
-            .any(|n| !members.contains(n) && n.to_ascii_lowercase() == new.to_ascii_lowercase());
+            .any(|n| !members.contains(n) && n.eq_ignore_ascii_case(new));
         if taken_by_non_member || (old != new && has_leftover_store(network, new)) {
             return Err(format!(
                 "A wallet named '{new}' already exists on {}",
@@ -1587,10 +1579,7 @@ pub fn delete_group_impl(
     let network = config.network;
     let members = config.group_members(network, group);
     if members.is_empty() {
-        return Err(format!(
-            "No wallet group '{group}' on {}",
-            network.as_str()
-        ));
+        return Err(format!("No wallet group '{group}' on {}", network.as_str()));
     }
     let open_member = state
         .open_wallet_name()

--- a/web-wallet/src-tauri/src/btcx_wallet/config.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/config.rs
@@ -415,7 +415,13 @@ impl BtcxWalletConfig {
 
     /// Record one wallet's balance snapshot (selector display), stamping
     /// the current time. No-op if the wallet is not registered.
-    pub fn set_balance_snapshot(&mut self, network: WalletNetwork, name: &str, sat: u64, height: u32) {
+    pub fn set_balance_snapshot(
+        &mut self,
+        network: WalletNetwork,
+        name: &str,
+        sat: u64,
+        height: u32,
+    ) {
         if let Some(mut meta) = self.wallet_meta(network, name) {
             meta.balance_snapshot = Some(BalanceSnapshot {
                 sat,
@@ -775,7 +781,10 @@ impl BtcxWalletConfig {
             return;
         }
         if let Err(e) = fs::copy(&path, &backup) {
-            log::warn!("btcx wallet: config backup to {} failed: {e}", backup.display());
+            log::warn!(
+                "btcx wallet: config backup to {} failed: {e}",
+                backup.display()
+            );
         } else {
             log::info!("btcx wallet: config backed up to {}", backup.display());
         }

--- a/web-wallet/src-tauri/src/btcx_wallet/state.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/state.rs
@@ -566,10 +566,7 @@ impl BtcxWalletState {
             [KeychainKind::External, KeychainKind::Internal]
                 .into_iter()
                 .map(|keychain| {
-                    let start = entry
-                        .wallet
-                        .derivation_index(keychain)
-                        .map_or(0, |i| i + 1);
+                    let start = entry.wallet.derivation_index(keychain).map_or(0, |i| i + 1);
                     let spks: Vec<bitcoin::ScriptBuf> = (start..start + STOP_GAP)
                         .map(|i| {
                             entry

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Phoenix Wallet",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "identifier": "org.pocx.phoenix",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/web-wallet/src/app/bitcoin/services/wallet/wallet-manager.service.ts
+++ b/web-wallet/src/app/bitcoin/services/wallet/wallet-manager.service.ts
@@ -259,7 +259,11 @@ export class WalletManagerService {
           isEncrypted: anyEncrypted,
           // Selector semantics: undefined = no unlock needed, 0 = locked,
           // >0 = unlocked. Keyring-encrypted seeds auto-unlock → undefined.
-          unlockedUntil: anyLocked ? 0 : anyEncrypted && !!open ? SESSION_UNLOCK_SECONDS : undefined,
+          unlockedUntil: anyLocked
+            ? 0
+            : anyEncrypted && !!open
+              ? SESSION_UNLOCK_SECONDS
+              : undefined,
         };
       });
     }

--- a/web-wallet/src/app/core/guards/node-setup.guard.ts
+++ b/web-wallet/src/app/core/guards/node-setup.guard.ts
@@ -26,11 +26,7 @@ export const nodeSetupGuard: CanActivateFn = async () => {
   const router = inject(Router);
   const appModeService = inject(AppModeService);
 
-  if (
-    appModeService.isNodeless() ||
-    appModeService.isMiningOnly() ||
-    !electronService.isDesktop
-  ) {
+  if (appModeService.isNodeless() || appModeService.isMiningOnly() || !electronService.isDesktop) {
     return true;
   }
 

--- a/web-wallet/src/app/features/auth/pages/wallet-select/wallet-select.component.ts
+++ b/web-wallet/src/app/features/auth/pages/wallet-select/wallet-select.component.ts
@@ -23,10 +23,7 @@ import { CookieAuthService } from '../../../../core/auth/cookie-auth.service';
 import { AppUpdateService } from '../../../../core/services/app-update.service';
 import { WalletUnlockService } from '../../../../shared/services/wallet-unlock.service';
 import { NodeService } from '../../../../node/services/node.service';
-import {
-  BtcxWalletService,
-  BtcxCompartment,
-} from '../../../../core/services/btcx-wallet.service';
+import { BtcxWalletService, BtcxCompartment } from '../../../../core/services/btcx-wallet.service';
 
 /**
  * WalletSelectComponent displays available wallets and options to create/import.

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1288,9 +1288,7 @@ export class MobileWalletLayoutComponent implements OnInit {
   });
 
   /** Wallet chip label: the GROUP name only (the pocket chip has the rest). */
-  readonly activeGroupName = computed(
-    () => this.activeGroup()?.group ?? this.wallet.walletName()
-  );
+  readonly activeGroupName = computed(() => this.activeGroup()?.group ?? this.wallet.walletName());
 
   /** The active group's pockets ([] while nothing matches). */
   readonly activePockets = computed<BtcxCompartment[]>(
@@ -1303,9 +1301,7 @@ export class MobileWalletLayoutComponent implements OnInit {
     const pocket = this.activePockets().find(c => c.name === name);
     if (!pocket) return null;
     const role = this.i18n.get(this.roleLabel(pocket));
-    return pocket.policy.coinType === 0
-      ? `${role}·${this.i18n.get('wallet_legacy_badge')}`
-      : role;
+    return pocket.policy.coinType === 0 ? `${role}·${this.i18n.get('wallet_legacy_badge')}` : role;
   });
 
   /** Drawer label of the active wallet: "group · Role". */
@@ -1342,9 +1338,7 @@ export class MobileWalletLayoutComponent implements OnInit {
   readonly switchingGroup = computed<string | null>(() => {
     const name = this.switching();
     if (name === null) return null;
-    return (
-      this.wallet.groups().find(g => g.compartments.some(c => c.name === name))?.group ?? name
-    );
+    return this.wallet.groups().find(g => g.compartments.some(c => c.name === name))?.group ?? name;
   });
 
   /**

--- a/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
@@ -15,11 +15,7 @@ import {
   BTCX_COIN_TYPE,
 } from '../../../../core/services/btcx-wallet.service';
 import { sanitizeReturnTo } from '../../return-to';
-import {
-  isInvalidWalletName,
-  isWalletNameTaken,
-  suggestWalletName,
-} from '../../wallet-name';
+import { isInvalidWalletName, isWalletNameTaken, suggestWalletName } from '../../wallet-name';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 import { WalletNameSectionComponent } from '../../components/wallet-name-section/wallet-name-section.component';
 

--- a/web-wallet/src/app/features/mobile-wallet/wallet-name.spec.ts
+++ b/web-wallet/src/app/features/mobile-wallet/wallet-name.spec.ts
@@ -51,5 +51,4 @@ describe('wallet-name helpers', () => {
       expect(deduped.endsWith('-2')).toBeTrue();
     });
   });
-
 });

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -75,134 +75,134 @@ type AddressMode = 'existing' | 'generate';
               <span>{{ 'mwallet_receive_v30_blocked' | i18n }}</span>
             </div>
           } @else {
-          <!-- Address Selection -->
-          <div class="form-section">
-            <div class="address-mode-row">
-              <mat-radio-group [(ngModel)]="addressMode" (change)="onAddressModeChange()">
-                <mat-radio-button value="existing">{{
-                  'use_existing_address' | i18n
-                }}</mat-radio-button>
-                <div class="generate-option">
-                  <mat-radio-button value="generate">{{
-                    'generate_new_address' | i18n
+            <!-- Address Selection -->
+            <div class="form-section">
+              <div class="address-mode-row">
+                <mat-radio-group [(ngModel)]="addressMode" (change)="onAddressModeChange()">
+                  <mat-radio-button value="existing">{{
+                    'use_existing_address' | i18n
                   }}</mat-radio-button>
-                  @if (addressMode === 'generate') {
-                    <button
-                      type="button"
-                      class="regenerate-btn"
-                      (click)="generateNewAddress()"
-                      [disabled]="isGenerating()"
-                      [title]="'generate_new' | i18n"
-                    >
-                      @if (isGenerating()) {
-                        <mat-spinner diameter="18"></mat-spinner>
-                      } @else {
-                        <mat-icon>refresh</mat-icon>
-                      }
-                    </button>
-                  }
-                </div>
-              </mat-radio-group>
-            </div>
-
-            @if (addressMode === 'existing') {
-              @if (!isLoadingAddresses()) {
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'select_address' | i18n }}</mat-label>
-                  <mat-select [(ngModel)]="selectedAddress">
-                    @for (addr of existingAddresses(); track addr.address) {
-                      <mat-option [value]="addr.address">
-                        <span class="address-option"
-                          >{{ addr.address }}{{ getAddressDisplayLabel(addr) }}</span
-                        >
-                      </mat-option>
+                  <div class="generate-option">
+                    <mat-radio-button value="generate">{{
+                      'generate_new_address' | i18n
+                    }}</mat-radio-button>
+                    @if (addressMode === 'generate') {
+                      <button
+                        type="button"
+                        class="regenerate-btn"
+                        (click)="generateNewAddress()"
+                        [disabled]="isGenerating()"
+                        [title]="'generate_new' | i18n"
+                      >
+                        @if (isGenerating()) {
+                          <mat-spinner diameter="18"></mat-spinner>
+                        } @else {
+                          <mat-icon>refresh</mat-icon>
+                        }
+                      </button>
                     }
-                  </mat-select>
-                </mat-form-field>
-              } @else {
-                <div class="loading-inline">
-                  <mat-spinner diameter="20"></mat-spinner>
-                  <span>{{ 'loading_addresses' | i18n }}</span>
-                </div>
+                  </div>
+                </mat-radio-group>
+              </div>
+
+              @if (addressMode === 'existing') {
+                @if (!isLoadingAddresses()) {
+                  <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>{{ 'select_address' | i18n }}</mat-label>
+                    <mat-select [(ngModel)]="selectedAddress">
+                      @for (addr of existingAddresses(); track addr.address) {
+                        <mat-option [value]="addr.address">
+                          <span class="address-option"
+                            >{{ addr.address }}{{ getAddressDisplayLabel(addr) }}</span
+                          >
+                        </mat-option>
+                      }
+                    </mat-select>
+                  </mat-form-field>
+                } @else {
+                  <div class="loading-inline">
+                    <mat-spinner diameter="20"></mat-spinner>
+                    <span>{{ 'loading_addresses' | i18n }}</span>
+                  </div>
+                }
               }
+            </div>
+
+            <!-- Amount -->
+            <div class="form-section">
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>{{ 'amount_optional' | i18n }}</mat-label>
+                <input
+                  matInput
+                  type="number"
+                  [(ngModel)]="amount"
+                  placeholder="0.00000000"
+                  step="0.00000001"
+                  min="0"
+                  autocomplete="off"
+                />
+                <span matTextSuffix>BTCX</span>
+              </mat-form-field>
+            </div>
+
+            <!-- Label -->
+            <div class="form-section">
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>{{ 'label_optional' | i18n }}</mat-label>
+                <input
+                  matInput
+                  [(ngModel)]="label"
+                  [placeholder]="'label_placeholder' | i18n"
+                  maxlength="50"
+                  autocomplete="off"
+                />
+              </mat-form-field>
+            </div>
+
+            <!-- QR Code Section -->
+            @if (currentAddress()) {
+              <div class="qr-section">
+                <div class="qr-code-container">
+                  <qrcode
+                    [qrdata]="paymentUri()"
+                    [width]="200"
+                    [errorCorrectionLevel]="'M'"
+                    [margin]="1"
+                    [colorDark]="'#1E3A5F'"
+                    [colorLight]="'#FFFFFF'"
+                  ></qrcode>
+                </div>
+
+                <div class="info-row">
+                  <span class="info-label">{{ 'address' | i18n }}:</span>
+                  <div
+                    class="info-value-row copyable"
+                    (click)="copyAddress()"
+                    [matTooltip]="'copy' | i18n"
+                  >
+                    <span class="address-value">{{ currentAddress() }}</span>
+                    <mat-icon class="copy-icon">content_copy</mat-icon>
+                  </div>
+                </div>
+
+                <div class="info-row">
+                  <span class="info-label">{{ 'payment_uri' | i18n }}:</span>
+                  <div
+                    class="info-value-row copyable"
+                    (click)="copyPaymentUri()"
+                    [matTooltip]="'copy' | i18n"
+                  >
+                    <span class="uri-value">{{ paymentUri() }}</span>
+                    <mat-icon class="copy-icon">content_copy</mat-icon>
+                  </div>
+                </div>
+              </div>
+            } @else {
+              <div class="no-address">
+                <mat-icon>qr_code</mat-icon>
+                <span>{{ 'select_or_generate_address' | i18n }}</span>
+              </div>
             }
-          </div>
-
-          <!-- Amount -->
-          <div class="form-section">
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'amount_optional' | i18n }}</mat-label>
-              <input
-                matInput
-                type="number"
-                [(ngModel)]="amount"
-                placeholder="0.00000000"
-                step="0.00000001"
-                min="0"
-                autocomplete="off"
-              />
-              <span matTextSuffix>BTCX</span>
-            </mat-form-field>
-          </div>
-
-          <!-- Label -->
-          <div class="form-section">
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'label_optional' | i18n }}</mat-label>
-              <input
-                matInput
-                [(ngModel)]="label"
-                [placeholder]="'label_placeholder' | i18n"
-                maxlength="50"
-                autocomplete="off"
-              />
-            </mat-form-field>
-          </div>
-
-          <!-- QR Code Section -->
-          @if (currentAddress()) {
-            <div class="qr-section">
-              <div class="qr-code-container">
-                <qrcode
-                  [qrdata]="paymentUri()"
-                  [width]="200"
-                  [errorCorrectionLevel]="'M'"
-                  [margin]="1"
-                  [colorDark]="'#1E3A5F'"
-                  [colorLight]="'#FFFFFF'"
-                ></qrcode>
-              </div>
-
-              <div class="info-row">
-                <span class="info-label">{{ 'address' | i18n }}:</span>
-                <div
-                  class="info-value-row copyable"
-                  (click)="copyAddress()"
-                  [matTooltip]="'copy' | i18n"
-                >
-                  <span class="address-value">{{ currentAddress() }}</span>
-                  <mat-icon class="copy-icon">content_copy</mat-icon>
-                </div>
-              </div>
-
-              <div class="info-row">
-                <span class="info-label">{{ 'payment_uri' | i18n }}:</span>
-                <div
-                  class="info-value-row copyable"
-                  (click)="copyPaymentUri()"
-                  [matTooltip]="'copy' | i18n"
-                >
-                  <span class="uri-value">{{ paymentUri() }}</span>
-                  <mat-icon class="copy-icon">content_copy</mat-icon>
-                </div>
-              </div>
-            </div>
-          } @else {
-            <div class="no-address">
-              <mat-icon>qr_code</mat-icon>
-              <span>{{ 'select_or_generate_address' | i18n }}</span>
-            </div>
-          }
           }
         </div>
       </div>

--- a/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
+++ b/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
@@ -2563,7 +2563,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
     }
   }
 
-
   async startManagedNode(): Promise<void> {
     this.isStartingNode.set(true);
     try {

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -35,10 +35,7 @@ import { MiningService } from '../../mining/services';
 import { ClockDriftService } from '../../core/services/clock-drift.service';
 import { ElectrumStatusService } from '../../core/services/electrum-status.service';
 import { BlockchainStateService } from '../../bitcoin/services/blockchain-state.service';
-import {
-  BtcxWalletService,
-  BtcxCompartment,
-} from '../../core/services/btcx-wallet.service';
+import { BtcxWalletService, BtcxCompartment } from '../../core/services/btcx-wallet.service';
 import { ClockDriftDialogComponent } from '../../shared/components/clock-drift-dialog/clock-drift-dialog.component';
 import { ElectrumServerListComponent } from '../../shared/components/electrum-server-list/electrum-server-list.component';
 

--- a/web-wallet/src/app/node/services/node.service.ts
+++ b/web-wallet/src/app/node/services/node.service.ts
@@ -85,9 +85,7 @@ export class NodeService {
    * (the nodeless btcx stack). THE signal every remote-mode branch keys on.
    * Always true on Android and in the desktop mobile-view dev launches.
    */
-  readonly isRemote = computed(
-    () => this.appMode.isNodeless() || this._config().mode === 'remote'
-  );
+  readonly isRemote = computed(() => this.appMode.isNodeless() || this._config().mode === 'remote');
   readonly isRunning = computed(() => this._status().running);
   readonly isInstalled = computed(() => this._status().installed);
   readonly isSynced = computed(() => this._status().synced);


### PR DESCRIPTION
Release prep for **v2.2.0** (last public release was 2.1.1).

- Bumps the version to `2.2.0` across `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`.
- Writes the 2.2.0 `CHANGELOG.md`: wallet **pockets** (compartments) redesign, multi-device balance-sync fixes (gap watch + balance-aware events), spend-only v30 receive gating, and full translations across all 25 locales.

Full test suite green locally before this PR: `cargo test --lib` (93 passed), `npm run test:ci` (80 passed), `ng lint`, `ng build`.

Merging this to master, then tagging `v2.2.0` triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
