### PR TITLE
feat(receive): first-unused address on open, same in both backends

### DIFF
--- a/web-wallet/src/app/core/backend/core-wallet-backend.ts
+++ b/web-wallet/src/app/core/backend/core-wallet-backend.ts
@@ -120,12 +120,15 @@ export class CoreWalletBackend implements WalletBackend {
   /** A bech32(m) receive address for the wallet's networks (not legacy/script). */
   private isReceiveBech32(address: string): boolean {
     const lower = address.toLowerCase();
+    // All PoCX networks incl. regtest (rpocx1) + both witness versions
+    // (…1q SegWit / …1p Taproot). Standard Bitcoin HRPs kept defensively.
     return (
+      lower.startsWith('pocx1') ||
+      lower.startsWith('tpocx1') ||
+      lower.startsWith('rpocx1') ||
       lower.startsWith('bc1') ||
       lower.startsWith('tb1') ||
-      lower.startsWith('bcrt1') ||
-      lower.startsWith('pocx1') ||
-      lower.startsWith('tpocx1')
+      lower.startsWith('bcrt1')
     );
   }
 

--- a/web-wallet/src/app/core/backend/core-wallet-backend.ts
+++ b/web-wallet/src/app/core/backend/core-wallet-backend.ts
@@ -59,6 +59,76 @@ export class CoreWalletBackend implements WalletBackend {
     return this.walletRpc.getNewAddress(walletName, label, type);
   }
 
+  /**
+   * First VIRGIN receive address, reconstructed for a Core descriptor wallet
+   * (Core has no native next-unused). Strategy:
+   *
+   * 1. `listreceivedbyaddress 0 true` — one call that returns EVERY revealed
+   *    receive address with its total received (minconf 0 counts unconfirmed)
+   *    and the txids that paid it. Virgin = received 0 sats AND no txids
+   *    (real on-chain usage, not the old `labels.length` heuristic). Change
+   *    addresses never appear here, so only external receive keys are considered.
+   * 2. If NO virgin exists (all revealed addresses used, or a fresh wallet with
+   *    none revealed), reveal a fresh unused one via `getnewaddress` — matching
+   *    BDK's reveal-only-when-none-outstanding contract.
+   * 3. Otherwise order the virgins by derivation index (`getaddressinfo`
+   *    hdkeypath) and return the lowest — the same "first unused" BDK gives.
+   *    `getaddressinfo` is called only on the (usually tiny) virgin subset.
+   *
+   * Any RPC failure falls back to `getnewaddress` so the page still shows a
+   * usable address.
+   */
+  async currentReceiveAddress(walletName: string): Promise<string> {
+    try {
+      const received = await this.walletRpc.listReceivedByAddress(walletName, 0, true);
+      const virgins = received
+        .filter(r => Math.round(r.amount * 1e8) === 0 && r.txids.length === 0)
+        .map(r => r.address)
+        .filter(a => this.isReceiveBech32(a));
+
+      if (virgins.length === 0) {
+        return this.walletRpc.getNewAddress(walletName, '', 'bech32');
+      }
+
+      const withIndex = await Promise.all(
+        virgins.map(async address => ({
+          address,
+          index: await this.receiveIndex(walletName, address),
+        }))
+      );
+      withIndex.sort((a, b) => a.index - b.index);
+      return withIndex[0].address;
+    } catch {
+      return this.walletRpc.getNewAddress(walletName, '', 'bech32');
+    }
+  }
+
+  /** Derivation index of a receive address from its `getaddressinfo` hdkeypath. */
+  private async receiveIndex(walletName: string, address: string): Promise<number> {
+    try {
+      const info = await this.walletRpc.getAddressInfo(walletName, address);
+      const path = info.hdkeypath;
+      if (!path) return Number.MAX_SAFE_INTEGER;
+      const last = path.split('/').pop() ?? '';
+      const idx = Number.parseInt(last.replace(/['h]/g, ''), 10);
+      return Number.isFinite(idx) ? idx : Number.MAX_SAFE_INTEGER;
+    } catch {
+      return Number.MAX_SAFE_INTEGER;
+    }
+  }
+
+  /** A bech32(m) receive address for the wallet's networks (not legacy/script). */
+  private isReceiveBech32(address: string): boolean {
+    const lower = address.toLowerCase();
+    return (
+      lower.startsWith('bc1') ||
+      lower.startsWith('tb1') ||
+      lower.startsWith('bcrt1') ||
+      lower.startsWith('pocx1') ||
+      lower.startsWith('tpocx1')
+    );
+  }
+
   async listUnspent(walletName: string): Promise<UTXO[]> {
     return this.walletRpc.listUnspent(walletName);
   }

--- a/web-wallet/src/app/core/backend/electrum-wallet-backend.ts
+++ b/web-wallet/src/app/core/backend/electrum-wallet-backend.ts
@@ -108,6 +108,12 @@ export class ElectrumWalletBackend implements WalletBackend {
     return this.btcxWallet.newAddress();
   }
 
+  async currentReceiveAddress(): Promise<string> {
+    // BDK `next_unused_address`: the lowest-index revealed-but-unused external
+    // address, revealing a fresh one only when none is outstanding.
+    return this.btcxWallet.currentAddress();
+  }
+
   async listUnspent(): Promise<UTXO[]> {
     const utxos = await invoke<BtcxUtxoDto[]>('btcx_wallet_utxos');
     return utxos.map(mapBtcxUtxo);

--- a/web-wallet/src/app/core/backend/wallet-backend.model.ts
+++ b/web-wallet/src/app/core/backend/wallet-backend.model.ts
@@ -28,6 +28,16 @@ export interface WalletBackend {
   /** Fresh receive address. Label/type are Core-only (capabilities). */
   getNewAddress(walletName: string, label?: string, type?: CoreAddressType): Promise<string>;
 
+  /**
+   * The address to SHOW on the receive page at open: the first VIRGIN
+   * (never-received) receive address — the lowest-derivation-index address
+   * that has never been paid. A fresh one is revealed ONLY when none is
+   * outstanding (no churn on repeated opens). Same contract as BDK
+   * `next_unused_address`; the Core backend reconstructs it from on-chain
+   * receive history.
+   */
+  currentReceiveAddress(walletName: string): Promise<string>;
+
   /** Spendable outputs in the Core `listunspent` shape. */
   listUnspent(walletName: string): Promise<UTXO[]>;
 

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -20,6 +20,7 @@ import { WalletRpcService } from '../../../../bitcoin/services/rpc/wallet-rpc.se
 import { buildPaymentUri } from '../../../../bitcoin/utils/payment-uri';
 import { NodeService } from '../../../../node/services/node.service';
 import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
+import { BackendRouterService } from '../../../../core/backend/backend-router.service';
 
 interface AddressInfo {
   address: string;
@@ -105,7 +106,7 @@ type AddressMode = 'existing' | 'generate';
                 </mat-radio-group>
               </div>
 
-              @if (addressMode === 'existing') {
+              @if (addressMode === 'existing' && canEnumerate()) {
                 @if (!isLoadingAddresses()) {
                   <mat-form-field appearance="outline" class="full-width">
                     <mat-label>{{ 'select_address' | i18n }}</mat-label>
@@ -553,7 +554,16 @@ export class ReceiveComponent implements OnInit, OnDestroy {
   private readonly location = inject(Location);
   private readonly nodeService = inject(NodeService);
   private readonly btcxWallet = inject(BtcxWalletService);
+  private readonly backendRouter = inject(BackendRouterService);
   private readonly destroy$ = new Subject<void>();
+
+  /**
+   * Whether the current backend can enumerate ALL of the wallet's addresses
+   * (the existing-address dropdown). Only Core RPC can; the remote/BDK backend
+   * exposes just the current first-unused, so there the dropdown collapses to
+   * that single value.
+   */
+  readonly canEnumerate = computed(() => !this.backendRouter.isRemote());
 
   /**
    * Remote (Electrum) mode + a legacy v30 (coin-0') pocket = spend-only:
@@ -600,7 +610,7 @@ export class ReceiveComponent implements OnInit, OnDestroy {
         this.addressMode = 'existing';
         this.existingAddresses.set([]);
         if (!this.spendOnly()) {
-          this.loadExistingAddresses();
+          this.loadReceiveAddresses();
         }
       });
 
@@ -617,7 +627,7 @@ export class ReceiveComponent implements OnInit, OnDestroy {
       await this.btcxWallet.initialize();
     }
     if (!this.spendOnly()) {
-      await this.loadExistingAddresses();
+      await this.loadReceiveAddresses();
     }
   }
 
@@ -630,48 +640,93 @@ export class ReceiveComponent implements OnInit, OnDestroy {
     this.location.back();
   }
 
-  async loadExistingAddresses(): Promise<void> {
+  /**
+   * Set the shown/default address to the first VIRGIN (never-received)
+   * address via the backend seam — identical in Core and remote modes
+   * (`currentReceiveAddress`), matching what mobile does. In Core mode ALSO
+   * build the existing-address dropdown; the remote/BDK backend can't
+   * enumerate every address, so there the single current address is the only
+   * selectable value.
+   */
+  async loadReceiveAddresses(): Promise<void> {
     if (this.spendOnly()) return;
     const walletName = this.walletManager.activeWallet;
     if (!walletName) return;
 
     this.isLoadingAddresses.set(true);
     try {
-      const addressMap = await this.walletRpc.getAddressesByLabel(walletName, '');
-      const addresses: AddressInfo[] = [];
+      const backend = this.backendRouter.wallet();
+      const current = await backend.currentReceiveAddress(walletName);
 
-      for (const [address, info] of Object.entries(addressMap)) {
-        if (this.isBech32Address(address)) {
-          try {
-            const addrInfo = await this.walletRpc.getAddressInfo(walletName, address);
-            addresses.push({
-              address,
-              purpose: (info as { purpose?: string }).purpose || 'receive',
-              isUsed: addrInfo.ismine && addrInfo.labels && addrInfo.labels.length > 0,
-              txCount: 0,
-              label: addrInfo.labels?.[0] || '',
-            });
-          } catch {
-            addresses.push({
-              address,
-              purpose: (info as { purpose?: string }).purpose || 'receive',
-              isUsed: false,
-              txCount: 0,
-              label: '',
-            });
-          }
-        }
+      if (this.canEnumerate()) {
+        await this.loadExistingAddressList(walletName, current);
+      } else {
+        // Remote: no address enumeration available — the current first-unused
+        // is the only entry (dropdown is hidden in remote anyway).
+        this.existingAddresses.set(
+          current
+            ? [{ address: current, purpose: 'receive', isUsed: false, txCount: 0, label: '' }]
+            : []
+        );
       }
 
-      this.existingAddresses.set(addresses);
-      if (addresses.length > 0) {
-        this.selectedAddress = addresses[addresses.length - 1].address;
-      }
+      // Default the selection to the first virgin, matching mobile.
+      this.selectedAddress = current;
     } catch (error) {
       console.error('Failed to load addresses:', error);
     } finally {
       this.isLoadingAddresses.set(false);
     }
+  }
+
+  /**
+   * Build the Core existing-address dropdown. `isUsed` reflects REAL on-chain
+   * usage (received sats / txids from `listreceivedbyaddress`), not the old
+   * `labels.length` heuristic. `ensure` guarantees the current first-unused is
+   * present so the selected value always has a matching option.
+   */
+  private async loadExistingAddressList(walletName: string, ensure?: string): Promise<void> {
+    const addressMap = await this.walletRpc.getAddressesByLabel(walletName, '');
+
+    // Real usage + label per address in a single call (minconf 0 counts
+    // unconfirmed receives; include_empty surfaces revealed-but-unused ones).
+    const usage = new Map<string, { used: boolean; label: string }>();
+    try {
+      const received = await this.walletRpc.listReceivedByAddress(walletName, 0, true);
+      for (const r of received) {
+        usage.set(r.address, {
+          used: Math.round(r.amount * 1e8) > 0 || r.txids.length > 0,
+          label: r.label ?? '',
+        });
+      }
+    } catch {
+      // best-effort — used/label fall back to defaults below.
+    }
+
+    const addresses: AddressInfo[] = [];
+    for (const [address, info] of Object.entries(addressMap)) {
+      if (!this.isBech32Address(address)) continue;
+      const u = usage.get(address);
+      addresses.push({
+        address,
+        purpose: (info as { purpose?: string }).purpose || 'receive',
+        isUsed: u?.used ?? false,
+        txCount: 0,
+        label: u?.label ?? '',
+      });
+    }
+
+    if (ensure && !addresses.some(a => a.address === ensure)) {
+      addresses.unshift({
+        address: ensure,
+        purpose: 'receive',
+        isUsed: false,
+        txCount: 0,
+        label: '',
+      });
+    }
+
+    this.existingAddresses.set(addresses);
   }
 
   async generateNewAddress(): Promise<void> {
@@ -681,9 +736,14 @@ export class ReceiveComponent implements OnInit, OnDestroy {
 
     this.isGenerating.set(true);
     try {
-      const address = await this.walletRpc.getNewAddress(walletName, this.label || '', 'bech32');
+      const address = await this.backendRouter
+        .wallet()
+        .getNewAddress(walletName, this.label || '', 'bech32');
       this.generatedAddress.set(address);
-      await this.loadExistingAddresses();
+      // Core: refresh the dropdown so the freshly revealed address shows.
+      if (this.canEnumerate()) {
+        await this.loadExistingAddressList(walletName, this.selectedAddress);
+      }
     } catch (error) {
       console.error('Failed to generate address:', error);
       this.notification.error('error_generating_address');

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -773,11 +773,16 @@ export class ReceiveComponent implements OnInit, OnDestroy {
 
   private isBech32Address(address: string): boolean {
     const lower = address.toLowerCase();
+    // Every PoCX network (pocx/tpocx/rpocx) and BOTH witness versions — the
+    // active wallet may be a SegWit (…1q) OR Taproot (…1p) compartment, and
+    // regtest uses the rpocx HRP. Standard Bitcoin HRPs kept defensively.
     return (
-      lower.startsWith('bc1q') ||
-      lower.startsWith('tb1q') ||
-      lower.startsWith('pocx1q') ||
-      lower.startsWith('tpocx1q')
+      lower.startsWith('pocx1') ||
+      lower.startsWith('tpocx1') ||
+      lower.startsWith('rpocx1') ||
+      lower.startsWith('bc1') ||
+      lower.startsWith('tb1') ||
+      lower.startsWith('bcrt1')
     );
   }
 


### PR DESCRIPTION
## What changes

On the desktop **Receive** page, the address shown **on page load** is now the **first VIRGIN (never-received) receive address** — the same behavior mobile already has — and it is **identical whether the backend is Core RPC or remote/Electrum**. The existing-address selector, amount and label fields are kept.

This also **fixes desktop Receive in remote/Electrum mode**, which was previously broken: the component was hardwired to Core RPC (`WalletRpcService.getAddressesByLabel` / `getAddressInfo`), so in remote mode those calls failed and the page showed no address. The route `/receive` is unguarded, so remote users hit this.

## How the default address is computed

New seam method `WalletBackend.currentReceiveAddress(walletName)`:

- **Electrum/BDK** → `btcx_wallet_current_address` (BDK `next_unused_address`): lowest revealed-but-unused external address, revealing a fresh one only when none is outstanding. No Rust changes were needed — this command already existed.
- **Core** (net-new, no native next-unused): one `listreceivedbyaddress 0 true` call returns every revealed receive address with total received (minconf 0 counts unconfirmed) and its txids. **Virgin = 0 sats received AND no txids** (real on-chain usage — replaces the old wrong `labels.length > 0` heuristic). Virgins are ordered by derivation index (`getaddressinfo` hdkeypath, called only on the small virgin subset) and the lowest is returned. If no virgin exists (all used, or a bare wallet), it reveals a fresh one via `getnewaddress` — matching BDK's reveal-when-none-outstanding contract. Any RPC failure falls back to `getnewaddress`.

**Cost (Core):** 1 `listreceivedbyaddress` + `getaddressinfo` per virgin candidate (typically a handful, often 1). The dropdown build reuses the same single `listreceivedbyaddress` for used/label flags (dropping the previous per-address `getaddressinfo` loop), so the page is cheaper overall than before.

## Existing-address selector in remote mode

The BDK backend has no "list all addresses" command (`btcx_wallet` only exposes reveal/peek). So the dropdown is **Core-only** (`canEnumerate()` = not remote). In remote mode the selector collapses to the single current first-unused value (shown via the QR/address panel); it no longer calls Core RPC. "Generate new" routes through the seam's `getNewAddress()` in both modes.

## Rust

None required.

## Verification

- `npx tsc -p tsconfig.app.json --noEmit` → exit 0
- `npm run lint` → All files pass linting
- `npm run format:check` → All matched files use Prettier code style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
