### PR TITLE
fix(mining): never run mining in wallet-only mode

### DIFF
--- a/web-wallet/src/app/app.component.ts
+++ b/web-wallet/src/app/app.component.ts
@@ -252,13 +252,13 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     // Auto-start runs on every Tauri launch that HAS the mining backend
-    // compiled in (desktop wallet, desktop mining-only, Android hybrid,
-    // Android mining-only). The Android wallet-only flavor has no mining
-    // commands, so these auto-starts are suppressed there — otherwise the
-    // service's first `refreshState()` / `loadConfig()` would invoke absent
-    // commands. Each service still has its own guards (missing config,
+    // enabled for this mode: hybrid (default desktop), mining-only, and the
+    // full mobile flavor. Wallet-only NEVER mines — on Android the commands
+    // are absent, and on desktop `--wallet-only` they are compiled in but must
+    // stay dormant (no background miner in a wallet-only session). `miningEnabled`
+    // captures both. Each service still has its own guards (missing config,
     // no chains/drives, node-not-ready) so the calls no-op safely otherwise.
-    if (this.appModeService.hasMiningBackend()) {
+    if (this.appModeService.miningEnabled()) {
       this.aggregatorService
         .autoStart()
         .catch(err => console.error('Aggregator auto-start failed:', err));

--- a/web-wallet/src/app/core/services/app-mode.service.ts
+++ b/web-wallet/src/app/core/services/app-mode.service.ts
@@ -65,9 +65,20 @@ export class AppModeService {
    * (Rust `mining` cargo feature) is compiled in. False ONLY in the Android
    * wallet-only flavor (`isWalletOnly()` + `isMobile()`), where every mining/
    * aggregator command is absent. Desktop `--wallet-only` keeps mining
-   * compiled, so it stays true there.
+   * compiled, so it stays true there — use this to guard whether a mining
+   * COMMAND is safe to call, NOT whether mining should run.
    */
   readonly hasMiningBackend = computed(() => !(this.isWalletOnly() && this.isMobile()));
+
+  /**
+   * Whether mining/plotting/aggregator should actually be ENABLED for this
+   * mode — the backend is compiled in AND we are not in wallet-only mode.
+   * Mining belongs to hybrid (default desktop), mining-only, and the full
+   * mobile flavor; wallet-only never mines, on ANY platform. (Desktop
+   * `--wallet-only` compiles mining in but must not auto-start or surface it —
+   * `hasMiningBackend` stays true there for command-safety, this is false.)
+   */
+  readonly miningEnabled = computed(() => this.hasMiningBackend() && !this.isWalletOnly());
 
   /** Whether the mode has been initialized (internal guard) */
   private readonly _isInitialized = signal(false);


### PR DESCRIPTION
## Problem
Desktop `--wallet-only` ran a **background miner**. The auto-start gate (`app.component.ts`) used `hasMiningBackend`, which means "mining feature is **compiled in**" — true for the hybrid desktop binary even under `--wallet-only`. So the miner auto-started (and `autoStart: true` configs kicked off rounds against a pool).

## Fix
Add `AppModeService.miningEnabled` = `hasMiningBackend() && !isWalletOnly()` and gate the aggregator + mining auto-start on it instead.

- Mining runs only in **hybrid (default desktop), mining-only, and full-mobile** modes.
- **Wallet-only never mines**, on any platform.
- `hasMiningBackend` keeps its original "is this command callable" meaning (still needed so Android wallet-only, where the commands are absent, doesn't invoke them).

Mining **UI/routes** were already gated off in wallet-only (`main-layout:489`, `mining-only.guard.ts`) — this closes the one remaining backend leak.

## Verified
Relaunched `--wallet-only` after the fix: app boots, **zero `pocx_miner` log lines** (previously it logged finished mining rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)