### PR TITLE
feat(layout): unify sidenav + drawer shells via shared dimension tokens

### DIFF
--- a/web-wallet/src/app/features/coins/pages/coins/coins.component.ts
+++ b/web-wallet/src/app/features/coins/pages/coins/coins.component.ts
@@ -80,29 +80,30 @@ import { AppModeService } from '../../../../core/services/app-mode.service';
         min-height: 0;
       }
 
-      /* Full-width gradient band; the inner row (below) is what carries the
-         column geometry and height, mirroring app-mwallet-page-header. */
+      /* Full-width gradient band. Its height is the shared balance band token
+         (--menu-balance-h) — the SAME height as the menu's balance block — so
+         the page header and the menu balance area move in tandem and both
+         shrink at the mobile breakpoint. */
       .header {
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
-        padding: 16px 0;
+        height: var(--menu-balance-h);
         flex-shrink: 0;
       }
 
       /* The header row spans the full page width (like the desktop header and
          the app's other page headers) — NOT constrained to the card column —
          so the back arrow sits at the page's left edge and refresh at its
-         right. Horizontal padding is the band's edge inset (24px desktop /
-         16px mobile). min-height lives here (not the band) so the band height
-         derives from the inner row + band padding. */
+         right. Fills the band height; horizontal padding is the band's edge
+         inset (24px desktop / 16px mobile). */
       .header-inner {
         display: flex;
         align-items: center;
         gap: 16px;
         width: 100%;
+        height: 100%;
         box-sizing: border-box;
         padding: 0 24px;
-        min-height: 40px;
 
         h1 {
           margin: 0;
@@ -188,19 +189,10 @@ import { AppModeService } from '../../../../core/services/app-mode.service';
       }
 
       @media (max-width: 600px) {
-        /* Pin the band to 68px — the mobile drawer's balance section
-           (.drawer-wallet-info in mobile-wallet-layout) rendered height,
-           measured in dev tools — so the coins header lines up with the menu's
-           balance block. Fixed height (not padding + button-driven min-height)
-           keeps it exact regardless of the mat-icon-button size. Title 20px. */
-        .header {
-          height: 68px;
-          padding: 0;
-        }
-
+        /* Band height comes from --menu-balance-h (shrinks to the mobile
+           balance-block height at this breakpoint). Only the edge padding and
+           title size change here. */
         .header-inner {
-          height: 100%;
-          min-height: 0;
           padding: 0 16px;
         }
 

--- a/web-wallet/src/app/features/contacts/pages/contact-list/contact-list.component.ts
+++ b/web-wallet/src/app/features/contacts/pages/contact-list/contact-list.component.ts
@@ -324,7 +324,8 @@ import {
       .header {
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
-        padding: 16px 24px;
+        height: var(--menu-balance-h);
+        padding: 0 24px;
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -748,12 +749,10 @@ import {
       // Responsive — reflow the table to stacked cards below 600px (tablet
       // portrait, phone). The full address wraps (word-break) at full width.
       @media (max-width: 600px) {
-        /* Pin the band to 68px — the mobile drawer's balance section
-           (.drawer-wallet-info) rendered height — so the contacts header lines
-           up with the menu's balance block, matching the coins page. Edge
-           padding 16px (tracks .content); 20px title. */
+        /* Band height comes from --menu-balance-h (shrinks to the mobile
+           balance-block height here) — in tandem with the menu balance block
+           and the coins page. Only edge padding + title change. */
         .header {
-          height: 68px;
           padding: 0 16px;
         }
 

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -489,7 +489,7 @@ interface NavGroup {
 
       /* Drawer — the desktop main-layout sidenav, mobile-sized. */
       .drawer {
-        width: 250px;
+        width: var(--menu-width);
         background: linear-gradient(180deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
         overflow-x: hidden;
@@ -507,7 +507,7 @@ interface NavGroup {
         --mat-list-list-item-hover-leading-icon-color: white;
         --mat-list-list-item-focus-leading-icon-color: white;
         --mat-list-active-indicator-color: rgba(255, 255, 255, 0.15);
-        --mat-list-list-item-one-line-container-height: 44px;
+        --mat-list-list-item-one-line-container-height: var(--menu-item-h);
         --mat-list-list-item-label-text-size: 14px;
       }
 
@@ -515,7 +515,7 @@ interface NavGroup {
         position: relative;
         display: flex;
         align-items: center;
-        height: 56px;
+        height: var(--toolbar-h);
         padding: 0 16px;
         gap: 10px;
         border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -555,22 +555,27 @@ interface NavGroup {
       }
 
       .drawer-wallet-info {
-        padding: 12px 16px;
+        height: var(--menu-balance-h);
+        padding: 0 16px;
         background: rgba(0, 0, 0, 0.2);
         text-align: center;
         flex-shrink: 0;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
 
         .drawer-wallet-name {
           font-size: 12px;
           opacity: 0.8;
-          margin-bottom: 2px;
+          margin-bottom: 4px;
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
         }
 
         .drawer-wallet-balance {
-          font-size: 16px;
+          font-size: 17px;
           font-weight: 500;
           font-variant-numeric: tabular-nums;
         }
@@ -675,7 +680,7 @@ interface NavGroup {
         background-color: white !important;
         color: rgba(0, 0, 0, 0.87) !important;
         padding: 0;
-        height: 56px;
+        height: var(--toolbar-h);
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         flex-shrink: 0;
         z-index: 2;

--- a/web-wallet/src/app/layout/main-layout/main-layout.component.ts
+++ b/web-wallet/src/app/layout/main-layout/main-layout.component.ts
@@ -173,7 +173,7 @@ interface NavGroup {
       }
 
       .sidenav {
-        width: 240px;
+        width: var(--menu-width);
         background: linear-gradient(180deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
         overflow-x: hidden;
@@ -193,7 +193,7 @@ interface NavGroup {
         --mat-list-list-item-hover-leading-icon-color: white;
         --mat-list-list-item-focus-leading-icon-color: white;
         --mat-list-active-indicator-color: rgba(255, 255, 255, 0.15);
-        --mat-list-list-item-one-line-container-height: 40px;
+        --mat-list-list-item-one-line-container-height: var(--menu-item-h);
         --mat-list-list-item-label-text-size: 13px;
       }
 
@@ -201,7 +201,7 @@ interface NavGroup {
         position: relative;
         display: flex;
         align-items: center;
-        height: 64px;
+        height: var(--toolbar-h);
         padding: 0 16px;
         gap: 10px;
         border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -288,7 +288,8 @@ interface NavGroup {
       }
 
       .wallet-info {
-        padding: 16px 24px;
+        height: var(--menu-balance-h);
+        padding: 0 24px;
         background: rgba(0, 0, 0, 0.2);
         display: flex;
         flex-direction: column;
@@ -305,6 +306,13 @@ interface NavGroup {
         // Increase balance display size
         ::ng-deep app-balance-display {
           font-size: 17px;
+        }
+      }
+
+      // Version line is desktop chrome — hidden at the mobile breakpoint.
+      @media (max-width: 600px) {
+        .header-version {
+          display: none;
         }
       }
 

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -397,7 +397,7 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
         background-color: white !important;
         color: rgba(0, 0, 0, 0.87) !important;
         padding: 0;
-        height: 64px;
+        height: var(--toolbar-h);
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
         /* Ensure all text/buttons inside toolbar have correct colors */
@@ -459,7 +459,7 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
 
       .action-button {
         min-width: 64px;
-        height: 64px;
+        height: var(--toolbar-h);
         border-radius: 0;
       }
 

--- a/web-wallet/src/styles.scss
+++ b/web-wallet/src/styles.scss
@@ -32,6 +32,29 @@ body {
 // bottom navigation half off-screen.
 :root {
   --android-safe-top: 0px;
+
+  // Unified menu/shell dimensions — the single source of truth shared by the
+  // desktop sidenav (main-layout) and the nodeless drawer (mobile-wallet-
+  // layout) so the two shells never drift. Values are the DESKTOP spec.
+  //
+  // Two "bands" appear in BOTH the menu and the pages and must move in tandem;
+  // each shrinks at the lowest breakpoint (see below):
+  //   --toolbar-h     = app top bar  ↔ menu logo/title bar
+  //   --menu-balance-h = page header ↔ menu balance block
+  // --menu-width and --menu-item-h are fixed at all widths. Per-variant item
+  // GATING (wallet-only shows fewer entries) is unaffected — this is size only.
+  --menu-width: 240px; // sidenav / drawer width
+  --menu-item-h: 40px; // nav list item height
+  --toolbar-h: 64px; // top bar: app toolbar + menu logo/title bar
+  --menu-balance-h: 71px; // balance band: menu balance block + page headers
+}
+
+// Lowest breakpoint: both shared bands shrink by width.
+@media (max-width: 600px) {
+  :root {
+    --toolbar-h: 56px;
+    --menu-balance-h: 68px;
+  }
 }
 
 body.platform-android {


### PR DESCRIPTION
## What

The desktop sidenav (`main-layout` + `app-toolbar`) and the nodeless drawer (`mobile-wallet-layout`) were two hand-maintained shells that had drifted (widths, header/toolbar/balance heights, nav-item heights). This makes their dimensions **global CSS tokens** in `styles.scss` — one source of truth both shells consume, so they can't drift again.

Values are the **desktop spec**. Two "bands" appear in both the menu and the pages and now move **in tandem**, each shrinking at the lowest breakpoint (≤600px):

| Token | > 600px | ≤ 600px | Used by |
|---|---|---|---|
| `--toolbar-h` | 64px | 56px | app toolbar **+** menu logo/title bar |
| `--menu-balance-h` | 71px | 68px | page header **+** menu balance block |
| `--menu-width` | 240px | — | sidenav / drawer |
| `--menu-item-h` | 40px | — | nav list item |

Also: **version line hidden on mobile**. Coins + contacts page headers now read `--menu-balance-h`.

## Not changed (by design)
- **Functionality** — nav items, per-variant gating (wallet-only shows fewer), and footers are untouched; this is purely dimensional.
- **User pages** (send/receive/transactions) keep their current headers until their own unification lands.

## Verification note
The **nodeless drawer** shell was verified live across widths (wallet-only dev). The **desktop `main-layout`** shell mirrors the exact same tokens (deterministic) but should be eyeballed in **managed-node mode** before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)