### PR TITLE
fix(mobile): language menu fills to bottom of screen

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1197,7 +1197,12 @@ interface NavGroup {
          and scroll internally, keeping the panel anchored under the button
          rather than pushed up under the Android status bar / notch. */
       ::ng-deep .lang-menu-panel {
-        max-height: 60vh;
+        /* Fill from just below the trigger down to (near) the bottom of the
+           screen, rather than a fixed cap that stops mid-screen. Subtract the
+           top safe-area inset + toolbar height so the panel still fits in the
+           space below the trigger (staying anchored below instead of flipping
+           up under the notch). */
+        max-height: calc(100vh - env(safe-area-inset-top, 0px) - 64px);
         overflow-y: auto;
       }
     `,

--- a/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
+++ b/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
@@ -340,7 +340,12 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
          and scroll internally, keeping the panel anchored under the button
          rather than pushed up under the Android status bar / notch. */
       ::ng-deep .lang-menu-panel {
-        max-height: 60vh;
+        /* Fill from just below the trigger down to (near) the bottom of the
+           screen, rather than a fixed cap that stops mid-screen. Subtract the
+           top safe-area inset + toolbar height so the panel still fits in the
+           space below the trigger (staying anchored below instead of flipping
+           up under the notch). */
+        max-height: calc(100vh - env(safe-area-inset-top, 0px) - 64px);
         overflow-y: auto;
       }
     `,


### PR DESCRIPTION
The `60vh` cap from #172 made the language selector stop mid-screen. Replace it with `calc(100vh - env(safe-area-inset-top, 0px) - 64px)` so the panel spans from just below the trigger down to near the bottom edge — while still fitting in the space below the trigger, so it stays anchored below (not flipped up under the notch). Applied to both mobile layouts (`mobile-wallet-layout`, `mining-layout`); desktop toolbar untouched.

Pure CSS value change; validated by the Android build's frontend-compile step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)