### PR TITLE
fix(ui): Android review round 3 — version tag rule + fully fit-derived transactions paging

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -22,6 +22,7 @@ import {
 import { ElectrumStatusService } from '../../../core/services/electrum-status.service';
 import { AppModeService } from '../../../core/services/app-mode.service';
 import { ViewportService } from '../../../core/services/viewport.service';
+import { AppUpdateService } from '../../../core/services/app-update.service';
 import { BtcxPipe, TimeAgoPipe } from '../../../shared/pipes';
 import { NotificationService } from '../../../shared/services';
 import {
@@ -119,7 +120,19 @@ interface NavGroup {
       >
         <div class="drawer-header">
           <img src="assets/images/logos/phoenix_v.svg" alt="Phoenix" class="drawer-logo" />
-          <span class="drawer-title">Phoenix Wallet</span>
+          <div class="drawer-title-block">
+            <span class="drawer-title">Phoenix Wallet</span>
+            @if (appVersion()) {
+              <div class="header-version" (click)="onVersionClick()">
+                <span class="version-text">v{{ appVersion() }}</span>
+                @if (showUpdateBadge()) {
+                  <span class="update-badge" title="{{ 'update_available' | i18n }}">
+                    <mat-icon>arrow_upward</mat-icon>
+                  </span>
+                }
+              </div>
+            }
+          </div>
           <button mat-icon-button class="drawer-close" (click)="drawer.close()">
             <mat-icon>close</mat-icon>
           </button>
@@ -488,6 +501,8 @@ interface NavGroup {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .wallet-layout {
         /* Visible viewport minus the Android status-bar padding on <body>:
            100vh fallback, 100dvh override — plain 100vh overflows on
@@ -538,8 +553,56 @@ interface NavGroup {
         height: 28px;
       }
 
-      .drawer-title {
+      .drawer-title-block {
         flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+      }
+
+      /* The desktop sidenav's version line, following the same rule: visible
+         only while the drawer is DOCKED (> tablet tier). */
+      .header-version {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        cursor: pointer;
+        margin-top: 1px;
+
+        .version-text {
+          font-size: 10px;
+          color: rgba(255, 255, 255, 0.5);
+        }
+
+        .update-badge {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 14px;
+          height: 14px;
+          background: #4caf50;
+          border-radius: 50%;
+
+          .mat-icon {
+            font-size: 10px;
+            width: 10px;
+            height: 10px;
+            color: white;
+          }
+        }
+
+        &:hover .version-text {
+          color: rgba(255, 255, 255, 0.8);
+        }
+      }
+
+      @include bp.tablet-down {
+        .header-version {
+          display: none;
+        }
+      }
+
+      .drawer-title {
         font-size: 15px;
         font-weight: 600;
         min-width: 0;
@@ -1234,6 +1297,30 @@ export class MobileWalletLayoutComponent implements OnInit {
   private readonly notification = inject(NotificationService);
   private readonly router = inject(Router);
   private readonly dialog = inject(MatDialog);
+  private readonly appUpdateService = inject(AppUpdateService);
+
+  readonly appVersion = computed(() => this.appUpdateService.currentVersion());
+  readonly showUpdateBadge = computed(() => this.appUpdateService.showUpdateBadge());
+
+  /** The desktop sidenav's version-tap: open the update dialog when one is pending. */
+  async onVersionClick(): Promise<void> {
+    const updateInfo = this.appUpdateService.updateInfo();
+    if (!updateInfo) {
+      return;
+    }
+    const { UpdateDialogComponent } =
+      await import('../../../shared/components/update-dialog/update-dialog.component');
+    const dialogRef = this.dialog.open(UpdateDialogComponent, {
+      data: updateInfo,
+      disableClose: false,
+      autoFocus: false,
+    });
+    dialogRef.afterClosed().subscribe((result: { dismissed?: boolean } | null) => {
+      if (result?.dismissed) {
+        this.appUpdateService.dismissUpdate();
+      }
+    });
+  }
 
   languages: Language[] = LANGUAGES;
 

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -249,7 +249,7 @@ type TransactionFilter =
                 [fitRowSelector]="'.tx-item'"
                 [fitMinRows]="3"
                 [fitFallbackRowPx]="96"
-                (fitRows)="onPhoneFit($event)"
+                (fitRows)="onFit($event)"
               >
                 @for (
                   tx of phoneRows();
@@ -261,7 +261,15 @@ type TransactionFilter =
                 }
               </div>
             } @else {
-              <div class="transactions-table-container">
+              <div
+                class="transactions-table-container"
+                appFitRows
+                [fitRowSelector]="'.fit-row'"
+                [fitHeaderSelector]="'thead'"
+                [fitMinRows]="3"
+                [fitFallbackRowPx]="46"
+                (fitRows)="onFit($event)"
+              >
                 <table class="transactions-table">
                   <thead>
                     <tr>
@@ -279,7 +287,7 @@ type TransactionFilter =
                       tx of paginatedTransactions();
                       track tx.txid + '-' + tx.vout + '-' + tx.category
                     ) {
-                      <tr class="tx-row" [class.unconfirmed]="tx.confirmations === 0">
+                      <tr class="tx-row fit-row" [class.unconfirmed]="tx.confirmations === 0">
                         <td class="col-datetime">
                           <div class="datetime-stack">
                             <span class="date">{{ formatTxDate(tx) }}</span>
@@ -396,10 +404,9 @@ type TransactionFilter =
             }
             <mat-paginator
               [length]="filteredTransactions().length"
-              [pageSize]="effectivePageSize()"
+              [pageSize]="fitPageSize()"
               [pageIndex]="pageIndex()"
-              [pageSizeOptions]="pageSizeOptions"
-              [hidePageSize]="viewport.phone()"
+              [hidePageSize]="true"
               (page)="onPageChange($event)"
               [showFirstLastButtons]="true"
             >
@@ -413,10 +420,23 @@ type TransactionFilter =
     `
       @use 'breakpoints' as bp;
 
+      /* Height chain for fit-based paging at EVERY width (coins/contacts
+         pattern): host fills the routed column, the card flex-fills the
+         leftover height, FitRows measures the table/card viewport. */
+      :host {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+
       .page-layout {
         display: flex;
         flex-direction: column;
-        height: 100%;
+        flex: 1 1 auto;
+        /* No height: 100% — percentage-of-auto breaks the bounded chain and
+           the fit viewport grows with its rows (circular measurement). */
+        min-height: 0;
         box-sizing: border-box;
         background: #eaf0f6;
       }
@@ -596,9 +616,17 @@ type TransactionFilter =
         background: #ffffff !important;
         border-radius: 8px;
         overflow: hidden;
+        flex: 1 1 0;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
 
         mat-card-content {
           padding: 16px 16px 0 16px !important;
+          flex: 1 1 0;
+          min-height: 0;
+          display: flex;
+          flex-direction: column;
         }
 
         mat-paginator {
@@ -715,9 +743,13 @@ type TransactionFilter =
         }
       }
 
+      /* The measured row viewport: height comes from the card (bounded
+         flex chain below), never from the rows — FitRows derives the page
+         size, so the fit-sized page never scrolls. */
       .transactions-table-container {
-        flex: 1;
-        overflow: auto;
+        flex: 1 1 0;
+        min-height: 0;
+        overflow: hidden;
         background: #ffffff;
       }
 
@@ -950,34 +982,6 @@ type TransactionFilter =
           }
         }
 
-        /* Height chain for the fit-based card list: bound the card so
-           FitRows can measure the leftover space (coins/contacts pattern). */
-        :host {
-          flex: 1 1 auto;
-          display: flex;
-          flex-direction: column;
-          min-height: 0;
-        }
-
-        .page-layout {
-          flex: 1 1 auto;
-          min-height: 0;
-        }
-
-        .transactions-card {
-          flex: 1 1 0;
-          min-height: 0;
-          display: flex;
-          flex-direction: column;
-
-          mat-card-content {
-            flex: 1 1 0;
-            min-height: 0;
-            display: flex;
-            flex-direction: column;
-          }
-        }
-
         .tx-card-list {
           flex: 1 1 0;
           min-height: 0;
@@ -1041,14 +1045,12 @@ export class TransactionListComponent implements OnInit, OnDestroy {
   transactions = signal<WalletTransaction[]>([]);
   activeFilter = signal<TransactionFilter>('all');
   pageIndex = signal(0);
-  pageSize = signal(10);
-  pageSizeOptions = [10, 25, 50];
-  /** Phone: fit-derived page size (FitRows measures the card list). */
-  readonly phonePageSize = signal(6);
-  /** The page size in effect: fit-derived on phone, the selector elsewhere. */
-  readonly effectivePageSize = computed(() =>
-    this.viewport.phone() ? this.phonePageSize() : this.pageSize()
-  );
+  /**
+   * Fit-derived page size at EVERY width (the app-wide pattern): FitRows
+   * measures how many rows fit the table/card viewport — no items-per-page
+   * selector. Initial value only covers the first paint.
+   */
+  readonly fitPageSize = signal(10);
   searchQuery = '';
   selectedType: TransactionFilter = 'all';
   dateFrom: Date | null = null;
@@ -1124,8 +1126,8 @@ export class TransactionListComponent implements OnInit, OnDestroy {
 
   paginatedTransactions = computed(() => {
     const txs = this.filteredTransactions();
-    const start = this.pageIndex() * this.effectivePageSize();
-    return txs.slice(start, start + this.effectivePageSize());
+    const start = this.pageIndex() * this.fitPageSize();
+    return txs.slice(start, start + this.fitPageSize());
   });
 
   oldestTransactionDate = computed(() => {
@@ -1158,11 +1160,11 @@ export class TransactionListComponent implements OnInit, OnDestroy {
   }
 
   /** New measured fit: adopt as page size, keep the first visible row on page. */
-  onPhoneFit(fit: number): void {
-    const oldSize = this.phonePageSize();
+  onFit(fit: number): void {
+    const oldSize = this.fitPageSize();
     if (fit === oldSize) return;
     const firstVisible = this.pageIndex() * oldSize;
-    this.phonePageSize.set(fit);
+    this.fitPageSize.set(fit);
     this.pageIndex.set(Math.floor(firstVisible / fit));
   }
 
@@ -1290,8 +1292,8 @@ export class TransactionListComponent implements OnInit, OnDestroy {
   }
 
   onPageChange(event: PageEvent): void {
+    // Page size is fit-derived (no selector) — only the index is user-driven.
     this.pageIndex.set(event.pageIndex);
-    this.pageSize.set(event.pageSize);
   }
 
   // Transaction display methods

--- a/web-wallet/src/app/layout/main-layout/main-layout.component.ts
+++ b/web-wallet/src/app/layout/main-layout/main-layout.component.ts
@@ -168,6 +168,8 @@ interface NavGroup {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .sidenav-container {
         height: 100%;
       }
@@ -309,8 +311,10 @@ interface NavGroup {
         }
       }
 
-      // Version line is desktop chrome — hidden at the mobile breakpoint.
-      @media (max-width: 600px) {
+      /* Version tag follows the menu: visible whenever the sidenav is
+         DOCKED (> tablet tier), hidden in overlay/collapsed mode — the same
+         line ViewportService.menuOverlay switches on. */
+      @include bp.tablet-down {
         .header-version {
           display: none;
         }

--- a/web-wallet/src/app/shared/directives/fit-rows.directive.ts
+++ b/web-wallet/src/app/shared/directives/fit-rows.directive.ts
@@ -58,6 +58,7 @@ export class FitRowsDirective implements AfterViewInit, OnDestroy {
 
   private readonly zone = inject(NgZone);
   private observer: ResizeObserver | null = null;
+  private mutations: MutationObserver | null = null;
   private lastFit: number | null = null;
   private rafId: number | null = null;
 
@@ -67,12 +68,20 @@ export class FitRowsDirective implements AfterViewInit, OnDestroy {
     // can't feed back on themselves within a frame.
     this.observer = new ResizeObserver(() => this.scheduleMeasure());
     this.observer.observe(this.el.nativeElement);
+    // A BOUNDED container never resizes when rows stream in later (async
+    // load), so the attach-time measurement — taken with zero rows and the
+    // fallback stride — would stick forever. Re-measure on child mutations;
+    // the rAF coalescing + emit-on-change guard keeps this loop-free.
+    this.mutations = new MutationObserver(() => this.scheduleMeasure());
+    this.mutations.observe(this.el.nativeElement, { childList: true, subtree: true });
     this.measure();
   }
 
   ngOnDestroy(): void {
     this.observer?.disconnect();
     this.observer = null;
+    this.mutations?.disconnect();
+    this.mutations = null;
     if (this.rafId !== null) cancelAnimationFrame(this.rafId);
     this.rafId = null;
   }


### PR DESCRIPTION
1. **Version tag follows the menu**: visible wherever the sidenav/drawer is docked (>900), hidden in overlay mode — and the wallet drawer now has the tag at all (ported from the desktop sidenav with update badge + dialog tap). Fixes the sidebar mismatch.
2. **Transactions page-size is fit-derived at every width** (selector removed). Root-caused three stacked bugs live: missing `.fit-row` marker on the table rows, `FitRowsDirective` never re-measuring when rows stream into a bounded container (MutationObserver added — hardens all fit consumers), and a legacy `height:100%` breaking the bounded chain. Screenshot-verified: "1–7 of 21", 7 fully visible rows, no selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX