### PR TITLE
fix(ios): stop focus-zoom on mnemonic word inputs

### DIFF
--- a/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
+++ b/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
@@ -156,7 +156,11 @@ export interface MnemonicEntryState {
         background: transparent;
         font-family: 'Roboto Mono', monospace;
         font-weight: 500;
-        font-size: 13px;
+        /* 16px, not smaller: iOS/WKWebView auto-zooms into a focused input
+           whose font-size is < 16px. The grid columns are fixed (repeat(N, 1fr)
+           per breakpoint), so this does NOT change the 2/3-per-row layout — it
+           only prevents the zoom-on-focus. */
+        font-size: 16px;
         min-width: 0;
         width: 0;
       }


### PR DESCRIPTION
On iOS the restore page zoomed in when the first word box was focused. iOS/WKWebView auto-zooms into any focused input with `font-size < 16px`; the mnemonic `.word-input` boxes were `13px`.

Fix: bump `.word-input` to `16px`. The grid columns are fixed `repeat(N, 1fr)` per breakpoint, so the 2/3-words-per-row layout is unchanged — only the zoom-on-focus is removed. Material inputs (name/passphrase) are already 16px. Android unaffected.

Note: exercised by the iOS build (PR #166), not the Android workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)