### PR TITLE
fix(android): unbreak wallet/mining flavor builds + per-flavor data dir

### DIFF
--- a/web-wallet/src-tauri/android-template/build.gradle.kts
+++ b/web-wallet/src-tauri/android-template/build.gradle.kts
@@ -20,16 +20,26 @@ plugins {
 // Per-flavor build identity is injected by CI via environment variables so a
 // single template produces the three Android flavors (hybrid / wallet / mining)
 // with distinct appIds. Fallbacks keep local `tauri android build` working:
-//   PHX_APP_ID       — applicationId + namespace (default: hybrid appId)
+//   PHX_APP_ID       — applicationId ONLY (default: hybrid appId)
 //   PHX_VERSION_NAME — versionName, the release tag without a leading "v"
 //   PHX_VERSION_CODE — integer versionCode (see CI: MAJOR*10000+MINOR*100+PATCH)
+//
+// The `namespace` must NOT vary per flavor: Tauri generates its Kotlin glue
+// (Logger.kt, the main activity) into the `org.pocx.phoenix` package (the
+// tauri.conf.json identifier / WRY_ANDROID_PACKAGE) and references BuildConfig
+// unqualified. BuildConfig is emitted into the `namespace` package, so moving
+// the namespace to a flavor appId (e.g. org.pocx.phoenix.wallet) leaves those
+// generated files unable to resolve BuildConfig. Keep namespace fixed and vary
+// only applicationId — the standard Android "same code, distinct appId" pattern.
 val phxAppId: String = System.getenv("PHX_APP_ID") ?: "org.pocx.phoenix"
 val phxVersionName: String = System.getenv("PHX_VERSION_NAME") ?: "1.0"
 val phxVersionCode: Int = (System.getenv("PHX_VERSION_CODE") ?: "1").toInt()
 
 android {
     compileSdk = 35
-    namespace = phxAppId
+    // Fixed — matches the tauri.conf.json identifier where Tauri's generated
+    // Kotlin + BuildConfig live. Per-flavor identity is applicationId only.
+    namespace = "org.pocx.phoenix"
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = phxAppId

--- a/web-wallet/src-tauri/build.rs
+++ b/web-wallet/src-tauri/build.rs
@@ -8,6 +8,10 @@ fn main() {
     // fixes both worlds: tests load (the import resolves lazily and task
     // dialogs are never shown in tests), and the app resolves v6 at call
     // time through its activation context exactly as before.
+    // The Android data dir is baked in from PHX_APP_ID at compile time (see
+    // app_data_dir): rebuild when the flavor's appId changes.
+    println!("cargo:rerun-if-env-changed=PHX_APP_ID");
+
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
     if target_os == "windows" && target_env == "msvc" {

--- a/web-wallet/src-tauri/src/lib.rs
+++ b/web-wallet/src-tauri/src/lib.rs
@@ -131,7 +131,15 @@ pub fn app_data_dir() -> PathBuf {
 
     #[cfg(target_os = "android")]
     {
-        PathBuf::from("/data/data/org.pocx.phoenix/files")
+        // The installed applicationId varies per build flavor (hybrid
+        // org.pocx.phoenix, wallet-only org.pocx.phoenix.wallet, mining-only
+        // org.pocx.phoenix.miner). Android sandboxes each app to
+        // /data/data/<applicationId>/files and blocks cross-app access, so the
+        // data dir MUST track the real appId — a fixed org.pocx.phoenix path
+        // would be unreadable from the .wallet / .miner flavors. CI injects the
+        // appId as PHX_APP_ID (inherited by the cargo build); default = hybrid.
+        let package = option_env!("PHX_APP_ID").unwrap_or("org.pocx.phoenix");
+        PathBuf::from(format!("/data/data/{package}/files"))
     }
 
     #[cfg(not(any(


### PR DESCRIPTION
## Problem
The new 3-flavor Android build (#169) failed for **wallet-only** and **mining-only**:
```
e: .../generated/Logger.kt:86:14 Unresolved reference: BuildConfig
```
The gradle template set `namespace = PHX_APP_ID` per flavor. But Tauri generates its Kotlin glue (Logger.kt, main activity) into the `org.pocx.phoenix` package (the `tauri.conf.json` identifier / `WRY_ANDROID_PACKAGE`) and references `BuildConfig` **unqualified**. `BuildConfig` is emitted into the `namespace` package, so a flavored namespace leaves it unresolvable. Hybrid passed only because its namespace happened to stay `org.pocx.phoenix`.

## Fix
- **Gradle:** keep `namespace` fixed at `org.pocx.phoenix`; vary only `applicationId` (standard Android same-code / distinct-appId pattern).
- **Runtime data dir:** was hardcoded to `/data/data/org.pocx.phoenix/files`, which the sandboxed `.wallet` / `.miner` flavors can't access (cross-app `/data/data` is blocked). Now derived from the real appId via `option_env!("PHX_APP_ID")` (CI already injects it; default = hybrid), with a `build.rs` `rerun-if-env-changed`. Each flavor gets isolated storage — required for side-by-side install.

## Verification
- `cargo check --features mining,wallet` → Finished. (The Android cfg block is trivial; the real proof is the re-run of the android build workflow, which this PR unblocks.)
- Not verified locally: the actual APK build (no Android SDK here) — re-running `android-build-test` after merge is the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)