### PR TITLE
fix(time): reach NTP servers over IPv6 on dual-stack hosts

### DIFF
--- a/web-wallet/src-tauri/src/time/commands.rs
+++ b/web-wallet/src-tauri/src/time/commands.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::net::SocketAddr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::UdpSocket;
 
@@ -24,13 +25,35 @@ pub struct ClockDriftReport {
 }
 
 async fn query_ntp(server: &'static str) -> Result<NtpSample, String> {
-    let addr = tokio::net::lookup_host(format!("{}:123", server))
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host(format!("{}:123", server))
         .await
         .map_err(|e| format!("dns: {}", e))?
-        .next()
-        .ok_or_else(|| "no address".to_string())?;
+        .collect();
+    if addrs.is_empty() {
+        return Err("no address".to_string());
+    }
 
-    let socket = UdpSocket::bind("0.0.0.0:0")
+    // Try each resolved address end-to-end (connect + round-trip). On
+    // dual-stack hosts the resolver may return IPv6 first; if that path is
+    // unreachable — a family mismatch on the socket, or a configured-but-
+    // dead IPv6 route that times out — we fall through to the next address
+    // (e.g. IPv4) instead of failing the whole server.
+    let mut last_err = "no address".to_string();
+    for addr in addrs {
+        match query_ntp_addr(server, addr).await {
+            Ok(sample) => return Ok(sample),
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
+}
+
+/// Query a single resolved NTP endpoint. The socket's address family is
+/// matched to `addr`: an IPv4-bound socket cannot connect to an IPv6
+/// address (WSAEAFNOSUPPORT on Windows) and vice versa.
+async fn query_ntp_addr(server: &'static str, addr: SocketAddr) -> Result<NtpSample, String> {
+    let bind_addr = if addr.is_ipv6() { "[::]:0" } else { "0.0.0.0:0" };
+    let socket = UdpSocket::bind(bind_addr)
         .await
         .map_err(|e| format!("bind: {}", e))?;
     socket


### PR DESCRIPTION
## Problem

The clock-drift indicator stopped working — the dialog shows **no NTP data** and **Check now** appears to do nothing.

Root cause is in `src-tauri/src/time/commands.rs::query_ntp`: it bound the UDP socket to `0.0.0.0` (IPv4-only) and took the **first** address from `lookup_host` without trying the rest. On an IPv6-enabled host, `getaddrinfo` (RFC 6724) returns the **IPv6** address first for any server with an AAAA record, so `connect()` failed with `WSAEAFNOSUPPORT` (os error 10047) and that server was silently dropped.

Since `time.cloudflare.com` and `time.google.com` are both AAAA-first, only `time.nist.gov` (no AAAA) succeeded — **1/3** responses, below the 2-sample minimum, so `check_clock_drift` returned `Err`. The frontend swallows that error (`clock-drift.service.ts` logs to `console.debug` only), which is why it silently shows no data.

It "worked before" because the code always assumed IPv4; it broke when the dev host/network became IPv6-enabled.

## Fix

- Bind a socket whose address family **matches** each resolved address (`[::]:0` for IPv6, `0.0.0.0:0` for IPv4).
- Try **every** resolved address end-to-end (connect + round-trip), falling through to the next on any failure — covering both the family mismatch and a configured-but-dead IPv6 route that would otherwise time out.

## Verification

Reproduced the exact tokio logic before/after on the affected dual-stack host:

**Before** — cloudflare/google fail with os error 10047, only nist (IPv4) works → 1/3.
**After** — all three respond (cloudflare + google over IPv6, nist over IPv4) → 3/3.

Verified end-to-end in a `tauri:dev` session: the clock-drift dialog now populates and **Check now** returns a reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)