### PR TITLE
Mobile polish: BIP39 field placement, language menu position, per-flavor Android labels

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -12,15 +12,20 @@ jobs:
       matrix:
         # Same 3-flavor matrix as the release workflow (see android-release.yml
         # for the rationale). This test build produces one artifact per flavor.
+        # app_name is the Android launcher label, patched into strings.xml per
+        # flavor (see android-release.yml). Desktop keeps "Phoenix Wallet".
         include:
           - flavor: hybrid
             app_id: org.pocx.phoenix
+            app_name: "Phoenix Suite"
             build_args: "-f mining -f wallet"
           - flavor: wallet   # Play Store candidate — NO mining compiled in
             app_id: org.pocx.phoenix.wallet
+            app_name: "Phoenix Wallet"
             build_args: "-f wallet"
           - flavor: mining   # sideload pure miner — NO wallet compiled in
             app_id: org.pocx.phoenix.miner
+            app_name: "Phoenix Miner"
             build_args: "-f mining"
     steps:
       - uses: actions/checkout@v4
@@ -148,10 +153,30 @@ jobs:
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           EOF
 
+      - name: Set Android launcher label — ${{ matrix.flavor }}
+        env:
+          PHX_APP_NAME: ${{ matrix.app_name }}
+        run: |
+          # Patch the generated strings.xml so the launcher label (the manifest
+          # uses android:label="@string/app_name") matches the flavor. Runs
+          # after `tauri android init` (which generates strings.xml) and the
+          # build.gradle.kts template copy. Guarded: fail loudly if the file or
+          # the app_name line is missing, so we notice rather than silently
+          # shipping the wrong label.
+          STRINGS="web-wallet/src-tauri/gen/android/app/src/main/res/values/strings.xml"
+          test -f "$STRINGS" || { echo "ERROR: $STRINGS not found (did tauri android init run?)"; exit 1; }
+          grep -q '<string name="app_name">' "$STRINGS" || { echo "ERROR: app_name string not found in $STRINGS"; exit 1; }
+          sed -i "s#<string name=\"app_name\">[^<]*</string>#<string name=\"app_name\">${PHX_APP_NAME}</string>#" "$STRINGS"
+          echo "Set launcher label to: ${PHX_APP_NAME}"
+          grep '<string name="app_name">' "$STRINGS"
+          # Re-assert the new label actually landed.
+          grep -q "<string name=\"app_name\">${PHX_APP_NAME}</string>" "$STRINGS" || { echo "ERROR: app_name patch did not apply"; exit 1; }
+
       - name: Build Android APK (ARM64 only) — ${{ matrix.flavor }}
         working-directory: web-wallet
         env:
           PHX_APP_ID: ${{ matrix.app_id }}
+          PHX_APP_NAME: ${{ matrix.app_name }}
           PHX_VERSION_NAME: ${{ steps.version.outputs.name }}
           PHX_VERSION_CODE: ${{ steps.version.outputs.code }}
         run: npx tauri android build --target aarch64 ${{ matrix.build_args }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -25,15 +25,21 @@ jobs:
         # EXACTLY `[wallet]` — no `--no-default-features` needed (and there is
         # no such flag on `tauri android build`; its `-- <args>` go to Gradle,
         # not cargo). Hybrid names both features explicitly.
+        # app_name is the Android launcher label, patched into strings.xml
+        # per flavor so the three installs are distinguishable on the home
+        # screen. Desktop keeps "Phoenix Wallet" (tauri.conf.json productName).
         include:
           - flavor: hybrid
             app_id: org.pocx.phoenix
+            app_name: "Phoenix Suite"
             build_args: "-f mining -f wallet"
           - flavor: wallet   # Play Store candidate — NO mining compiled in
             app_id: org.pocx.phoenix.wallet
+            app_name: "Phoenix Wallet"
             build_args: "-f wallet"
           - flavor: mining   # sideload pure miner — NO wallet compiled in
             app_id: org.pocx.phoenix.miner
+            app_name: "Phoenix Miner"
             build_args: "-f mining"
     steps:
       - uses: actions/checkout@v4
@@ -175,10 +181,30 @@ jobs:
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           EOF
 
+      - name: Set Android launcher label — ${{ matrix.flavor }}
+        env:
+          PHX_APP_NAME: ${{ matrix.app_name }}
+        run: |
+          # Patch the generated strings.xml so the launcher label (the manifest
+          # uses android:label="@string/app_name") matches the flavor. Runs
+          # after `tauri android init` (which generates strings.xml) and the
+          # build.gradle.kts template copy. Guarded: fail loudly if the file or
+          # the app_name line is missing, so we notice rather than silently
+          # shipping the wrong label.
+          STRINGS="web-wallet/src-tauri/gen/android/app/src/main/res/values/strings.xml"
+          test -f "$STRINGS" || { echo "ERROR: $STRINGS not found (did tauri android init run?)"; exit 1; }
+          grep -q '<string name="app_name">' "$STRINGS" || { echo "ERROR: app_name string not found in $STRINGS"; exit 1; }
+          sed -i "s#<string name=\"app_name\">[^<]*</string>#<string name=\"app_name\">${PHX_APP_NAME}</string>#" "$STRINGS"
+          echo "Set launcher label to: ${PHX_APP_NAME}"
+          grep '<string name="app_name">' "$STRINGS"
+          # Re-assert the new label actually landed.
+          grep -q "<string name=\"app_name\">${PHX_APP_NAME}</string>" "$STRINGS" || { echo "ERROR: app_name patch did not apply"; exit 1; }
+
       - name: Build Android APK (ARM64 only) — ${{ matrix.flavor }}
         working-directory: web-wallet
         env:
           PHX_APP_ID: ${{ matrix.app_id }}
+          PHX_APP_NAME: ${{ matrix.app_name }}
           PHX_VERSION_NAME: ${{ steps.version.outputs.name }}
           PHX_VERSION_CODE: ${{ steps.version.outputs.code }}
         run: npx tauri android build --target aarch64 ${{ matrix.build_args }}

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -448,7 +448,16 @@ interface NavGroup {
                 <mat-icon class="lang-icon secondary-text">language</mat-icon>
               </button>
 
-              <mat-menu #langMenu="matMenu">
+              <!-- lang-menu-panel caps the panel height so the ~26-locale
+                   list always fits in the space below the trigger and scrolls
+                   internally, instead of the CDK overlay pushing it up to the
+                   top of the viewport (under the status bar / notch). -->
+              <mat-menu
+                #langMenu="matMenu"
+                class="lang-menu-panel"
+                yPosition="below"
+                [overlapTrigger]="false"
+              >
                 @for (lang of languages; track lang.code) {
                   <button mat-menu-item (click)="setLanguage(lang)">
                     {{ lang.nativeName }}
@@ -1182,6 +1191,14 @@ interface NavGroup {
             color: rgba(255, 255, 255, 0.45);
           }
         }
+      }
+
+      /* Cap the language menu so its ~26 items fit below the toolbar trigger
+         and scroll internally, keeping the panel anchored under the button
+         rather than pushed up under the Android status bar / notch. */
+      ::ng-deep .lang-menu-panel {
+        max-height: 60vh;
+        overflow-y: auto;
       }
     `,
   ],

--- a/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/create/wallet-create.component.ts
@@ -109,6 +109,40 @@ type CreateStep = 'name' | 'phrase' | 'verify' | 'protect';
             </div>
           }
 
+          <!-- BIP39 25th word — belongs right after the recovery phrase.
+               SEPARATE from the at-rest encryption passphrase (asked later on
+               the protect step). Folded into the derivation: with it set, the
+               recovery phrase alone will NOT restore the funds. -->
+          <mat-checkbox [(ngModel)]="useBip39" class="bip39-toggle">
+            {{ 'mwallet_bip39_toggle' | i18n }}
+          </mat-checkbox>
+
+          @if (useBip39) {
+            <p class="warning-text">
+              <mat-icon class="warning-icon">warning</mat-icon>
+              {{ 'mwallet_bip39_warning' | i18n }}
+            </p>
+
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>{{ 'mwallet_bip39_label' | i18n }}</mat-label>
+              <input matInput type="password" [(ngModel)]="bip39Passphrase" autocomplete="off" />
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>{{ 'mwallet_bip39_confirm' | i18n }}</mat-label>
+              <input
+                matInput
+                type="password"
+                [(ngModel)]="bip39PassphraseConfirm"
+                autocomplete="off"
+              />
+            </mat-form-field>
+
+            @if (bip39PassphraseConfirm && bip39Passphrase !== bip39PassphraseConfirm) {
+              <p class="error-text">{{ 'mwallet_passphrase_mismatch' | i18n }}</p>
+            }
+          }
+
           <mat-checkbox [(ngModel)]="acknowledged">
             {{ 'mwallet_backup_ack' | i18n }}
           </mat-checkbox>
@@ -120,7 +154,11 @@ type CreateStep = 'name' | 'phrase' | 'verify' | 'protect';
             <button
               mat-raised-button
               color="primary"
-              [disabled]="!acknowledged || words().length === 0"
+              [disabled]="
+                !acknowledged ||
+                words().length === 0 ||
+                (useBip39 && bip39Passphrase !== bip39PassphraseConfirm)
+              "
               (click)="startVerify()"
             >
               {{ 'next' | i18n }}
@@ -194,39 +232,6 @@ type CreateStep = 'name' | 'phrase' | 'verify' | 'protect';
             </mat-form-field>
 
             @if (passphraseConfirm && passphrase !== passphraseConfirm) {
-              <p class="error-text">{{ 'mwallet_passphrase_mismatch' | i18n }}</p>
-            }
-          }
-
-          <!-- BIP39 25th word — SEPARATE from the at-rest passphrase above.
-               Folded into the derivation: with it set, the recovery phrase
-               alone will NOT restore the funds. -->
-          <mat-checkbox [(ngModel)]="useBip39" class="bip39-toggle">
-            {{ 'mwallet_bip39_toggle' | i18n }}
-          </mat-checkbox>
-
-          @if (useBip39) {
-            <p class="warning-text">
-              <mat-icon class="warning-icon">warning</mat-icon>
-              {{ 'mwallet_bip39_warning' | i18n }}
-            </p>
-
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'mwallet_bip39_label' | i18n }}</mat-label>
-              <input matInput type="password" [(ngModel)]="bip39Passphrase" autocomplete="off" />
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'mwallet_bip39_confirm' | i18n }}</mat-label>
-              <input
-                matInput
-                type="password"
-                [(ngModel)]="bip39PassphraseConfirm"
-                autocomplete="off"
-              />
-            </mat-form-field>
-
-            @if (bip39PassphraseConfirm && bip39Passphrase !== bip39PassphraseConfirm) {
               <p class="error-text">{{ 'mwallet_passphrase_mismatch' | i18n }}</p>
             }
           }

--- a/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/restore/wallet-restore.component.ts
@@ -145,15 +145,10 @@ import { WalletNameSectionComponent } from '../../components/wallet-name-section
               (changed)="onMnemonicChanged($event)"
             ></app-mnemonic-entry>
 
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'mwallet_passphrase_optional' | i18n }}</mat-label>
-              <input matInput type="password" [(ngModel)]="passphrase" autocomplete="off" />
-            </mat-form-field>
-            <p class="hint-text small">{{ 'mwallet_passphrase_hint' | i18n }}</p>
-
-            <!-- BIP39 25th word — SEPARATE from the at-rest passphrase above.
-                 It must match what the seed was created with, or the probe
-                 finds no history. -->
+            <!-- BIP39 25th word — belongs right after the recovery phrase, so
+                 it reads as part of the phrase (matching the create flow).
+                 SEPARATE from the at-rest passphrase below. It must match what
+                 the seed was created with, or the probe finds no history. -->
             <mat-checkbox [(ngModel)]="useBip39" [disabled]="restoring()" class="bip39-toggle">
               {{ 'mwallet_bip39_toggle' | i18n }}
             </mat-checkbox>
@@ -168,6 +163,12 @@ import { WalletNameSectionComponent } from '../../components/wallet-name-section
                 <input matInput type="password" [(ngModel)]="bip39Passphrase" autocomplete="off" />
               </mat-form-field>
             }
+
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>{{ 'mwallet_passphrase_optional' | i18n }}</mat-label>
+              <input matInput type="password" [(ngModel)]="passphrase" autocomplete="off" />
+            </mat-form-field>
+            <p class="hint-text small">{{ 'mwallet_passphrase_hint' | i18n }}</p>
 
             <p class="hint-text small">{{ 'mwallet_restore_probe_note' | i18n }}</p>
 

--- a/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
+++ b/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
@@ -103,7 +103,16 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
               <mat-icon class="lang-icon secondary-text">language</mat-icon>
             </button>
 
-            <mat-menu #langMenu="matMenu">
+            <!-- lang-menu-panel caps the panel height so the ~26-locale list
+                 always fits below the trigger and scrolls internally, instead
+                 of the CDK overlay pushing it up to the top of the viewport
+                 (under the status bar / notch) in the mobile mining flavor. -->
+            <mat-menu
+              #langMenu="matMenu"
+              class="lang-menu-panel"
+              yPosition="below"
+              [overlapTrigger]="false"
+            >
               @for (lang of languages; track lang.code) {
                 <button mat-menu-item (click)="setLanguage(lang)">
                   {{ lang.nativeName }}
@@ -325,6 +334,14 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
         .status-indicators {
           height: 56px;
         }
+      }
+
+      /* Cap the language menu so its ~26 items fit below the toolbar trigger
+         and scroll internally, keeping the panel anchored under the button
+         rather than pushed up under the Android status bar / notch. */
+      ::ng-deep .lang-menu-panel {
+        max-height: 60vh;
+        overflow-y: auto;
       }
     `,
   ],


### PR DESCRIPTION
Three mobile/Android polish fixes.

## 1. BIP39 25th-word field placement (create + restore)
Moves the optional BIP39 passphrase (25th word) field so it sits **directly under the recovery phrase**, reading as part of the phrase rather than as an at-rest passphrase.

- **Create** (`wallet-create.component.ts`): field moved from the `protect` step up into the `phrase` step, right under the 24-word grid, with a confirm/mismatch guard on that step's Next button (pre-existing working-tree edits, carried in this commit).
- **Restore** (`wallet-restore.component.ts`): field moved from **after** the at-rest passphrase to **immediately after** `<app-mnemonic-entry>` and **before** the at-rest passphrase field. Kept separate from the at-rest passphrase (distinct state). Restore has no confirm field by design — a wrong word simply finds no Electrum history — so only the warning validation applies; the restore button's disabled condition was already independent of BIP39.

## 2. Mobile language menu opens below the trigger
The ~26-locale `mat-menu` was taller than the space below the toolbar trigger, so the CDK overlay pushed the panel up to the top of the viewport (under the status bar / notch).

Fix: cap the panel with `class="lang-menu-panel"` (`max-height: 60vh; overflow-y: auto;`) so it fits in the space below the trigger and scrolls internally, plus `yPosition="below"` and `[overlapTrigger]="false"`. With the trigger in the top toolbar there is ~full-viewport space below it, so a 60vh panel fits and the CDK's preferred "below" position wins instead of the fallback that pushes it up.

Applied to `mobile-wallet-layout.component.ts` and `mining-layout.component.ts` (mobile mining flavor). Desktop `toolbar.component.ts` intentionally untouched.

## 3. Per-flavor Android launcher labels
Distinct home-screen labels per Android flavor; desktop `productName` in `tauri.conf.json` unchanged.

- hybrid → **Phoenix Suite**
- wallet → **Phoenix Wallet**
- mining → **Phoenix Miner**

Mechanism (both `android-release.yml` and `android-build-test.yml`): added `app_name` to each matrix flavor and exported it as `PHX_APP_NAME`, plus a new guarded step (after `tauri android init` / the build.gradle.kts template copy, before build) that patches `gen/android/app/src/main/res/values/strings.xml`:
```
sed -i "s#<string name=\"app_name\">[^<]*</string>#<string name=\"app_name\">${PHX_APP_NAME}</string>#" "$STRINGS"
```
The step fails loudly if the file or the `app_name` line is missing and re-asserts the new value landed. **This path only runs in CI (Android can't be built locally), so it is verified on the next workflow re-run.**

## Verification
- `npx tsc -p tsconfig.app.json --noEmit` — passed (exit 0)
- `npm run lint` — "All files pass linting"
- Both workflow YAML files parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)