### PR TITLE
feat(build): three Android flavors via symmetric mining/wallet cargo features

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -5,10 +5,38 @@ on:
 
 jobs:
   build-android:
-    name: Build & Sign Android APK
+    name: Build & Sign Android APK (${{ matrix.flavor }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Same 3-flavor matrix as the release workflow (see android-release.yml
+        # for the rationale). This test build produces one artifact per flavor.
+        include:
+          - flavor: hybrid
+            app_id: org.pocx.phoenix
+            build_args: ""
+          - flavor: wallet   # Play Store candidate — NO mining compiled in
+            app_id: org.pocx.phoenix.wallet
+            build_args: "-f wallet -- --no-default-features"
+          - flavor: mining   # sideload pure miner — NO wallet compiled in
+            app_id: org.pocx.phoenix.miner
+            build_args: "-f mining -- --no-default-features"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Compute version identity
+        id: version
+        run: |
+          # No release tag in the test workflow — derive from tauri.conf.json.
+          VERSION=$(node -p "require('./web-wallet/src-tauri/tauri.conf.json').version")
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          MAJOR=${MAJOR:-0}; MINOR=${MINOR:-0}; PATCH=${PATCH:-0}
+          CODE=$((MAJOR * 10000 + MINOR * 100 + PATCH))
+          if [ "$CODE" -lt 1 ]; then CODE=1; fi
+          echo "name=$VERSION" >> $GITHUB_OUTPUT
+          echo "code=$CODE" >> $GITHUB_OUTPUT
+          echo "versionName=$VERSION versionCode=$CODE"
 
       - name: Free disk space
         run: |
@@ -45,6 +73,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './web-wallet/src-tauri -> target'
+          key: ${{ matrix.flavor }}
 
       - name: Install web-wallet dependencies
         working-directory: web-wallet
@@ -105,7 +134,9 @@ jobs:
           # Decode keystore from secret
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > $HOME/release.keystore
 
-          # Replace generated build.gradle.kts with our signing-enabled template
+          # Replace generated build.gradle.kts with our signing-enabled template.
+          # The template reads PHX_APP_ID / PHX_VERSION_NAME / PHX_VERSION_CODE
+          # from the environment (set on the build step) for per-flavor identity.
           cp web-wallet/src-tauri/android-template/build.gradle.kts \
              web-wallet/src-tauri/gen/android/app/build.gradle.kts
 
@@ -117,9 +148,13 @@ jobs:
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           EOF
 
-      - name: Build Android APK (ARM64 only)
+      - name: Build Android APK (ARM64 only) — ${{ matrix.flavor }}
         working-directory: web-wallet
-        run: npx tauri android build --target aarch64
+        env:
+          PHX_APP_ID: ${{ matrix.app_id }}
+          PHX_VERSION_NAME: ${{ steps.version.outputs.name }}
+          PHX_VERSION_CODE: ${{ steps.version.outputs.code }}
+        run: npx tauri android build --target aarch64 ${{ matrix.build_args }}
 
       - name: Find signed APK
         id: find-apk
@@ -140,6 +175,6 @@ jobs:
       - name: Upload APK as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Phoenix-PoCX-Android-ARM64-test
+          name: Phoenix-PoCX-Android-${{ matrix.flavor }}-ARM64-test
           path: ${{ steps.find-apk.outputs.apk_path }}
           retention-days: 14

--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -15,13 +15,13 @@ jobs:
         include:
           - flavor: hybrid
             app_id: org.pocx.phoenix
-            build_args: ""
+            build_args: "-f mining -f wallet"
           - flavor: wallet   # Play Store candidate — NO mining compiled in
             app_id: org.pocx.phoenix.wallet
-            build_args: "-f wallet -- --no-default-features"
+            build_args: "-f wallet"
           - flavor: mining   # sideload pure miner — NO wallet compiled in
             app_id: org.pocx.phoenix.miner
-            build_args: "-f mining -- --no-default-features"
+            build_args: "-f mining"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -8,8 +8,30 @@ permissions:
 
 jobs:
   build-android:
-    name: Build & Sign Android APK
+    name: Build & Sign Android APK (${{ matrix.flavor }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Three Android build flavors from one codebase. Each disables one
+        # cargo feature; the appId differs so all three can coexist / upload
+        # side by side. Only the `wallet` flavor is the Play Store candidate
+        # (no mining code compiled in); `mining` is a sideload pure-miner;
+        # `hybrid` keeps the existing appId so current sideload installs update.
+        #
+        # build_args: passed to `tauri android build`. `-f <feature>` is always
+        # honored by the CLI; `-- --no-default-features` is a runner passthrough
+        # that reaches cargo so the OTHER feature is dropped from the binary.
+        include:
+          - flavor: hybrid
+            app_id: org.pocx.phoenix
+            build_args: ""
+          - flavor: wallet   # Play Store candidate — NO mining compiled in
+            app_id: org.pocx.phoenix.wallet
+            build_args: "-f wallet -- --no-default-features"
+          - flavor: mining   # sideload pure miner — NO wallet compiled in
+            app_id: org.pocx.phoenix.miner
+            build_args: "-f mining -- --no-default-features"
     steps:
       - uses: actions/checkout@v4
 
@@ -25,6 +47,20 @@ jobs:
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Found latest release: $TAG"
+
+      - name: Compute version identity
+        id: version
+        run: |
+          TAG="${{ steps.release.outputs.tag }}"
+          VERSION="${TAG#v}"
+          # versionCode scheme: MAJOR*10000 + MINOR*100 + PATCH (e.g. 2.2.0 -> 20200)
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          MAJOR=${MAJOR:-0}; MINOR=${MINOR:-0}; PATCH=${PATCH:-0}
+          CODE=$((MAJOR * 10000 + MINOR * 100 + PATCH))
+          if [ "$CODE" -lt 1 ]; then CODE=1; fi
+          echo "name=$VERSION" >> $GITHUB_OUTPUT
+          echo "code=$CODE" >> $GITHUB_OUTPUT
+          echo "versionName=$VERSION versionCode=$CODE"
 
       - name: Free disk space
         run: |
@@ -61,6 +97,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './web-wallet/src-tauri -> target'
+          key: ${{ matrix.flavor }}
 
       - name: Install web-wallet dependencies
         working-directory: web-wallet
@@ -121,7 +158,9 @@ jobs:
           # Decode keystore from secret
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > $HOME/release.keystore
 
-          # Replace generated build.gradle.kts with our signing-enabled template
+          # Replace generated build.gradle.kts with our signing-enabled template.
+          # The template reads PHX_APP_ID / PHX_VERSION_NAME / PHX_VERSION_CODE
+          # from the environment (set on the build step) for per-flavor identity.
           cp web-wallet/src-tauri/android-template/build.gradle.kts \
              web-wallet/src-tauri/gen/android/app/build.gradle.kts
 
@@ -133,9 +172,13 @@ jobs:
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           EOF
 
-      - name: Build Android APK (ARM64 only)
+      - name: Build Android APK (ARM64 only) — ${{ matrix.flavor }}
         working-directory: web-wallet
-        run: npx tauri android build --target aarch64
+        env:
+          PHX_APP_ID: ${{ matrix.app_id }}
+          PHX_VERSION_NAME: ${{ steps.version.outputs.name }}
+          PHX_VERSION_CODE: ${{ steps.version.outputs.code }}
+        run: npx tauri android build --target aarch64 ${{ matrix.build_args }}
 
       - name: Verify signed APK exists
         id: verify
@@ -158,13 +201,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.release.outputs.tag }}"
-          VERSION="${TAG#v}"
+          VERSION="${{ steps.version.outputs.name }}"
           APK_FILE="${{ steps.verify.outputs.apk_path }}"
 
-          NEW_NAME="Phoenix-PoCX-${VERSION}-Android-ARM64.apk"
+          # Per-flavor asset name so the three uploads never clobber each other.
+          NEW_NAME="Phoenix-PoCX-${VERSION}-Android-${{ matrix.flavor }}-ARM64.apk"
           cp "$APK_FILE" "$NEW_NAME"
 
           echo "Uploading $NEW_NAME to release $TAG"
           gh release upload "$TAG" "$NEW_NAME" --repo ${{ github.repository }} --clobber
 
-          echo "Successfully uploaded Android APK to $TAG"
+          echo "Successfully uploaded Android APK ($NEW_NAME) to $TAG"

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -19,19 +19,22 @@ jobs:
         # (no mining code compiled in); `mining` is a sideload pure-miner;
         # `hybrid` keeps the existing appId so current sideload installs update.
         #
-        # build_args: passed to `tauri android build`. `-f <feature>` is always
-        # honored by the CLI; `-- --no-default-features` is a runner passthrough
-        # that reaches cargo so the OTHER feature is dropped from the binary.
+        # build_args: passed to `tauri android build`. `-f <feature>` is
+        # honored by the CLI and reaches cargo. It is ADDITIVE and cargo's
+        # default features are EMPTY (see Cargo.toml), so `-f wallet` yields
+        # EXACTLY `[wallet]` — no `--no-default-features` needed (and there is
+        # no such flag on `tauri android build`; its `-- <args>` go to Gradle,
+        # not cargo). Hybrid names both features explicitly.
         include:
           - flavor: hybrid
             app_id: org.pocx.phoenix
-            build_args: ""
+            build_args: "-f mining -f wallet"
           - flavor: wallet   # Play Store candidate — NO mining compiled in
             app_id: org.pocx.phoenix.wallet
-            build_args: "-f wallet -- --no-default-features"
+            build_args: "-f wallet"
           - flavor: mining   # sideload pure miner — NO wallet compiled in
             app_id: org.pocx.phoenix.miner
-            build_args: "-f mining -- --no-default-features"
+            build_args: "-f mining"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,20 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
-      - name: Check Rust code
-        run: cargo check
+      - name: Check Rust code (hybrid — both flavors)
+        run: cargo check --features mining,wallet
+
+      # Keep the feature gating honest: each flavor must compile on its own,
+      # otherwise a stray cross-feature dependency would only surface in the
+      # Android per-flavor builds.
+      - name: Check Rust code (wallet-only flavor)
+        run: cargo check --features wallet
+
+      - name: Check Rust code (mining-only flavor)
+        run: cargo check --features mining
 
       - name: Run Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --features mining,wallet -- -D warnings
 
   rust-audit:
     name: Rust Audit

--- a/.github/workflows/desktop-build-test.yml
+++ b/.github/workflows/desktop-build-test.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build Tauri app (Windows - NSIS only, skip MSI for pre-release versions)
         if: matrix.os_name == 'Windows'
         working-directory: web-wallet
-        run: npm run tauri build -- --target ${{ matrix.target }} --bundles nsis
+        run: npm run tauri build -- --target ${{ matrix.target }} --bundles nsis -f mining -f wallet
 
       - name: Setup Apple certificate
         if: matrix.os_name == 'macOS'
@@ -112,12 +112,12 @@ jobs:
         working-directory: web-wallet
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        run: npm run tauri build -- --target ${{ matrix.target }}
+        run: npm run tauri build -- --target ${{ matrix.target }} -f mining -f wallet
 
       - name: Build Tauri app (Linux)
         if: matrix.os_name == 'Linux'
         working-directory: web-wallet
-        run: npm run tauri build -- --target ${{ matrix.target }}
+        run: npm run tauri build -- --target ${{ matrix.target }} -f mining -f wallet
 
       - name: Fix AppImage - Remove bundled EGL/Wayland libs
         if: matrix.os_name == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Build Tauri app (Windows - NSIS only, skip MSI for pre-release versions)
         if: matrix.os_name == 'Windows'
         working-directory: web-wallet
-        run: npm run tauri build -- --target ${{ matrix.target }} --bundles nsis
+        run: npm run tauri build -- --target ${{ matrix.target }} --bundles nsis -f mining -f wallet
 
       - name: Setup Apple certificate
         if: matrix.os_name == 'macOS'
@@ -132,12 +132,12 @@ jobs:
         working-directory: web-wallet
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        run: npm run tauri build -- --target ${{ matrix.target }}
+        run: npm run tauri build -- --target ${{ matrix.target }} -f mining -f wallet
 
       - name: Build Tauri app (Linux)
         if: matrix.os_name == 'Linux'
         working-directory: web-wallet
-        run: npm run tauri build -- --target ${{ matrix.target }}
+        run: npm run tauri build -- --target ${{ matrix.target }} -f mining -f wallet
 
       - name: Fix AppImage - Remove bundled EGL/Wayland libs
         if: matrix.os_name == 'Linux'

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -13,8 +13,8 @@
     "format:check": "prettier --check \"src/**/*.{ts,html,scss}\"",
     "format:fix": "prettier --write \"src/**/*.{ts,html,scss}\"",
     "tauri": "tauri",
-    "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:dev": "tauri dev -f mining -f wallet",
+    "tauri:build": "tauri build -f mining -f wallet"
   },
   "private": true,
   "dependencies": {

--- a/web-wallet/src-tauri/.vscode/settings.json
+++ b/web-wallet/src-tauri/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": ["mining", "wallet"]
+}

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -13,11 +13,40 @@ name = "phoenix_pocx_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [features]
-# Wallet-only launch flavor (the future iOS / wallet-only-Android app):
-# on Android, `get_launch_mode` reports "wallet-mobile" instead of "mobile",
-# so the frontend shows only the nodeless wallet (no mining, no node).
-# Desktop builds keep both modes and pick at runtime via `--wallet-only`.
-wallet-only = []
+# Two symmetric build-flavor features. Each Android flavor disables one; the
+# desktop binary always builds `default` (both) and picks the runtime layout
+# via CLI flags (`--mining-only` / `--mobile` / `--wallet-only`).
+#
+#   Hybrid       (default)                        wallet + mining
+#   Wallet-only  --no-default-features -F wallet  wallet, NO mining compiled
+#   Mining-only  --no-default-features -F mining  mining, NO wallet compiled
+#
+# `mining` gates the pocx mining/plotting/aggregator stack and every
+# mining/aggregator Tauri command. `wallet` gates the nodeless btcx_wallet
+# backend (btcx crates + bdk) and every btcx_wallet_*/btcx_psbt_*/
+# btcx_electrum_* command. `get_launch_mode` derives the Android mode from
+# whichever feature(s) are enabled (both → mobile, wallet → wallet-mobile,
+# mining → mining).
+default = ["mining", "wallet"]
+mining = [
+    "dep:pocx_miner",
+    "dep:pocx_plotter_v2",
+    "dep:pocx_address",
+    "dep:pocx_aggregator",
+]
+wallet = [
+    "dep:params-btcx",
+    "dep:keys-btcx",
+    "dep:seedstore",
+    "dep:electrum-btcx",
+    "dep:wallet-btcx",
+    "dep:bitcoin",
+    "dep:bdk_wallet",
+    "dep:bech32",
+    "dep:scrypt",
+    "dep:chacha20poly1305",
+    "dep:rand",
+]
 
 # macOS miner launcher - native binary to avoid Rosetta prompts
 [[bin]]
@@ -52,28 +81,28 @@ num_cpus = "1.16"
 # Async runtime for mining operations
 tokio = { version = "1", features = ["full"] }
 
-# PoCX mining libraries
-pocx_miner = "1.0.5"
-pocx_plotter_v2 = { version = "1.0.5", features = ["opencl"] }
-pocx_address = "1.0.5"
-pocx_aggregator = "1.0.5"
+# PoCX mining libraries (gated by the `mining` feature)
+pocx_miner = { version = "1.0.5", optional = true }
+pocx_plotter_v2 = { version = "1.0.5", features = ["opencl"], optional = true }
+pocx_address = { version = "1.0.5", optional = true }
+pocx_aggregator = { version = "1.0.5", optional = true }
 
 
-# Nodeless BTCX wallet stack (shared btcx crates)
-params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
-keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
-seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
-electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
-wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9" }
-bitcoin = { version = "0.32", features = ["serde", "rand-std"] }
-bdk_wallet = { version = "2", features = ["rusqlite"] }
+# Nodeless BTCX wallet stack (shared btcx crates) — gated by the `wallet` feature
+params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
+keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
+seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
+electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
+wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
+bitcoin = { version = "0.32", features = ["serde", "rand-std"], optional = true }
+bdk_wallet = { version = "2", features = ["rusqlite"], optional = true }
 # bech32 with custom HRPs (pocx/tpocx/rpocx) â€” same version the btcx crates use
-bech32 = "0.11"
+bech32 = { version = "0.11", optional = true }
 # Descriptor-at-rest wraps for imported wallets (btcx_wallet::descstore) â€”
 # the same primitives and parameters seedstore uses for seed.mnemonic.
-scrypt = "0.11"
-chacha20poly1305 = "0.10"
-rand = "0.8"
+scrypt = { version = "0.11", optional = true }
+chacha20poly1305 = { version = "0.10", optional = true }
+rand = { version = "0.8", optional = true }
 
 # SHA256 hashing for node binary verification
 sha2 = "0.10"

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -13,13 +13,24 @@ name = "phoenix_pocx_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [features]
-# Two symmetric build-flavor features. Each Android flavor disables one; the
-# desktop binary always builds `default` (both) and picks the runtime layout
-# via CLI flags (`--mining-only` / `--mobile` / `--wallet-only`).
+# Two symmetric build-flavor features. `default` is intentionally EMPTY:
+# every build must name the flavor it wants. This is the robust choice for
+# Android — `tauri android build -f <feature>` is ADDITIVE (it only ever
+# ADDS features, it cannot subtract), and there is no native
+# `--no-default-features` flag on that subcommand; its `-- <args>` reach the
+# Gradle runner, NOT cargo. With an empty default, `-f wallet` yields EXACTLY
+# `[wallet]` under plain cargo semantics — no passthrough needed, no risk of
+# the other flavor silently leaking into the binary.
 #
-#   Hybrid       (default)                        wallet + mining
-#   Wallet-only  --no-default-features -F wallet  wallet, NO mining compiled
-#   Mining-only  --no-default-features -F mining  mining, NO wallet compiled
+#   Hybrid       -f mining -f wallet  (cargo: --features mining,wallet)
+#   Wallet-only  -f wallet            wallet, NO mining compiled
+#   Mining-only  -f mining            mining, NO wallet compiled
+#
+# Because default is empty, every NON-Android build must pass features too:
+# the desktop `tauri:dev`/`tauri:build` scripts and CI use
+# `-f mining -f wallet`, and bare `cargo` invocations use
+# `--features mining,wallet`. rust-analyzer gets the features from
+# `.vscode/settings.json` so gated code isn't greyed out.
 #
 # `mining` gates the pocx mining/plotting/aggregator stack and every
 # mining/aggregator Tauri command. `wallet` gates the nodeless btcx_wallet
@@ -27,7 +38,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 # btcx_electrum_* command. `get_launch_mode` derives the Android mode from
 # whichever feature(s) are enabled (both → mobile, wallet → wallet-mobile,
 # mining → mining).
-default = ["mining", "wallet"]
+default = []
 mining = [
     "dep:pocx_miner",
     "dep:pocx_plotter_v2",

--- a/web-wallet/src-tauri/android-template/build.gradle.kts
+++ b/web-wallet/src-tauri/android-template/build.gradle.kts
@@ -17,16 +17,26 @@ plugins {
     id("rust")
 }
 
+// Per-flavor build identity is injected by CI via environment variables so a
+// single template produces the three Android flavors (hybrid / wallet / mining)
+// with distinct appIds. Fallbacks keep local `tauri android build` working:
+//   PHX_APP_ID       — applicationId + namespace (default: hybrid appId)
+//   PHX_VERSION_NAME — versionName, the release tag without a leading "v"
+//   PHX_VERSION_CODE — integer versionCode (see CI: MAJOR*10000+MINOR*100+PATCH)
+val phxAppId: String = System.getenv("PHX_APP_ID") ?: "org.pocx.phoenix"
+val phxVersionName: String = System.getenv("PHX_VERSION_NAME") ?: "1.0"
+val phxVersionCode: Int = (System.getenv("PHX_VERSION_CODE") ?: "1").toInt()
+
 android {
     compileSdk = 35
-    namespace = "org.pocx.phoenix"
+    namespace = phxAppId
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
-        applicationId = "org.pocx.phoenix"
+        applicationId = phxAppId
         minSdk = 24
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = phxVersionCode
+        versionName = phxVersionName
     }
 
     signingConfigs {

--- a/web-wallet/src-tauri/src/lib.rs
+++ b/web-wallet/src-tauri/src/lib.rs
@@ -10,16 +10,19 @@ use tauri::Manager;
 // Logging module
 mod logging;
 
-// Aggregator module
+// Aggregator module (part of the `mining` build flavor)
+#[cfg(feature = "mining")]
 pub mod aggregator;
 
-// Mining module
+// Mining module (gated by the `mining` build flavor)
+#[cfg(feature = "mining")]
 pub mod mining;
 
 // Node management module
 pub mod node;
 
-// Nodeless BTCX wallet module (btcx crates over Electrum)
+// Nodeless BTCX wallet module (btcx crates over Electrum; `wallet` flavor)
+#[cfg(feature = "wallet")]
 pub mod btcx_wallet;
 
 // Update checking module
@@ -279,19 +282,25 @@ fn is_dev() -> bool {
 /// --mobile is passed (dev-testing the FULL Android flavor: mining + the
 /// nodeless wallet), "wallet-mobile" if --wallet-only is passed (the
 /// wallet-only Android flavor), otherwise "wallet"
-/// Android: "mobile" (nodeless BTCX wallet + mining, no local node), or
-/// "wallet-mobile" when built with the `wallet-only` cargo feature (the
-/// wallet-only app flavor: nodeless BTCX wallet only, no mining either)
+/// Android: derived from the compiled build flavor (cargo features) —
+///   both `mining` + `wallet` → "mobile"   (Hybrid app: mining + nodeless wallet)
+///   only `wallet`           → "wallet-mobile" (Play Store wallet-only app)
+///   only `mining`           → "mining"    (sideload pure-miner app, external payout)
 #[tauri::command]
 fn get_launch_mode() -> String {
-    // Android is always nodeless: the wallet-only flavor is wallet-mobile,
-    // the full flavor is mobile (mining plus the nodeless wallet).
+    // Android is always nodeless. Which surfaces exist is decided at compile
+    // time: the wallet/mining code for the disabled feature isn't in the
+    // binary, so the mode must match what was actually built.
     #[cfg(target_os = "android")]
     {
-        #[cfg(feature = "wallet-only")]
-        return "wallet-mobile".to_string();
-        #[cfg(not(feature = "wallet-only"))]
+        #[cfg(all(feature = "mining", feature = "wallet"))]
         return "mobile".to_string();
+        #[cfg(all(feature = "wallet", not(feature = "mining")))]
+        return "wallet-mobile".to_string();
+        #[cfg(all(feature = "mining", not(feature = "wallet")))]
+        return "mining".to_string();
+        #[cfg(not(any(feature = "mining", feature = "wallet")))]
+        return "wallet".to_string();
     }
 
     #[cfg(not(target_os = "android"))]
@@ -346,12 +355,30 @@ fn get_debug_paths() -> DebugPaths {
         node_config: node::config::NodeConfig::config_path()
             .to_string_lossy()
             .to_string(),
-        mining_config: mining::state::get_config_file_path()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default(),
-        aggregator_config: aggregator::state::get_config_file_path()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default(),
+        mining_config: {
+            #[cfg(feature = "mining")]
+            {
+                mining::state::get_config_file_path()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            }
+            #[cfg(not(feature = "mining"))]
+            {
+                String::new()
+            }
+        },
+        aggregator_config: {
+            #[cfg(feature = "mining")]
+            {
+                aggregator::state::get_config_file_path()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            }
+            #[cfg(not(feature = "mining"))]
+            {
+                String::new()
+            }
+        },
         bitcoin_conf: node_config
             .bitcoin_conf_path()
             .to_string_lossy()
@@ -624,20 +651,20 @@ pub fn run() {
         eprintln!("Failed to initialize logger: {}. Log dir: {:?}", e, log_dir);
     }
 
-    // Create shared mining state
+    // Create shared mining + aggregator state (mining build flavor only)
+    #[cfg(feature = "mining")]
     let mining_state = mining::state::create_mining_state();
-
-    // Create shared plotter runtime (for task management)
+    #[cfg(feature = "mining")]
     let plotter_runtime = mining::create_plotter_runtime();
+    #[cfg(feature = "mining")]
+    let aggregator_state = aggregator::state::create_aggregator_state();
 
     // Create shared node state and manager
     let node_state = node::create_node_state();
     let node_manager = node::NodeManager::new();
 
-    // Create shared aggregator state
-    let aggregator_state = aggregator::state::create_aggregator_state();
-
-    // Create shared nodeless BTCX wallet state
+    // Create shared nodeless BTCX wallet state (wallet build flavor only)
+    #[cfg(feature = "wallet")]
     let btcx_wallet_state = btcx_wallet::create_btcx_wallet_state();
 
     let mut builder = tauri::Builder::default()
@@ -661,12 +688,25 @@ pub fn run() {
                 .add_migrations("sqlite:mining.db", include_migrations())
                 .build(),
         )
-        .manage(mining_state)
-        .manage(plotter_runtime)
         .manage(node_state)
-        .manage(node_manager)
-        .manage(aggregator_state)
-        .manage(btcx_wallet_state)
+        .manage(node_manager);
+
+    // Mining + aggregator state (mining build flavor only)
+    #[cfg(feature = "mining")]
+    {
+        builder = builder
+            .manage(mining_state)
+            .manage(plotter_runtime)
+            .manage(aggregator_state);
+    }
+
+    // Nodeless BTCX wallet state (wallet build flavor only)
+    #[cfg(feature = "wallet")]
+    {
+        builder = builder.manage(btcx_wallet_state);
+    }
+
+    builder = builder
         .setup(|app| {
             // Set app handle for TauriEventAppender (log forwarding to frontend)
             logging::set_app_handle(app.handle().clone());
@@ -678,16 +718,31 @@ pub fn run() {
                 app.set_menu(menu)?;
             }
 
-            // Register miner callback for mining events (with state for deadline persistence)
-            let state = app
-                .state::<mining::state::SharedMiningState>()
-                .inner()
-                .clone();
-            mining::callback::TauriMinerCallback::register(app.handle().clone(), state);
+            // Register miner + aggregator callbacks (mining build flavor only)
+            #[cfg(feature = "mining")]
+            {
+                // Register miner callback for mining events (with state for deadline persistence)
+                let state = app
+                    .state::<mining::state::SharedMiningState>()
+                    .inner()
+                    .clone();
+                mining::callback::TauriMinerCallback::register(app.handle().clone(), state);
+
+                // Register aggregator callback (OnceLock - must be done once at startup)
+                let agg_state = app
+                    .state::<aggregator::state::SharedAggregatorState>()
+                    .inner()
+                    .clone();
+                aggregator::callback::TauriAggregatorCallback::register(
+                    app.handle().clone(),
+                    agg_state,
+                );
+            }
 
             // Resume the nodeless BTCX wallet if it was set up (off the main
             // thread — opening dials nothing, but sqlite + seed I/O should
-            // never delay startup; failures only log).
+            // never delay startup; failures only log). Wallet flavor only.
+            #[cfg(feature = "wallet")]
             {
                 let state = app
                     .state::<btcx_wallet::SharedBtcxWalletState>()
@@ -709,16 +764,6 @@ pub fn run() {
                     }
                 });
             }
-
-            // Register aggregator callback (OnceLock - must be done once at startup)
-            let agg_state = app
-                .state::<aggregator::state::SharedAggregatorState>()
-                .inner()
-                .clone();
-            aggregator::callback::TauriAggregatorCallback::register(
-                app.handle().clone(),
-                agg_state,
-            );
 
             // Set window title based on launch mode (desktop only)
             #[cfg(not(target_os = "android"))]
@@ -893,114 +938,208 @@ pub fn run() {
             node::commands::wait_for_node_ready,
             node::commands::is_node_ready,
             node::commands::stop_node_gracefully,
+            // ===== Mining + aggregator commands (mining build flavor only) =====
+            // Each entry is `#[cfg(feature = "mining")]`-gated so the pure
+            // wallet-only flavor does not register (or reference) any mining
+            // command — the mining/aggregator modules aren't compiled there.
             // Mining device commands
+            #[cfg(feature = "mining")]
             mining::commands::detect_mining_devices,
             // Mining drive commands
+            #[cfg(feature = "mining")]
             mining::commands::list_plot_drives,
+            #[cfg(feature = "mining")]
             mining::commands::get_plot_drive_info,
+            #[cfg(feature = "mining")]
             mining::commands::delete_orphan_file,
             // Mining state commands
+            #[cfg(feature = "mining")]
             mining::commands::get_mining_state,
+            #[cfg(feature = "mining")]
             mining::commands::get_mining_config,
+            #[cfg(feature = "mining")]
             mining::commands::save_mining_config,
             // Chain configuration commands
+            #[cfg(feature = "mining")]
             mining::commands::add_chain_config,
+            #[cfg(feature = "mining")]
             mining::commands::update_chain_config,
+            #[cfg(feature = "mining")]
             mining::commands::remove_chain_config,
+            #[cfg(feature = "mining")]
             mining::commands::reorder_chain_priorities,
             // Drive configuration commands
+            #[cfg(feature = "mining")]
             mining::commands::add_drive_config,
+            #[cfg(feature = "mining")]
             mining::commands::update_drive_config,
+            #[cfg(feature = "mining")]
             mining::commands::remove_drive_config,
             // CPU configuration commands
+            #[cfg(feature = "mining")]
             mining::commands::update_cpu_config,
             // Plotter device commands
+            #[cfg(feature = "mining")]
             mining::commands::update_plotter_device,
             // Mining control commands
+            #[cfg(feature = "mining")]
             mining::commands::start_mining,
+            #[cfg(feature = "mining")]
             mining::commands::stop_mining,
             // Benchmark commands
+            #[cfg(feature = "mining")]
             mining::commands::run_device_benchmark,
             // Reset command
+            #[cfg(feature = "mining")]
             mining::commands::reset_mining_config,
             // Deadline commands
+            #[cfg(feature = "mining")]
             mining::commands::get_recent_deadlines,
             // Address validation commands
+            #[cfg(feature = "mining")]
             mining::commands::validate_pocx_address,
+            #[cfg(feature = "mining")]
             mining::commands::get_address_info,
+            #[cfg(feature = "mining")]
             mining::commands::hex_to_bech32,
             // Plotter state commands
+            #[cfg(feature = "mining")]
             mining::commands::get_plotter_state,
+            #[cfg(feature = "mining")]
             mining::commands::is_plotter_running,
+            #[cfg(feature = "mining")]
             mining::commands::get_stop_type,
             // Plot plan commands
+            #[cfg(feature = "mining")]
             mining::commands::get_plot_plan,
+            #[cfg(feature = "mining")]
             mining::commands::set_plot_plan,
+            #[cfg(feature = "mining")]
             mining::commands::clear_plot_plan,
+            #[cfg(feature = "mining")]
             mining::commands::start_plot_plan,
+            #[cfg(feature = "mining")]
             mining::commands::soft_stop_plot_plan,
+            #[cfg(feature = "mining")]
             mining::commands::hard_stop_plot_plan,
+            #[cfg(feature = "mining")]
             mining::commands::advance_plot_plan,
             // Plotter execution commands
+            #[cfg(feature = "mining")]
             mining::commands::execute_plot_item,
+            #[cfg(feature = "mining")]
             mining::commands::execute_plot_batch,
             // Aggregator commands
+            #[cfg(feature = "mining")]
             aggregator::commands::get_aggregator_config,
+            #[cfg(feature = "mining")]
             aggregator::commands::save_aggregator_config,
+            #[cfg(feature = "mining")]
             aggregator::commands::start_aggregator,
+            #[cfg(feature = "mining")]
             aggregator::commands::stop_aggregator,
+            #[cfg(feature = "mining")]
             aggregator::commands::is_aggregator_running,
+            #[cfg(feature = "mining")]
             aggregator::commands::get_aggregator_status,
+            #[cfg(feature = "mining")]
             aggregator::commands::get_aggregator_stats,
-            // Nodeless BTCX wallet commands - Status & Seed
+            // ===== Nodeless BTCX wallet commands (wallet build flavor only) =====
+            // Each entry is `#[cfg(feature = "wallet")]`-gated so the pure
+            // mining-only flavor does not register any wallet command — the
+            // btcx_wallet backend isn't compiled there.
+            // Status & Seed
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_status,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_generate_mnemonic,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_create,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_restore,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_reprobe,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_rescan_legacy,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_import_descriptor,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_validate_import,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_unlock,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_lock,
-            // Nodeless BTCX wallet commands - Named-wallet registry
+            // Named-wallet registry
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_list,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_list_grouped,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_group_sync,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_select,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_close,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_delete,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_delete_group,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_rename,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_rename_group,
-            // Nodeless BTCX wallet commands - Operations
+            // Operations
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_new_address,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_current_address,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_balance,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_transactions,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_send,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_bumpfee,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_fee_estimates,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_broadcast_tx,
-            // Nodeless BTCX wallet commands - Config & Sync
+            // Config & Sync
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_get_config,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_set_config,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_sync_now,
-            // Nodeless BTCX wallet commands - Forging assignments
+            // Forging assignments
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_create_assignment,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_revoke_assignment,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_get_assignment,
-            // Nodeless BTCX wallet commands - PSBT operations
+            // PSBT operations
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_psbt_decode,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_psbt_analyze,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_psbt_wallet_process,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_psbt_finalize,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_psbt_combine,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_create_funded_psbt,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_utxos,
-            // Nodeless BTCX wallet commands - Electrum health & chain info
+            // Electrum health & chain info
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_electrum_health,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_electrum_probe,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_chain_info,
             write_text_file,
             write_binary_file,

--- a/web-wallet/src/app/app.component.ts
+++ b/web-wallet/src/app/app.component.ts
@@ -239,7 +239,9 @@ export class AppComponent implements OnInit, OnDestroy {
         // Remote (Electrum) mode: no node to start — bring up the local
         // wallet stack instead (sync-event listeners + status/config), so
         // the event-driven chain/wallet state services get their signal.
-        if (this.nodeService.isRemote()) {
+        // Skipped in the Android mining-only flavor: the wallet backend
+        // isn't compiled there, so btcx_wallet_* commands are absent.
+        if (this.nodeService.isRemote() && this.appModeService.hasWalletBackend()) {
           await this.btcxWallet.initialize();
         }
       }
@@ -249,17 +251,22 @@ export class AppComponent implements OnInit, OnDestroy {
       this.isStartingNode.set(false);
     }
 
-    // Auto-start runs on every Tauri launch (desktop wallet, desktop
-    // mining-only, Android mining-only). Each service has its own guards
-    // — missing config, missing chains/drives, node-not-ready — so these
-    // calls no-op safely when preconditions aren't met.
-    this.aggregatorService
-      .autoStart()
-      .catch(err => console.error('Aggregator auto-start failed:', err));
+    // Auto-start runs on every Tauri launch that HAS the mining backend
+    // compiled in (desktop wallet, desktop mining-only, Android hybrid,
+    // Android mining-only). The Android wallet-only flavor has no mining
+    // commands, so these auto-starts are suppressed there — otherwise the
+    // service's first `refreshState()` / `loadConfig()` would invoke absent
+    // commands. Each service still has its own guards (missing config,
+    // no chains/drives, node-not-ready) so the calls no-op safely otherwise.
+    if (this.appModeService.hasMiningBackend()) {
+      this.aggregatorService
+        .autoStart()
+        .catch(err => console.error('Aggregator auto-start failed:', err));
 
-    this.miningService
-      .autoStartMining()
-      .catch(err => console.error('Mining auto-start failed:', err));
+      this.miningService
+        .autoStartMining()
+        .catch(err => console.error('Mining auto-start failed:', err));
+    }
 
     // Start periodic status refresh (every 30 seconds). Remote mode has no
     // local node process to watch — its connectivity rides the

--- a/web-wallet/src/app/bitcoin/services/blockchain-state.service.ts
+++ b/web-wallet/src/app/bitcoin/services/blockchain-state.service.ts
@@ -10,6 +10,7 @@ import { CookieAuthService } from '../../core/auth/cookie-auth.service';
 import { PocxNotificationService } from './pocx-notification.service';
 import { NodeService } from '../../node/services/node.service';
 import { BtcxWalletService } from '../../core/services/btcx-wallet.service';
+import { AppModeService } from '../../core/services/app-mode.service';
 import {
   BTCX_BLOCK_TIME_SECONDS,
   formatNetworkCapacityTib,
@@ -61,6 +62,7 @@ export class BlockchainStateService implements OnDestroy {
   private readonly notificationService = inject(PocxNotificationService);
   private readonly nodeService = inject(NodeService);
   private readonly btcxWallet = inject(BtcxWalletService);
+  private readonly appMode = inject(AppModeService);
   private readonly destroy$ = new Subject<void>();
 
   constructor() {
@@ -195,6 +197,13 @@ export class BlockchainStateService implements OnDestroy {
    */
   async refresh(): Promise<void> {
     const remote = this.nodeService.isRemote();
+    // Android mining-only flavor: remote is reported (nodeless), but the
+    // wallet backend that serves the Electrum chain tip isn't compiled in —
+    // there is no chain source here, so skip rather than call btcx_chain_info
+    // (an absent command). Mining gets base_target from the pool/miner backend.
+    if (remote && !this.appMode.hasWalletBackend()) {
+      return;
+    }
     // Core: skip if not authenticated (credentials not loaded yet).
     if (!remote && !this.cookieAuth.isAuthenticated) {
       return;

--- a/web-wallet/src/app/core/services/app-mode.service.ts
+++ b/web-wallet/src/app/core/services/app-mode.service.ts
@@ -47,6 +47,28 @@ export class AppModeService {
     () => this.isMobile() || this.isMobileMode() || this.isWalletOnly()
   );
 
+  /**
+   * Whether the nodeless BTCX wallet backend (Rust `wallet` cargo feature) is
+   * compiled into THIS build. False ONLY in the Android mining-only flavor —
+   * `get_launch_mode` returns "mining" on Android, so `isMiningOnly()` is true
+   * AND `isMobile()` is true. There the `btcx_wallet_*` / `btcx_electrum_*` /
+   * `btcx_chain_info` commands are absent and callers MUST NOT invoke them.
+   *
+   * Desktop `--mining-only` keeps the wallet compiled (the desktop binary is
+   * always the hybrid build and picks the layout at runtime), so it stays
+   * true there — no behavior change for desktop mining-only.
+   */
+  readonly hasWalletBackend = computed(() => !(this.isMiningOnly() && this.isMobile()));
+
+  /**
+   * Symmetric counterpart: whether the mining/plotting/aggregator backend
+   * (Rust `mining` cargo feature) is compiled in. False ONLY in the Android
+   * wallet-only flavor (`isWalletOnly()` + `isMobile()`), where every mining/
+   * aggregator command is absent. Desktop `--wallet-only` keeps mining
+   * compiled, so it stays true there.
+   */
+  readonly hasMiningBackend = computed(() => !(this.isWalletOnly() && this.isMobile()));
+
   /** Whether the mode has been initialized (internal guard) */
   private readonly _isInitialized = signal(false);
 

--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -480,6 +480,11 @@ interface ChainModalData {
           </div>
           <div class="section-content">
             <div class="radio-group">
+              <!-- "Use wallet address" is only meaningful when an in-app
+                   wallet exists. The Android mining-only flavor has no wallet
+                   backend, so this option is hidden and the custom (external)
+                   payout address below is the sole choice. -->
+              @if (appMode.hasWalletBackend()) {
               <label class="radio-option" [class.disabled]="useWalletAddressDisabled()">
                 <input
                   type="radio"
@@ -553,6 +558,7 @@ interface ChainModalData {
                   }
                 </div>
               </label>
+              }
               <label class="radio-option">
                 <input
                   type="radio"
@@ -3114,6 +3120,12 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
   }
 
   private async loadWalletAddress(): Promise<void> {
+    // Android mining-only flavor: there is NO in-app wallet (the wallet
+    // backend isn't compiled), so never source a wallet address here — the
+    // custom external plotting address is the only option. Guards against
+    // invoking absent btcx_wallet_* commands.
+    if (!this.appMode.hasWalletBackend()) return;
+
     // Mobile mode sources the address from the nodeless BTCX wallet instead
     // (initMobileWalletAddress); the Core-RPC wallet does not exist there.
     if (this.appMode.isMobileMode()) return;
@@ -3872,11 +3884,13 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
     };
 
     const walletName = this.walletManager.activeWallet;
-    if (this.nodeService.isRemote()) {
+    if (this.nodeService.isRemote() && this.appMode.hasWalletBackend()) {
       // Remote: "is mine" has no cheap analog (no getaddressinfo) — the
       // assignment state still comes from the client-side Electrum
       // derivation, which is what actually matters for plotting to a
-      // foreign address.
+      // foreign address. (Android mining-only has no wallet backend, so the
+      // assignment lookup is skipped there — the address is still validated
+      // locally above.)
       try {
         const assignmentStatus = (await this.btcxWallet.getAssignment(address)) as {
           has_assignment: boolean;


### PR DESCRIPTION
Stacked on **`feat/unify-seed-bip39`** (not master).

Builds three Android flavors from one codebase, each disabling one of two new **symmetric cargo features** (`mining`, `wallet`). Desktop stays one hybrid binary that picks its layout at runtime.

| Flavor | Build | appId | Contains |
|---|---|---|---|
| Hybrid (default) | `-f mining -f wallet` | `org.pocx.phoenix` (unchanged) | wallet + mining |
| Wallet-only (Play) | `-f wallet` | `org.pocx.phoenix.wallet` | wallet, **no mining compiled** |
| Mining-only (sideload) | `-f mining` | `org.pocx.phoenix.miner` | mining, **no wallet compiled** |

> **Update (robustness fix, commit `5546da3`):** `default` is now **empty** (`default = []`) and every build names its features explicitly. See the "Robustness fix" section below — this replaces the earlier `--no-default-features` passthrough approach, which never actually reached cargo.

## What changed

### P1 — Cargo features + cfg-gating (`Cargo.toml`, `lib.rs`)
- `mining` gates `pocx_miner`/`pocx_plotter_v2`/`pocx_address`/`pocx_aggregator`; `wallet` gates the btcx crates + `bdk_wallet`/`bitcoin`/`bech32`/`scrypt`/`chacha20poly1305`/`rand`. All made `optional`. `default = []` (was `["mining","wallet"]`). Old `wallet-only` marker feature removed.
- `lib.rs`: cfg-gated the `mining`/`aggregator`/`btcx_wallet` modules, their state creation + `.manage()` + setup callbacks + wallet resume thread, the `get_debug_paths` fields, and **every** mining/aggregator/btcx_wallet entry in `generate_handler!`.
- `get_launch_mode()` Android arm now derives from the compiled features: both→`mobile`, wallet→`wallet-mobile`, mining→`mining`. Desktop arm unchanged.

### P2 — Gradle per-flavor + CI 3-flavor matrix
- `android-template/build.gradle.kts`: `applicationId`/`namespace`, `versionCode`, `versionName` read `PHX_APP_ID` / `PHX_VERSION_CODE` / `PHX_VERSION_NAME` from env (fallbacks keep local `tauri android build` working). Also fixes the hardcoded `1.0`/`1` bug — `versionCode = MAJOR*10000+MINOR*100+PATCH`, `versionName` = tag.
- Both android workflows converted to `strategy.matrix.flavor: [hybrid, wallet, mining]`, each mapping flavor → `-f <feature>` args + appId + per-flavor asset name (`Phoenix-PoCX-${VERSION}-Android-<flavor>-ARM64.apk`, no `--clobber` collisions). Only `wallet` is the Play candidate (commented); all three upload to the release. Signing preserved per flavor.
  - Feature selection is `-f mining -f wallet` (hybrid), `-f wallet`, `-f mining` — no `--no-default-features` anywhere (see "Robustness fix").

### P3 — Desktop mining-only shortcut
- Already present on the base branch (`nsis/hooks.nsi` + `bundle.windows.nsis.installerHooks`): a "Phoenix PoCX Miner" Start-Menu (and Desktop) shortcut launching `--mining-only`. No change needed.

### P4 — Frontend mining-only mobile UX + symmetric command suppression
- `AppModeService.hasWalletBackend` / `hasMiningBackend` computeds — false **only** in the matching Android single-feature flavor (`isMiningOnly()&&isMobile()` / `isWalletOnly()&&isMobile()`); desktop `--mining-only`/`--wallet-only` keep both compiled, so they're unaffected.
- Suppressed absent-command calls: `app.component` gates the btcx wallet resume and the mining/aggregator auto-starts; `BlockchainStateService` skips the remote `btcx_chain_info` refresh; the mining setup wizard skips wallet-address sourcing + assignment lookup and **hides the "use wallet address" option**, leaving the external **payout-address field** as the sole choice in mining-only. Mining-only mobile reuses the existing `/miner` surface (MiningLayoutComponent, no wallet nav).

## Robustness fix (commit `5546da3`)

The original per-flavor build args were `tauri android build -f wallet -- --no-default-features` on top of `default = ["mining","wallet"]`. That does **not** work: `tauri android build` has **no** native `--no-default-features` flag, and its `-- <args>` are forwarded to the **Gradle runner, not cargo**. So `--no-default-features` never reached cargo — and because `-f` is only *additive*, every flavor would have compiled **both** stacks. The wallet-only (Play Store) APK would have shipped **with mining**, and mining-only **with the wallet** — silently defeating the whole feature-gating (a wrong-flavor build, not a build failure, so CI wouldn't have caught it).

Fix: set **`default = []`** and name features explicitly everywhere. Under plain cargo semantics `-f wallet` then yields **exactly** `[wallet]` — no passthrough needed, and the additive `-f` is now correct instead of a foot-gun. Consequently every non-Android build that relied on the old default now passes features:
- `package.json` `tauri:dev`/`tauri:build` → `-f mining -f wallet`
- `desktop-build-test.yml` / `release.yml` `tauri build` steps → `-f mining -f wallet`
- `ci.yml` `cargo check`/`clippy` → `--features mining,wallet`, **plus** two new checks (`--features wallet`, `--features mining`) so each flavor is proven to compile on its own and gating can't silently regress
- `.vscode/settings.json`: `rust-analyzer.cargo.features = ["mining","wallet"]` so gated code isn't greyed out now that the default is empty

## Verification (actually run on this machine)

Robustness fix (`web-wallet/src-tauri`, all reach **Finished**):
- `cargo check --features mining,wallet` (hybrid) → **Finished** ✓
- `cargo check --features wallet` → **Finished** ✓ — `cargo tree` confirms **no `pocx_*` crates** in the graph (bdk/btcx present)
- `cargo check --features mining` → **Finished** ✓ — `cargo tree` confirms **no bdk/btcx crates** in the graph (`pocx_*` present)
- `cargo check` (bare, no features) → **Finished** ✓ — the node-only core compiles on its own
- `cargo build --bin phoenix-pocx-miner` → **Finished** ✓ — the macOS miner launcher builds with **no features** (standalone; only `std` + `dirs`)

Frontend (unaffected by the fix):
- `npx tsc -p tsconfig.app.json --noEmit` → exit 0, clean ✓
- `npm run lint` → "All files pass linting" ✓
- `npm run build` (AOT, what CI runs) → bundle generation complete, exit 0 ✓ (only pre-existing NG8102 + CSS-budget warnings)

## NOT verified (needs CI / device)
- No real Android build / APK produced — `tauri android init` needs an Android SDK/NDK not present here. The 3-flavor matrix, per-flavor gradle env injection, and signing are code-reviewed only. `-f <feature>` reaching cargo through `tauri android build` is standard/expected behaviour, but should be confirmed on the first real CI run of the android workflows. With `default = []` there is no longer any passthrough foot-gun: `-f wallet`/`-f mining` are ordinary cargo feature selection.
- No device test, no Play submission.

## Deferred / for review
- In Android mining-only, the wizard can't show forging-assignment status for a typed plotting address (that lookup needs the wallet's Electrum derivation, which isn't compiled). Address is still validated locally; assignment status is simply omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
