### PR TITLE
fix(mobile): 2-col mnemonic grid on phones + language menu bottom on iOS

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1201,8 +1201,10 @@ interface NavGroup {
            screen, rather than a fixed cap that stops mid-screen. Subtract the
            top safe-area inset + toolbar height so the panel still fits in the
            space below the trigger (staying anchored below instead of flipping
-           up under the notch). */
-        max-height: calc(100vh - env(safe-area-inset-top, 0px) - 64px);
+           up under the notch). dvh (not vh) tracks the true visible height on
+           iOS; content is already pushed down by env(safe-area-inset-top)
+           globally (styles.scss), so subtract that inset + the 56px toolbar. */
+        max-height: calc(100dvh - env(safe-area-inset-top, 0px) - 56px);
         overflow-y: auto;
       }
     `,

--- a/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
+++ b/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
@@ -344,8 +344,10 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
            screen, rather than a fixed cap that stops mid-screen. Subtract the
            top safe-area inset + toolbar height so the panel still fits in the
            space below the trigger (staying anchored below instead of flipping
-           up under the notch). */
-        max-height: calc(100vh - env(safe-area-inset-top, 0px) - 64px);
+           up under the notch). dvh (not vh) tracks the true visible height on
+           iOS; content is already pushed down by env(safe-area-inset-top)
+           globally (styles.scss), so subtract that inset + the 56px toolbar. */
+        max-height: calc(100dvh - env(safe-area-inset-top, 0px) - 56px);
         overflow-y: auto;
       }
     `,

--- a/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
+++ b/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
@@ -201,7 +201,10 @@ export interface MnemonicEntryState {
         }
       }
 
-      @media (max-width: 400px) {
+      /* All phones (incl. large iPhones ~430px), not just narrow ones, drop to
+         2 columns — at 16px a 3-per-row word box is too narrow to show a full
+         BIP39 word. 3/4 columns are kept only for tablets/desktop (>480px). */
+      @media (max-width: 480px) {
         .mnemonic-input-grid {
           grid-template-columns: repeat(2, 1fr);
 


### PR DESCRIPTION
After the 16px input bump, large phones (iPhone Pro Max ~430px) rendered the mnemonic grid at 3 columns — too narrow to show a full BIP39 word. The 2-column rule was gated at `max-width: 400px`, so 400–599px devices got 3 columns.

Fix: raise the 2-column breakpoint to `max-width: 480px`, so all phones (incl. large iPhones/Androids) get 2 readable columns; 3/4 columns remain for tablets/desktop. Fixes iOS; also makes >400px Android phones consistent at 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)