### PR TITLE
fix(ui): Android review round 2 — density, actions row, mining setup nav

### DIFF
--- a/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -266,6 +266,21 @@ import { MiningService } from '../../../../mining/services';
           </mat-card-content>
         </mat-card>
 
+        <!-- Send / Receive quick actions — the old mobile home's row; phone
+             only (wider layouts reach them via the nav). -->
+        @if (viewport.phone()) {
+          <div class="actions-row">
+            <button mat-raised-button color="primary" (click)="goSend()">
+              <mat-icon>send</mat-icon>
+              {{ 'send' | i18n }}
+            </button>
+            <button mat-raised-button (click)="goReceive()">
+              <mat-icon>call_received</mat-icon>
+              {{ 'receive' | i18n }}
+            </button>
+          </div>
+        }
+
         <!-- Balance Chart Card -->
         <mat-card class="balance-chart-card">
           <mat-card-header>
@@ -654,27 +669,13 @@ import { MiningService } from '../../../../mining/services';
         @include bp.phone {
           grid-template-columns: 1fr;
           grid-template-rows: auto auto minmax(240px, 1fr);
-          /* Old-mobile density: 12px page rhythm, compact cards, 28px amount
-             — frees the vertical space the recent list needs for 3 full rows. */
+          /* 12px page rhythm (old mobile). Card-density overrides live at
+             the END of this stylesheet — they must FOLLOW the base card
+             blocks to win their equal-specificity !important ties. */
           gap: 12px;
           padding: 12px;
-
-          mat-card-header {
-            padding: 10px 16px 0 16px !important;
-          }
-
-          mat-card-content {
-            padding: 8px 16px 12px 16px !important;
-          }
-
-          .total-balance-card .total-balance {
-            font-size: 28px;
-            margin-bottom: 8px;
-          }
-
-          .total-balance-card .balance-breakdown {
-            padding-top: 8px;
-          }
+          /* Room for the actions row: net, balance, actions, transactions. */
+          grid-template-rows: auto auto auto minmax(240px, 1fr);
 
           /* .info-item qualifier beats the base ".blockchain-status-card
              .blockchain-info .info-item { display: flex }" rule, which ties a
@@ -1250,6 +1251,47 @@ import { MiningService } from '../../../../mining/services';
           }
         }
       }
+
+      /* Quick actions row (phone): the old mobile home's Send/Receive pair. */
+      .actions-row {
+        display: flex;
+        gap: 8px;
+
+        button {
+          flex: 1;
+        }
+      }
+
+      /* ── Phone density (old mobile rhythm) ─────────────────────────────
+         MUST stay the LAST block: the base card rules above use equally
+         specific selectors (some with !important), and a same-specificity
+         tie is decided by source order. */
+      @include bp.phone {
+        .blockchain-status-card mat-card-header,
+        .total-balance-card mat-card-header,
+        .transactions-card mat-card-header,
+        .mine-hint-card mat-card-header {
+          padding: 10px 16px 0 16px !important;
+        }
+
+        .blockchain-status-card mat-card-content,
+        .total-balance-card mat-card-content {
+          padding: 8px 16px 12px 16px !important;
+        }
+
+        .total-balance-card .total-balance {
+          font-size: 28px;
+          margin-bottom: 8px;
+        }
+
+        .total-balance-card .balance-breakdown {
+          padding-top: 8px;
+
+          .breakdown-item {
+            padding: 2px 0;
+          }
+        }
+      }
     `,
   ],
 })
@@ -1559,6 +1601,14 @@ export class DashboardComponent implements AfterViewInit {
   /** Open the per-address "Coins & Addresses" view (shell-aware route). */
   goToCoins(): void {
     void this.router.navigate([this.appMode.pageRoute('/coins')]);
+  }
+
+  goSend(): void {
+    void this.router.navigate([this.appMode.pageRoute('/send')]);
+  }
+
+  goReceive(): void {
+    void this.router.navigate([this.appMode.pageRoute('/receive')]);
   }
 
   // Blockchain info methods

--- a/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -1267,29 +1267,67 @@ import { MiningService } from '../../../../mining/services';
          specific selectors (some with !important), and a same-specificity
          tie is decided by source order. */
       @include bp.phone {
+        /* Exact old-mobile card spec (the retired wallet-home): title 15px
+           with a 20px icon, uniform 16px card padding, 28px amount with a
+           15px unit, 13px breakdown rows at 3px rhythm. Material's card
+           header brings its own min-height/typography — flatten it. */
         .blockchain-status-card mat-card-header,
         .total-balance-card mat-card-header,
         .transactions-card mat-card-header,
         .mine-hint-card mat-card-header {
-          padding: 10px 16px 0 16px !important;
+          padding: 14px 16px 0 16px !important;
+          min-height: 0;
+        }
+
+        .blockchain-status-card mat-card-title,
+        .total-balance-card mat-card-title,
+        .transactions-card mat-card-title,
+        .mine-hint-card mat-card-title {
+          font-size: 15px !important;
+          line-height: 20px !important;
+
+          mat-icon {
+            font-size: 20px;
+            width: 20px;
+            height: 20px;
+          }
         }
 
         .blockchain-status-card mat-card-content,
         .total-balance-card mat-card-content {
-          padding: 8px 16px 12px 16px !important;
+          padding: 10px 16px 16px 16px !important;
+        }
+
+        .total-balance-card .coins-link-btn {
+          width: 32px;
+          height: 32px;
+          padding: 0;
         }
 
         .total-balance-card .total-balance {
           font-size: 28px;
-          margin-bottom: 8px;
+          margin-bottom: 10px;
+
+          .unit {
+            font-size: 15px;
+          }
         }
 
         .total-balance-card .balance-breakdown {
-          padding-top: 8px;
+          padding-top: 10px;
 
           .breakdown-item {
-            padding: 2px 0;
+            padding: 3px 0;
+
+            .label,
+            .value {
+              font-size: 13px;
+            }
           }
+        }
+
+        .blockchain-status-card .blockchain-info {
+          gap: 8px 12px;
         }
       }
     `,

--- a/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
@@ -708,7 +708,8 @@ const UTXO_PAGE_SIZE = 10;
         }
 
         .size-field {
-          width: 170px;
+          /* Slim amount box — the address/txid filter takes the freed width. */
+          width: 110px;
           flex-shrink: 0;
         }
 

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -573,6 +573,24 @@ type AddressMode = 'existing' | 'generate';
           flex-direction: column;
           gap: 8px;
         }
+
+        /* Compact phone rhythm: tighter page/card padding + section spacing. */
+        .content {
+          padding: 12px;
+        }
+
+        .receive-card {
+          padding: 14px 16px;
+        }
+
+        .form-section {
+          margin-bottom: 6px;
+        }
+
+        .qr-section {
+          margin-top: 8px;
+          padding-top: 8px;
+        }
       }
     `,
   ],

--- a/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
+++ b/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
@@ -1699,9 +1699,14 @@ export class MiningDashboardComponent implements OnInit, OnDestroy {
     }
   });
 
-  /** Setup route path - differs between wallet mode and mining-only mode */
+  /**
+   * Setup route path. The /miner tree serves mining-only AND the mobile
+   * (Android hybrid) mode — its guard admits both; the desktop /mining tree
+   * is guard-blocked there, which stranded these buttons on Android (the
+   * navigation was silently cancel-redirected back to the dashboard).
+   */
   readonly setupRoute = computed(() =>
-    this.appMode.isMiningOnly() ? '/miner/setup' : '/mining/setup'
+    this.appMode.isMiningOnly() || this.appMode.isMobileMode() ? '/miner/setup' : '/mining/setup'
   );
 
   // Use service signals directly so component state stays in lock-step with
@@ -2384,11 +2389,15 @@ export class MiningDashboardComponent implements OnInit, OnDestroy {
       }
     }
 
-    // Wait for all data to load
-    await Promise.all(loadPromises);
+    // Kick the preloads but NEVER gate navigation on them: a hung or
+    // rejected device probe (OpenCL detection on some boxes / Android)
+    // used to swallow the click entirely — the await sat before the
+    // navigate, so the button silently did nothing. The wizard loads its
+    // own data anyway; the preloads are just a warm-up.
+    void Promise.all(loadPromises).catch(err => console.warn('Setup preload failed:', err));
 
     // Navigate to setup with step parameter
-    this.router.navigate([this.setupRoute()], { queryParams: { step } });
+    await this.router.navigate([this.setupRoute()], { queryParams: { step } });
   }
 
   // Plotter methods


### PR DESCRIPTION
Round 2 of Johnny's on-device findings (branch also carries the earlier uncommitted round-2 work):

1. **Dashboard phone density — now actually applies.** Round 1's overrides lost equal-specificity `!important` ties to later base rules; the definitive block now sits at the end of the stylesheet. 28px balance, compact paddings.
2. **Send/Receive quick-action row restored** on the phone dashboard (old mobile home behavior, shell-aware routes).
3. **Receive page compacted** at phone.
4. **PSBT coin filter**: amount box 110px, address filter grows.
5. **Mining setup buttons on Android — root-caused live** (router-event tracing on the `--mobile` flavor): (a) `setupRoute` still returned the guard-blocked desktop `/mining/setup` — the round-1 edit had been silently dropped by an aborted batch script; navigation was cancel-redirected back to the dashboard. (b) `navigateToSetup` awaited OpenCL device-probe preloads *before* navigating — a hung probe swallowed the click. Both fixed; verified end-to-end (`NavigationEnd /miner/setup?step=1`, wizard on screen).

Also in this branch from round 2 part 1: tx details gated to RPC-mode only, PSBT circles-only steps + band header, send fee selector in the forging-assignment style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX