### PR TITLE
fix(ui): Android review round 1 — six on-device findings

### DIFF
--- a/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -457,10 +457,12 @@ import { MiningService } from '../../../../mining/services';
                                   <span>{{ 'view_address_in_explorer' | i18n }}</span>
                                 </button>
                               }
-                              <button mat-menu-item (click)="viewTransactionDetails(tx)">
-                                <mat-icon>info</mat-icon>
-                                <span>{{ 'transaction_details' | i18n }}</span>
-                              </button>
+                              @if (!isRemote()) {
+                                <button mat-menu-item (click)="viewTransactionDetails(tx)">
+                                  <mat-icon>info</mat-icon>
+                                  <span>{{ 'transaction_details' | i18n }}</span>
+                                </button>
+                              }
                               @if (tx.address) {
                                 <mat-divider></mat-divider>
                                 <button mat-menu-item (click)="sendToAddress(tx.address)">
@@ -652,6 +654,27 @@ import { MiningService } from '../../../../mining/services';
         @include bp.phone {
           grid-template-columns: 1fr;
           grid-template-rows: auto auto minmax(240px, 1fr);
+          /* Old-mobile density: 12px page rhythm, compact cards, 28px amount
+             — frees the vertical space the recent list needs for 3 full rows. */
+          gap: 12px;
+          padding: 12px;
+
+          mat-card-header {
+            padding: 10px 16px 0 16px !important;
+          }
+
+          mat-card-content {
+            padding: 8px 16px 12px 16px !important;
+          }
+
+          .total-balance-card .total-balance {
+            font-size: 28px;
+            margin-bottom: 8px;
+          }
+
+          .total-balance-card .balance-breakdown {
+            padding-top: 8px;
+          }
 
           /* .info-item qualifier beats the base ".blockchain-status-card
              .blockchain-info .info-item { display: flex }" rule, which ties a
@@ -1680,9 +1703,9 @@ export class DashboardComponent implements AfterViewInit {
   // Actions — all navigation goes through pageRoute() so the SAME component
   // links correctly under both shells (desktop `/x` vs nodeless `/wallet/x`).
   viewTransactionDetails(tx: WalletTransaction): void {
-    // The nodeless shell has no per-txid detail route — its history page is
-    // the destination; desktop keeps the txid deep-link.
-    if (this.appMode.isNodeless()) {
+    // Details are a Core-RPC feature — in Electrum/remote mode (any shell)
+    // the destination is the transactions/history LIST instead.
+    if (this.isRemote()) {
       this.router.navigate([this.appMode.pageRoute('/transactions')]);
       return;
     }

--- a/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
+++ b/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
@@ -71,13 +71,6 @@ export const MOBILE_WALLET_ROUTES: Routes = [
           ),
       },
       {
-        path: 'history/:txid',
-        loadComponent: () =>
-          import('../../features/transactions/pages/transaction-detail/transaction-detail.component').then(
-            m => m.TransactionDetailComponent
-          ),
-      },
-      {
         // Unified responsive coins/balance-details page — the same component
         // the desktop /coins route uses (features/coins).
         path: 'coins',

--- a/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
+++ b/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
@@ -669,6 +669,8 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: block;
         width: 100%;
@@ -681,10 +683,14 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
       }
 
       // Header — blue gradient like send page
+      /* Gradient band on the shared balance-band token (in tandem with the
+         menu balance block; shrinks at the phone tier). */
       .header {
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
-        padding: 16px 24px;
+        min-height: var(--menu-balance-h);
+        box-sizing: border-box;
+        padding: 0 24px;
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1040,6 +1046,26 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
         &.active {
           color: rgb(0, 35, 65);
           font-weight: 500;
+        }
+      }
+
+      /* Phone: circles-only wizard — the label shows for the ACTIVE step
+         only, so 4 steps always fit. Header padding tracks phone. */
+      @include bp.phone {
+        .header {
+          padding: 0 16px;
+        }
+
+        .step-label:not(.active) {
+          display: none;
+        }
+
+        .step {
+          gap: 4px;
+        }
+
+        .step-indicator .step-line {
+          margin: 0 6px;
         }
       }
 

--- a/web-wallet/src/app/features/send/pages/send/send.component.ts
+++ b/web-wallet/src/app/features/send/pages/send/send.component.ts
@@ -703,15 +703,18 @@ const SANE_PRESET_MAX_SAT_VB = 200;
       }
 
       // Fee section
+      /* Forging-assignment fee-selector geometry: always 4-across, compact
+         (flex-basis 25%, no min-width) — never a stacked full-width column. */
       .fee-options {
         display: flex;
         flex-wrap: wrap;
         gap: 4px;
         margin-bottom: 6px;
+        width: 100%;
 
         button {
-          flex: 1;
-          min-width: 85px;
+          flex: 1 1 calc(25% - 4px);
+          min-width: 0;
           height: auto;
           padding: 4px 2px;
           border-color: #e0e0e0;
@@ -1026,10 +1029,6 @@ const SANE_PRESET_MAX_SAT_VB = 200;
            .balance-display, which outranks a shallower hide rule. */
         .header .header-right .balance-display {
           display: none;
-        }
-
-        .fee-options button {
-          min-width: 100%;
         }
 
         .amount-row {

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -337,10 +337,12 @@ type TransactionFilter =
                                 <span>{{ 'view_address_in_explorer' | i18n }}</span>
                               </button>
                             }
-                            <button mat-menu-item (click)="viewTransactionDetails(tx)">
-                              <mat-icon>info</mat-icon>
-                              <span>{{ 'transaction_details' | i18n }}</span>
-                            </button>
+                            @if (!isRemote()) {
+                              <button mat-menu-item (click)="viewTransactionDetails(tx)">
+                                <mat-icon>info</mat-icon>
+                                <span>{{ 'transaction_details' | i18n }}</span>
+                              </button>
+                            }
                             @if (tx.address) {
                               <mat-divider></mat-divider>
                               <button mat-menu-item (click)="sendToAddress(tx.address)">
@@ -1016,6 +1018,9 @@ export class TransactionListComponent implements OnInit, OnDestroy {
   private readonly btcxWallet = inject(BtcxWalletService);
   readonly viewport = inject(ViewportService);
 
+  /** Electrum/remote mode — the Core-only detail view is hidden. */
+  readonly isRemote = computed(() => this.backendRouter.isRemote());
+
   constructor() {
     // Remote/nodeless mode: new blocks arrive via the background sync — ride
     // the btcx-wallet:sync signal and reload silently (no spinner flash; the
@@ -1352,6 +1357,9 @@ export class TransactionListComponent implements OnInit, OnDestroy {
 
   // Actions
   viewTransactionDetails(tx: WalletTransaction): void {
+    // Details are a Core-RPC feature (raw tx decode etc.) — no detail view in
+    // Electrum/remote mode.
+    if (this.isRemote()) return;
     this.router.navigate([this.appMode.pageRoute('/transactions'), tx.txid]);
   }
 

--- a/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
+++ b/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
@@ -21,6 +21,7 @@ import { I18nPipe, I18nService } from '../../../core/i18n';
 import { AppModeService } from '../../../core/services/app-mode.service';
 import { invoke } from '@tauri-apps/api/core';
 import { MiningService } from '../../services';
+import { downloadTextFile } from '../../../shared/utils/download';
 import { DriveConfig, calculateNetworkCapacityTib, formatCapacity } from '../../models';
 import { ConfirmDialogComponent } from '../../../shared/components/confirm-dialog/confirm-dialog.component';
 import { PlanViewerDialogComponent } from '../../components/plan-viewer-dialog/plan-viewer-dialog.component';
@@ -2324,11 +2325,10 @@ export class MiningDashboardComponent implements OnInit, OnDestroy {
     ]);
 
     const csv = [headers.join(','), ...rows.map(r => r.join(','))].join('\n');
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = 'deadline_history.csv';
-    link.click();
+    // Shared helper: a detached <a download> click is a silent no-op in the
+    // Tauri webview (WebView2/Android) — downloadTextFile attaches to the DOM
+    // and defers the object-URL revoke, so the export works in-app.
+    void downloadTextFile('deadline_history.csv', csv);
   }
 
   toggleLogFilter(filter: string): void {


### PR DESCRIPTION
Johnny's findings from testing the unified app on Android:

1. **Tx details = RPC-only** — `/wallet/history/:txid` route removed; details menu item + txid/row-tap navigation gated off in Electrum/remote mode (any shell).
2. **Dashboard phone density** — old-mobile rhythm restored (12px gaps, compact paddings, 28px balance) so the recent list's 3 rows actually fit.
3. **PSBT steps at phone** — circles-only indicator, label on the active step only.
4. **PSBT header** — onto the shared balance-band token.
5. **Send fee selector** — forging-assignment geometry (4-across compact chips).
6. **Mining on Android hybrid** — setup buttons target `/miner/setup` (desktop `/mining` tree is guard-blocked in mobile mode); best-deadline CSV export via `downloadTextFile` (detached `<a download>` is a no-op in the Tauri webview).

Merging on full green; APK build follows for re-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX