### PR TITLE
feat(wallet-only): hide + guard the forging-assignment feature

### DIFF
--- a/web-wallet/src/app/app.routes.ts
+++ b/web-wallet/src/app/app.routes.ts
@@ -151,8 +151,11 @@ export const routes: Routes = [
         loadChildren: () =>
           import('./features/contacts/contacts.routes').then(m => m.CONTACTS_ROUTES),
       },
+      // Wallet-only mode is "transactions only" — forging assignments are
+      // hidden and the route is blocked (deep-link defense in depth).
       {
         path: 'forging-assignment',
+        canActivate: [notWalletOnlyGuard],
         loadChildren: () =>
           import('./features/forging-assignment/forging-assignment.routes').then(
             m => m.FORGING_ASSIGNMENT_ROUTES

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -20,6 +20,7 @@ import {
   BtcxChainInfo,
 } from '../../../core/services/btcx-wallet.service';
 import { ElectrumStatusService } from '../../../core/services/electrum-status.service';
+import { AppModeService } from '../../../core/services/app-mode.service';
 import { BtcxPipe, TimeAgoPipe } from '../../../shared/pipes';
 import { NotificationService } from '../../../shared/services';
 import {
@@ -138,7 +139,7 @@ interface NavGroup {
             </a>
           </mat-nav-list>
 
-          @for (group of navGroups; track group.id) {
+          @for (group of navGroups(); track group.id) {
             <div class="nav-group">
               <div class="nav-group-title">{{ group.titleKey | i18n }}</div>
               <mat-nav-list class="nav-section">
@@ -1189,6 +1190,7 @@ export class MobileWalletLayoutComponent implements OnInit {
   readonly i18n = inject(I18nService);
   readonly wallet = inject(BtcxWalletService);
   readonly electrumStatus = inject(ElectrumStatusService);
+  private readonly appMode = inject(AppModeService);
   private readonly notification = inject(NotificationService);
   private readonly router = inject(Router);
   private readonly dialog = inject(MatDialog);
@@ -1201,24 +1203,34 @@ export class MobileWalletLayoutComponent implements OnInit {
    * desktop's transactions group minus the Core-only PSBT builder) and
    * mining (forging assignment only — the Mining section itself lives in
    * the bottom navigation, so the drawer does not repeat it).
+   *
+   * Wallet-only mode is "transactions only": the mining group (forging
+   * assignment) is omitted entirely there.
    */
-  readonly navGroups: NavGroup[] = [
-    {
-      id: 'transactions',
-      titleKey: 'transactions',
-      items: [
-        { path: '/wallet/history', icon: 'compare_arrows', labelKey: 'transactions' },
-        { path: '/wallet/send', icon: 'send', labelKey: 'send', needsWallet: true },
-        { path: '/wallet/receive', icon: 'call_received', labelKey: 'receive', needsWallet: true },
-        { path: '/wallet/contacts', icon: 'contacts', labelKey: 'contacts' },
-      ],
-    },
-    {
-      id: 'mining',
-      titleKey: 'mining',
-      items: [{ path: '/wallet/assignment', icon: 'swap_horiz', labelKey: 'forging_assignment' }],
-    },
-  ];
+  readonly navGroups = computed<NavGroup[]>(() => {
+    const groups: NavGroup[] = [
+      {
+        id: 'transactions',
+        titleKey: 'transactions',
+        items: [
+          { path: '/wallet/history', icon: 'compare_arrows', labelKey: 'transactions' },
+          { path: '/wallet/send', icon: 'send', labelKey: 'send', needsWallet: true },
+          { path: '/wallet/receive', icon: 'call_received', labelKey: 'receive', needsWallet: true },
+          { path: '/wallet/contacts', icon: 'contacts', labelKey: 'contacts' },
+        ],
+      },
+    ];
+
+    if (!this.appMode.isWalletOnly()) {
+      groups.push({
+        id: 'mining',
+        titleKey: 'mining',
+        items: [{ path: '/wallet/assignment', icon: 'swap_horiz', labelKey: 'forging_assignment' }],
+      });
+    }
+
+    return groups;
+  });
 
   /** Name of the wallet a switch is in flight for, or null. */
   readonly switching = signal<string | null>(null);

--- a/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
+++ b/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { notWalletOnlyGuard } from '../../core/guards';
 
 /**
  * Mobile wallet routes (mobile mode only, guarded by mobileWalletGuard).
@@ -54,8 +55,11 @@ export const MOBILE_WALLET_ROUTES: Routes = [
         loadComponent: () =>
           import('./pages/coins/wallet-coins.component').then(m => m.WalletCoinsComponent),
       },
+      // Wallet-only mode is "transactions only" — forging assignments are
+      // hidden and the route is blocked (deep-link defense in depth).
       {
         path: 'assignment',
+        canActivate: [notWalletOnlyGuard],
         loadComponent: () =>
           import('./pages/assignment/wallet-assignment.component').then(
             m => m.WalletAssignmentComponent

--- a/web-wallet/src/app/layout/main-layout/main-layout.component.ts
+++ b/web-wallet/src/app/layout/main-layout/main-layout.component.ts
@@ -17,6 +17,7 @@ import { WalletService } from '../../bitcoin/services/wallet/wallet.service';
 import { ToolbarComponent } from '../toolbar/toolbar.component';
 import { AggregatorService } from '../../aggregator/services/aggregator.service';
 import { AppUpdateService } from '../../core/services/app-update.service';
+import { AppModeService } from '../../core/services/app-mode.service';
 import { NodeService } from '../../node/services/node.service';
 
 interface NavItem {
@@ -446,6 +447,7 @@ export class MainLayoutComponent implements OnInit, OnDestroy {
   private readonly walletService = inject(WalletService);
   private readonly aggregatorService = inject(AggregatorService);
   private readonly appUpdateService = inject(AppUpdateService);
+  private readonly appMode = inject(AppModeService);
   private readonly dialog = inject(MatDialog);
   private readonly store = inject(Store);
   private readonly destroy$ = new Subject<void>();
@@ -475,11 +477,14 @@ export class MainLayoutComponent implements OnInit, OnDestroy {
       miningItems.push({ path: '/aggregator', icon: 'hub', labelKey: 'aggregator' });
     }
 
-    miningItems.push({
-      path: '/forging-assignment',
-      icon: 'swap_horiz',
-      labelKey: 'forging_assignment',
-    });
+    // Wallet-only mode is "transactions only" — no forging assignments.
+    if (!this.appMode.isWalletOnly()) {
+      miningItems.push({
+        path: '/forging-assignment',
+        icon: 'swap_horiz',
+        labelKey: 'forging_assignment',
+      });
+    }
 
     const transactionItems: NavItem[] = [
       { path: '/transactions', icon: 'compare_arrows', labelKey: 'transactions' },


### PR DESCRIPTION
## What & why

In **wallet-only mode**, the forging-assignment feature is now completely inaccessible — **wallet-only = transactions only**. There is no value in managing forging assignments from a mobile-style wallet flavor, and surfacing a half-relevant "forging" entry there just causes confusion.

This is a **frontend mode gate** keyed on `AppModeService.isWalletOnly()` (true for the Android `wallet-mobile` flavor and the desktop `--wallet-only` sim). Gating on the **mode** rather than the compiled backend is deliberate: it also hides forging in the desktop `--wallet-only` simulator, so the sim keeps mirroring the real mobile wallet-only app.

**Rust is untouched.** The assignment commands remain `#[cfg(feature="wallet")]` — the hybrid desktop build still needs them, so nothing was recompiled out and no cargo feature was added.

## Nav entry points hidden (`@if (!isWalletOnly())` / conditional build)

- `layout/main-layout/main-layout.component.ts` — the mining nav group no longer pushes the `/forging-assignment` item.
- `features/mobile-wallet/layout/mobile-wallet-layout.component.ts` — `navGroups` is now a `computed` that omits the whole `mining` group (its only item was `/wallet/assignment`) in wallet-only mode.

## Routes guarded (deep-link defense in depth)

Both forging routes now `canActivate: [notWalletOnlyGuard]` — the existing guard that redirects to `/wallet` when `isWalletOnly()`, so a direct URL / deep link can't reach forging:

- desktop `/forging-assignment` (`app.routes.ts`)
- mobile `/wallet/assignment` (`mobile-wallet.routes.ts`)

I reused the pre-existing `notWalletOnlyGuard` (same `notRemoteGuard` shape, already redirects to `/wallet`) rather than adding a duplicate guard.

Incidental `assignment` mentions were left alone: the transaction-type label `tx.pocx_type === 'assignment'` in the dashboard, the `/forging` entry in the toolbar's wallet-switch `routesThatStay` list (not a nav entry, and doesn't even match `/forging-assignment`), and a stale doc-comment in `wallet-home` — none are navigation/entry points.

## Verification

- `npx tsc -p tsconfig.app.json --noEmit` — clean (no output)
- `npm run lint` — "All files pass linting."

🤖 Generated with [Claude Code](https://claude.com/claude-code)