### PR TITLE
fix(ui): receive address selector returns + assignment desktop spacing

### DIFF
--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -1914,7 +1914,9 @@ pub struct BtcxTxProbe {
 }
 
 #[tauri::command]
-pub fn btcx_wallet_tx_probe(state: State<'_, SharedBtcxWalletState>) -> Result<BtcxTxProbe, String> {
+pub fn btcx_wallet_tx_probe(
+    state: State<'_, SharedBtcxWalletState>,
+) -> Result<BtcxTxProbe, String> {
     state.with_entry(|entry| {
         Ok(BtcxTxProbe {
             total: entry.wallet.transactions().count(),

--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -1790,11 +1790,10 @@ pub fn tx_display_address(
     entry: &WalletEntry,
     network: WalletNetwork,
     info: &WalletTxInfo,
+    tx: &bitcoin::Transaction,
 ) -> Option<String> {
     use bdk_wallet::KeychainKind;
 
-    let txid: bitcoin::Txid = info.txid.parse().ok()?;
-    let tx = entry.wallet.get_tx(txid)?.tx_node.tx.clone();
     let spks = || tx.output.iter().map(|o| &o.script_pubkey);
     let own_external = |spk: &bitcoin::ScriptBuf| {
         matches!(
@@ -1844,7 +1843,16 @@ pub fn wallet_transactions_impl(
         // timestamp) — no amount, fee or address math. The old path computed
         // sent_and_received AND calculate_fee for EVERY tx ever before
         // slicing, which made fat wallets take seconds per call.
-        let mut keys: Vec<(bitcoin::Txid, u64, Option<u64>)> = entry
+        // The tx Arc rides along from this single canonicalization pass —
+        // get_tx() re-canonicalizes the WHOLE graph on every call (O(history)
+        // each), so the window below must never touch it.
+        type Key = (
+            bitcoin::Txid,
+            std::sync::Arc<bitcoin::Transaction>,
+            u64,
+            Option<u64>,
+        );
+        let mut keys: Vec<Key> = entry
             .wallet
             .transactions()
             .map(|wtx| {
@@ -1858,12 +1866,17 @@ pub fn wallet_transactions_impl(
                         last_seen,
                     } => (0, first_seen.or(last_seen)),
                 };
-                (wtx.tx_node.txid, confirmations, timestamp)
+                (
+                    wtx.tx_node.txid,
+                    wtx.tx_node.tx.clone(),
+                    confirmations,
+                    timestamp,
+                )
             })
             .collect();
         // The crate's ordering, verbatim: mempool first, then shallow, then
         // deep; ties by descending time; unbroadcast (no timestamp) first.
-        keys.sort_by_key(|(_, confs, ts)| (*confs, std::cmp::Reverse(ts.unwrap_or(u64::MAX))));
+        keys.sort_by_key(|(_, _, confs, ts)| (*confs, std::cmp::Reverse(ts.unwrap_or(u64::MAX))));
         let total = keys.len();
 
         // EXPENSIVE math only for the requested window. Fee is computed for
@@ -1874,9 +1887,7 @@ pub fn wallet_transactions_impl(
             .into_iter()
             .skip(offset.unwrap_or(0))
             .take(limit.unwrap_or(usize::MAX))
-            .filter_map(|(txid, confirmations, timestamp)| {
-                let wtx = entry.wallet.get_tx(txid)?;
-                let tx = wtx.tx_node.tx.clone();
+            .map(|(txid, tx, confirmations, timestamp)| {
                 let (sent, received) = entry.wallet.sent_and_received(&tx);
                 let (sent, received) = (sent.to_sat(), received.to_sat());
                 let (direction, amount_sat, fee_sat) = if sent > received {
@@ -1895,8 +1906,8 @@ pub fn wallet_transactions_impl(
                     confirmations,
                     timestamp,
                 };
-                let address = tx_display_address(entry, network, &info);
-                Some(BtcxWalletTxDto { info, address })
+                let address = tx_display_address(entry, network, &info, &tx);
+                BtcxWalletTxDto { info, address }
             })
             .collect();
         Ok(BtcxWalletTxPage { items, total })

--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -1936,6 +1936,146 @@ pub fn btcx_wallet_tx_probe(
     })
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BtcxTxDetailInput {
+    pub coinbase: bool,
+    pub txid: String,
+    pub vout: u32,
+    pub sequence: u32,
+    /// Prevout data when the wallet's tx graph knows the funding output
+    /// (always true for the wallet's own spends).
+    pub prev_address: Option<String>,
+    pub prev_value_sat: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BtcxTxDetailOutput {
+    pub n: u32,
+    pub address: Option<String>,
+    pub op_return: bool,
+    pub value_sat: u64,
+    pub script_hex: String,
+    pub script_asm: String,
+}
+
+/// Everything the transaction-detail page shows, served on demand from the
+/// synced BDK graph — the remote-mode stand-in for Core's gettransaction +
+/// verbose getrawtransaction.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BtcxTxDetail {
+    pub txid: String,
+    pub wtxid: String,
+    pub raw_hex: String,
+    pub size: u64,
+    pub vsize: u64,
+    pub weight: u64,
+    pub version: i32,
+    pub locktime: u32,
+    pub direction: String,
+    pub amount_sat: u64,
+    pub fee_sat: Option<u64>,
+    pub confirmations: u64,
+    pub timestamp: Option<u64>,
+    pub block_height: Option<u32>,
+    pub block_hash: Option<String>,
+    pub rbf: bool,
+    pub inputs: Vec<BtcxTxDetailInput>,
+    pub outputs: Vec<BtcxTxDetailOutput>,
+}
+
+#[tauri::command]
+pub fn btcx_wallet_tx_detail(
+    state: State<'_, SharedBtcxWalletState>,
+    txid: String,
+) -> Result<BtcxTxDetail, String> {
+    let network = state.get_config().network;
+    let txid: bitcoin::Txid = txid.parse().map_err(|e| format!("invalid txid: {e}"))?;
+    state.with_entry(|entry| {
+        use bdk_wallet::chain::ChainPosition;
+        let wtx = entry
+            .wallet
+            .get_tx(txid)
+            .ok_or_else(|| "transaction not found in wallet history".to_string())?;
+        let tip = entry.wallet.latest_checkpoint().height();
+        let (confirmations, timestamp, block_height, block_hash) = match wtx.chain_position {
+            ChainPosition::Confirmed { anchor, .. } => (
+                u64::from((tip + 1).saturating_sub(anchor.block_id.height)),
+                Some(anchor.confirmation_time),
+                Some(anchor.block_id.height),
+                Some(anchor.block_id.hash.to_string()),
+            ),
+            ChainPosition::Unconfirmed {
+                first_seen,
+                last_seen,
+            } => (0, first_seen.or(last_seen), None, None),
+        };
+        let tx = wtx.tx_node.tx.clone();
+        let (sent, received) = entry.wallet.sent_and_received(&tx);
+        let (sent, received) = (sent.to_sat(), received.to_sat());
+        let fee = entry.wallet.calculate_fee(&tx).ok().map(|a| a.to_sat());
+        let (direction, amount_sat) = if sent > received {
+            let net_out = sent - received;
+            ("sent", net_out - fee.unwrap_or(0).min(net_out))
+        } else {
+            ("received", received - sent)
+        };
+        let graph = entry.wallet.tx_graph();
+        let coinbase = tx.is_coinbase();
+        let inputs = tx
+            .input
+            .iter()
+            .map(|txin| {
+                let prev = graph.get_txout(txin.previous_output);
+                BtcxTxDetailInput {
+                    coinbase,
+                    txid: txin.previous_output.txid.to_string(),
+                    vout: txin.previous_output.vout,
+                    sequence: txin.sequence.0,
+                    prev_address: prev
+                        .and_then(|o| super::psbt::spk_to_address(network, &o.script_pubkey)),
+                    prev_value_sat: prev.map(|o| o.value.to_sat()),
+                }
+            })
+            .collect();
+        let outputs = tx
+            .output
+            .iter()
+            .enumerate()
+            .map(|(n, out)| BtcxTxDetailOutput {
+                n: n as u32,
+                address: super::psbt::spk_to_address(network, &out.script_pubkey),
+                op_return: out.script_pubkey.is_op_return(),
+                value_sat: out.value.to_sat(),
+                script_hex: format!("{:x}", out.script_pubkey),
+                script_asm: out.script_pubkey.to_asm_string(),
+            })
+            .collect();
+        Ok(BtcxTxDetail {
+            txid: txid.to_string(),
+            wtxid: tx.compute_wtxid().to_string(),
+            raw_hex: bitcoin::consensus::encode::serialize_hex(&*tx),
+            size: tx.total_size() as u64,
+            vsize: tx.vsize() as u64,
+            weight: tx.weight().to_wu(),
+            version: tx.version.0,
+            locktime: tx.lock_time.to_consensus_u32(),
+            direction: direction.into(),
+            amount_sat,
+            fee_sat: fee,
+            confirmations,
+            timestamp,
+            block_height,
+            block_hash,
+            rbf: tx.is_explicitly_rbf(),
+            inputs,
+            outputs,
+        })
+    })
+}
+
 /// Transaction history, newest first (the activity feed), each entry
 /// carrying the display address derived from its outputs. Optional
 /// `limit`/`offset` slice the feed so the dashboard/transaction pages stay

--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -1836,23 +1836,89 @@ pub fn wallet_transactions_impl(
     offset: Option<usize>,
 ) -> Result<BtcxWalletTxPage, String> {
     let network = state.get_config().network;
-    let infos = state
-        .backend()?
-        .wallet_transactions()
-        .map_err(|e| format!("{e:#}"))?;
-    let total = infos.len();
     state.with_entry(|entry| {
-        Ok(BtcxWalletTxPage {
-            items: infos
-                .into_iter()
-                .skip(offset.unwrap_or(0))
-                .take(limit.unwrap_or(usize::MAX))
-                .map(|info| {
-                    let address = tx_display_address(entry, network, &info);
-                    BtcxWalletTxDto { info, address }
-                })
-                .collect(),
-            total,
+        use bdk_wallet::chain::ChainPosition;
+        let tip = entry.wallet.latest_checkpoint().height();
+
+        // CHEAP pass over the whole history: sort keys only (confirmations +
+        // timestamp) — no amount, fee or address math. The old path computed
+        // sent_and_received AND calculate_fee for EVERY tx ever before
+        // slicing, which made fat wallets take seconds per call.
+        let mut keys: Vec<(bitcoin::Txid, u64, Option<u64>)> = entry
+            .wallet
+            .transactions()
+            .map(|wtx| {
+                let (confirmations, timestamp) = match wtx.chain_position {
+                    ChainPosition::Confirmed { anchor, .. } => (
+                        u64::from((tip + 1).saturating_sub(anchor.block_id.height)),
+                        Some(anchor.confirmation_time),
+                    ),
+                    ChainPosition::Unconfirmed {
+                        first_seen,
+                        last_seen,
+                    } => (0, first_seen.or(last_seen)),
+                };
+                (wtx.tx_node.txid, confirmations, timestamp)
+            })
+            .collect();
+        // The crate's ordering, verbatim: mempool first, then shallow, then
+        // deep; ties by descending time; unbroadcast (no timestamp) first.
+        keys.sort_by_key(|(_, confs, ts)| (*confs, std::cmp::Reverse(ts.unwrap_or(u64::MAX))));
+        let total = keys.len();
+
+        // EXPENSIVE math only for the requested window. Fee is computed for
+        // SEND rows only (it shapes the displayed net amount); receives — the
+        // bulk of a mining wallet — skip prevout resolution entirely. Full
+        // fee detail stays on-demand (detail views), never per list row.
+        let items = keys
+            .into_iter()
+            .skip(offset.unwrap_or(0))
+            .take(limit.unwrap_or(usize::MAX))
+            .filter_map(|(txid, confirmations, timestamp)| {
+                let wtx = entry.wallet.get_tx(txid)?;
+                let tx = wtx.tx_node.tx.clone();
+                let (sent, received) = entry.wallet.sent_and_received(&tx);
+                let (sent, received) = (sent.to_sat(), received.to_sat());
+                let (direction, amount_sat, fee_sat) = if sent > received {
+                    let net_out = sent - received;
+                    let fee = entry.wallet.calculate_fee(&tx).ok().map(|a| a.to_sat());
+                    ("sent", net_out - fee.unwrap_or(0).min(net_out), fee)
+                } else {
+                    ("received", received - sent, None)
+                };
+                let info = WalletTxInfo {
+                    txid: txid.to_string(),
+                    direction: direction.into(),
+                    amount_sat,
+                    fee_sat,
+                    vsize: tx.vsize() as u64,
+                    confirmations,
+                    timestamp,
+                };
+                let address = tx_display_address(entry, network, &info);
+                Some(BtcxWalletTxDto { info, address })
+            })
+            .collect();
+        Ok(BtcxWalletTxPage { items, total })
+    })
+}
+
+/// Near-free change probe for the transaction list: history size + tip.
+/// Callers compare against the last probe and skip refetching the (still
+/// windowed, but not free) transaction list when nothing moved.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BtcxTxProbe {
+    pub total: usize,
+    pub tip: u32,
+}
+
+#[tauri::command]
+pub fn btcx_wallet_tx_probe(state: State<'_, SharedBtcxWalletState>) -> Result<BtcxTxProbe, String> {
+    state.with_entry(|entry| {
+        Ok(BtcxTxProbe {
+            total: entry.wallet.transactions().count(),
+            tip: entry.wallet.latest_checkpoint().height(),
         })
     })
 }

--- a/web-wallet/src-tauri/src/lib.rs
+++ b/web-wallet/src-tauri/src/lib.rs
@@ -1104,6 +1104,7 @@ pub fn run() {
             btcx_wallet::commands::btcx_wallet_balance,
             #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_transactions,
+            btcx_wallet::commands::btcx_wallet_tx_probe,
             #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_send,
             #[cfg(feature = "wallet")]

--- a/web-wallet/src-tauri/src/lib.rs
+++ b/web-wallet/src-tauri/src/lib.rs
@@ -1104,7 +1104,10 @@ pub fn run() {
             btcx_wallet::commands::btcx_wallet_balance,
             #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_transactions,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_tx_probe,
+            #[cfg(feature = "wallet")]
+            btcx_wallet::commands::btcx_wallet_tx_detail,
             #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_send,
             #[cfg(feature = "wallet")]

--- a/web-wallet/src/app/bitcoin/services/wallet/wallet.service.ts
+++ b/web-wallet/src/app/bitcoin/services/wallet/wallet.service.ts
@@ -67,6 +67,8 @@ export class WalletService implements OnDestroy {
   private readonly _recentTransactions = signal<WalletTransaction[]>([]);
   private readonly _activeMultisig = signal<MultisigInfo | null>(null);
   private readonly _activeWatchOnly = signal<boolean>(false);
+  /** Last remote tx probe {total, tip} — reload gate for sync ticks. */
+  private _lastTxProbe: { total: number; tip: number } | null = null;
 
   // Public readonly signals
   readonly balance = this._balance.asReadonly();
@@ -176,14 +178,30 @@ export class WalletService implements OnDestroy {
       this._txCount.set(details.txCount);
       this._activeWatchOnly.set(details.watchOnly);
 
-      // Fetch recent transactions (100 for chart history, sorted newest first)
-      const transactions = await backend.listTransactions(walletName, 100);
-      const recentTxs = [...transactions].sort((a, b) => b.time - a.time);
-      this._recentTransactions.set(recentTxs);
-      this.recentTransactionsSubject.next(recentTxs); // Keep observable in sync
+      // Fetch recent transactions (100 for chart history). In remote mode
+      // this refresh runs on EVERY sync tick — skip the (windowed but not
+      // free) list fetch when the probe says nothing moved.
+      let skipTxFetch = false;
+      if (remote) {
+        try {
+          const probe = await this.btcxWallet.txProbe();
+          skipTxFetch =
+            this._lastTxProbe !== null &&
+            this._lastTxProbe.total === probe.total &&
+            this._lastTxProbe.tip === probe.tip &&
+            this._recentTransactions().length > 0;
+          this._lastTxProbe = probe;
+        } catch {
+          // probe unavailable — fall through to a normal fetch
+        }
+      }
+      if (!skipTxFetch) {
+        const transactions = await backend.listTransactions(walletName, 100);
+        const recentTxs = [...transactions].sort((a, b) => b.time - a.time);
+        this._recentTransactions.set(recentTxs);
+      }
 
       // Update transaction state tracking for notifications
-      this.transactionState.updateTransactions(recentTxs);
 
       this._lastUpdated.set(new Date());
     } catch (error) {

--- a/web-wallet/src/app/core/backend/core-wallet-backend.ts
+++ b/web-wallet/src/app/core/backend/core-wallet-backend.ts
@@ -52,7 +52,11 @@ export class CoreWalletBackend implements WalletBackend {
     count: number,
     skip = 0
   ): Promise<WalletTransaction[]> {
-    return this.walletRpc.listTransactions(walletName, '*', count, skip);
+    // Core's listtransactions returns OLDEST-first; the backend contract
+    // (matching the Electrum/BDK side) is newest-first, so consumers never
+    // re-sort.
+    const txs = await this.walletRpc.listTransactions(walletName, '*', count, skip);
+    return [...txs].sort((a, b) => b.time - a.time);
   }
 
   async getNewAddress(walletName: string, label = '', type?: CoreAddressType): Promise<string> {

--- a/web-wallet/src/app/core/backend/electrum-wallet-backend.ts
+++ b/web-wallet/src/app/core/backend/electrum-wallet-backend.ts
@@ -87,8 +87,9 @@ export class ElectrumWalletBackend implements WalletBackend {
   }
 
   async getWalletDetails(): Promise<WalletBackendDetails> {
-    // limit 0 = count-only: total without items, DTO mapping or IPC bulk.
-    const { total } = await this.btcxWallet.fetchTransactionsPage(0);
+    // Near-free probe — the old limit-0 page call still walked the whole
+    // history on the Rust side just to count it.
+    const { total } = await this.btcxWallet.txProbe();
     return { txCount: total, watchOnly: false };
   }
 

--- a/web-wallet/src/app/core/services/btcx-wallet.service.ts
+++ b/web-wallet/src/app/core/services/btcx-wallet.service.ts
@@ -106,6 +106,48 @@ export interface BtcxWalletTx {
   address: string | null;
 }
 
+/** Wire shape of `btcx_wallet_tx_detail` (camelCase from serde). */
+export interface BtcxTxDetailInput {
+  coinbase: boolean;
+  txid: string;
+  vout: number;
+  sequence: number;
+  /** Prevout data when the wallet's tx graph knows the funding output. */
+  prevAddress: string | null;
+  prevValueSat: number | null;
+}
+
+export interface BtcxTxDetailOutput {
+  n: number;
+  address: string | null;
+  opReturn: boolean;
+  valueSat: number;
+  scriptHex: string;
+  scriptAsm: string;
+}
+
+/** Full on-demand transaction detail from the synced BDK graph. */
+export interface BtcxTxDetail {
+  txid: string;
+  wtxid: string;
+  rawHex: string;
+  size: number;
+  vsize: number;
+  weight: number;
+  version: number;
+  locktime: number;
+  direction: 'sent' | 'received';
+  amountSat: number;
+  feeSat: number | null;
+  confirmations: number;
+  timestamp: number | null;
+  blockHeight: number | null;
+  blockHash: string | null;
+  rbf: boolean;
+  inputs: BtcxTxDetailInput[];
+  outputs: BtcxTxDetailOutput[];
+}
+
 /** Fee estimates in decimal sat/vB (`btcx_wallet_fee_estimates`). */
 export interface BtcxFeeEstimates {
   /** Coin feerate floor (the custom field's minimum/default). */
@@ -1006,6 +1048,13 @@ export class BtcxWalletService {
    *  last probe and skip refetching the list when nothing moved. */
   async txProbe(): Promise<{ total: number; tip: number }> {
     return invoke<{ total: number; tip: number }>('btcx_wallet_tx_probe');
+  }
+
+  /** On-demand full detail for one tx (in/outputs, sizes, raw hex, block),
+   *  served from the synced BDK graph — the remote-mode stand-in for Core's
+   *  gettransaction + verbose getrawtransaction. */
+  async txDetail(txid: string): Promise<BtcxTxDetail> {
+    return invoke<BtcxTxDetail>('btcx_wallet_tx_detail', { txid });
   }
 
   async fetchTransactionsPage(

--- a/web-wallet/src/app/core/services/btcx-wallet.service.ts
+++ b/web-wallet/src/app/core/services/btcx-wallet.service.ts
@@ -1002,6 +1002,12 @@ export class BtcxWalletService {
    * `limit: 0` is a cheap count-only query (no items, no per-item work).
    * Both absent = the full history. Throws on failure.
    */
+  /** Near-free change probe: history size + tip. Callers compare with the
+   *  last probe and skip refetching the list when nothing moved. */
+  async txProbe(): Promise<{ total: number; tip: number }> {
+    return invoke<{ total: number; tip: number }>('btcx_wallet_tx_probe');
+  }
+
   async fetchTransactionsPage(
     limit?: number,
     offset?: number

--- a/web-wallet/src/app/features/blocks/pages/block-details/block-details.component.ts
+++ b/web-wallet/src/app/features/blocks/pages/block-details/block-details.component.ts
@@ -253,10 +253,14 @@ import { BlocksCacheService } from '../../services/blocks-cache.service';
         background: #f5f5f5;
       }
 
+      /* Gradient band on the shared balance-band token (app-wide header
+         height scheme). */
       .header {
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
-        padding: 16px 24px;
+        min-height: var(--menu-balance-h);
+        box-sizing: border-box;
+        padding: 0 24px;
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -269,7 +273,7 @@ import { BlocksCacheService } from '../../services/blocks-cache.service';
 
         h1 {
           margin: 0;
-          font-size: 24px;
+          font-size: 20px;
           font-weight: 300;
         }
 

--- a/web-wallet/src/app/features/blocks/pages/block-list/block-list.component.ts
+++ b/web-wallet/src/app/features/blocks/pages/block-list/block-list.component.ts
@@ -175,10 +175,14 @@ import { PocxBlock, BLOCK_COUNT_OPTIONS } from '../../models/block.model';
         background: #eaf0f6;
       }
 
+      /* Gradient band on the shared balance-band token (app-wide header
+         height scheme). */
       .header {
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
-        padding: 16px 24px;
+        min-height: var(--menu-balance-h);
+        box-sizing: border-box;
+        padding: 0 24px;
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -191,7 +195,7 @@ import { PocxBlock, BLOCK_COUNT_OPTIONS } from '../../models/block.model';
 
         h1 {
           margin: 0;
-          font-size: 24px;
+          font-size: 20px;
           font-weight: 300;
         }
 

--- a/web-wallet/src/app/features/blocks/pages/transaction-details/transaction-details.component.ts
+++ b/web-wallet/src/app/features/blocks/pages/transaction-details/transaction-details.component.ts
@@ -245,10 +245,14 @@ import {
         background: #f5f5f5;
       }
 
+      /* Gradient band on the shared balance-band token (app-wide header
+         height scheme). */
       .header {
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
-        padding: 16px 24px;
+        min-height: var(--menu-balance-h);
+        box-sizing: border-box;
+        padding: 0 24px;
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -261,7 +265,7 @@ import {
 
         h1 {
           margin: 0;
-          font-size: 24px;
+          font-size: 20px;
           font-weight: 300;
         }
 

--- a/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -1791,13 +1791,7 @@ export class DashboardComponent implements AfterViewInit {
   // Actions — all navigation goes through pageRoute() so the SAME component
   // links correctly under both shells (desktop `/x` vs nodeless `/wallet/x`).
   viewTransactionDetails(tx: WalletTransaction): void {
-    // Details are a Core-RPC feature — in Electrum/remote mode (any shell)
-    // the destination is the transactions/history LIST instead.
-    if (this.isRemote()) {
-      this.router.navigate([this.appMode.pageRoute('/transactions')]);
-      return;
-    }
-    this.router.navigate(['/transactions', tx.txid]);
+    this.router.navigate([this.appMode.pageRoute('/transactions'), tx.txid]);
   }
 
   copyToClipboard(text: string): void {

--- a/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
+++ b/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
@@ -306,7 +306,8 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
                   mat-raised-button
                   color="primary"
                   class="full-width action-button"
-                  [disabled]="!forgingValid() || busy()"
+                  [disabled]="!forgingValid() || busy() || watchOnly()"
+                  [matTooltip]="watchOnly() ? ('watch_only' | i18n) : ''"
                   (click)="create()"
                 >
                   @if (busy()) {
@@ -326,7 +327,8 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
                 <button
                   mat-stroked-button
                   class="full-width action-button revoke-button"
-                  [disabled]="busy()"
+                  [disabled]="busy() || watchOnly()"
+                  [matTooltip]="watchOnly() ? ('watch_only' | i18n) : ''"
                   (click)="revoke()"
                 >
                   @if (busy()) {
@@ -818,6 +820,10 @@ export class ForgingAssignmentComponent implements OnInit, OnDestroy {
   readonly wallet = inject(BtcxWalletService);
   private readonly walletManager = inject(WalletManagerService);
   private readonly walletService = inject(WalletService);
+
+  /** Watch-only Core wallet: no private keys, so create/revoke are disabled
+   *  (send is nav-hidden for these wallets; assignment stays viewable). */
+  readonly watchOnly = computed(() => this.walletService.activeWatchOnly());
   private readonly walletRpc = inject(WalletRpcService);
   private readonly blockchainRpc = inject(BlockchainRpcService);
   private readonly miningRpc = inject(MiningRpcService);
@@ -959,10 +965,18 @@ export class ForgingAssignmentComponent implements OnInit, OnDestroy {
     try {
       let addresses: string[];
       if (this.isRemote()) {
-        // Funded wallet addresses — non-change first, then change, deduped.
+        // Funded wallet addresses — non-change first, then change, deduped;
+        // the current receive address leads regardless of funding (a fresh
+        // wallet always has something to select).
         const utxos = await this.wallet.utxos();
         const sorted = [...utxos].sort((a, b) => Number(a.isChange) - Number(b.isChange));
         addresses = [];
+        try {
+          const current = await this.wallet.currentAddress();
+          if (current) addresses.push(current);
+        } catch {
+          // no current address (e.g. spend-only) — funded list only
+        }
         for (const utxo of sorted) {
           if (utxo.address && !addresses.includes(utxo.address)) {
             addresses.push(utxo.address);
@@ -971,13 +985,49 @@ export class ForgingAssignmentComponent implements OnInit, OnDestroy {
       } else {
         const walletName = this.walletManager.activeWallet;
         if (!walletName) return;
-        // Receiving addresses (empty label), SegWit v0 only — bech32
-        // starting with bc1q/tb1q or pocx1q/tpocx1q (the node's assignment
-        // RPCs reject everything else).
-        const addressMap = await this.walletRpc.getAddressesByLabel(walletName, '');
-        addresses = Object.keys(addressMap).filter(address =>
-          /^(bc1q|tb1q|pocx1q|tpocx1q)[a-z0-9]{38,}$/i.test(address)
-        );
+        // FUNDED addresses via listunspent — matching the remote path's
+        // semantics (the plot address must hold a coin anyway) and, unlike
+        // the address book, rescan-discovered funds of a REIMPORTED
+        // descriptor wallet show up here. SegWit v0 only — the node's
+        // assignment RPCs reject everything else.
+        const utxos = await this.walletRpc.listUnspent(walletName);
+        const seen = new Set<string>();
+        addresses = [];
+        // The FIRST derivation of every external receive chain leads the
+        // list regardless of funding (plots typically bind to it; a fresh
+        // wallet always has something to select) — active current-coin-type
+        // chain first, then legacy restore chains.
+        try {
+          const { descriptors } = await this.walletRpc.listDescriptors(walletName);
+          const sorted = [...descriptors].sort(
+            (a, b) => Number(b.active ?? false) - Number(a.active ?? false)
+          );
+          for (const d of sorted) {
+            if (d.internal || !d.desc.startsWith('wpkh(')) continue;
+            const derived = await this.walletRpc.deriveAddresses(d.desc, [0, 0]);
+            const first = derived[0];
+            if (
+              first &&
+              !seen.has(first) &&
+              /^(bc1q|tb1q|pocx1q|tpocx1q)[a-z0-9]{38,}$/i.test(first)
+            ) {
+              seen.add(first);
+              addresses.push(first);
+            }
+          }
+        } catch {
+          // pre-descriptor wallet — funded list below is all there is
+        }
+        for (const utxo of utxos) {
+          if (
+            utxo.address &&
+            !seen.has(utxo.address) &&
+            /^(bc1q|tb1q|pocx1q|tpocx1q)[a-z0-9]{38,}$/i.test(utxo.address)
+          ) {
+            seen.add(utxo.address);
+            addresses.push(utxo.address);
+          }
+        }
       }
       this.walletAddresses.set(addresses);
       if (!this.plotAddress && addresses.length > 0) {

--- a/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
+++ b/web-wallet/src/app/features/forging-assignment/pages/forging-assignment/forging-assignment.component.ts
@@ -453,12 +453,15 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
         width: 100%;
       }
 
+      /* Desktop rhythm — matches the send page's label/field spacing: the
+         field keeps a little subscript air and sections separate clearly.
+         The phone tier re-compresses below. */
       .slim-field {
-        margin-bottom: -8px;
+        margin-bottom: 0;
       }
 
       .section-divider {
-        margin: 12px 0;
+        margin: 18px 0;
       }
 
       /* Send-page section label (uppercase mini-header above the input
@@ -469,7 +472,7 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
         color: rgb(0, 35, 65);
         text-transform: uppercase;
         letter-spacing: 0.5px;
-        margin: 0 0 4px;
+        margin: 4px 0 8px;
       }
 
       .hint-text {
@@ -787,6 +790,15 @@ const ASSIGNMENT_PREVIEW_VSIZE_VB = 170;
 
         .section-label {
           display: none;
+        }
+
+        /* Phone re-compresses to the exact mobile rhythm. */
+        .slim-field {
+          margin-bottom: -8px;
+        }
+
+        .section-divider {
+          margin: 12px 0;
         }
 
         .fee-header .fee-title {

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1367,7 +1367,7 @@ export class MobileWalletLayoutComponent implements OnInit {
           // Mining dashboard in the menu whenever this build/mode actually
           // mines (hybrid mobile) — same destination as the bottom tab.
           ...(this.appMode.miningEnabled()
-            ? [{ path: '/miner/dashboard', icon: 'memory', labelKey: 'mining_dashboard' }]
+            ? [{ path: '/wallet/mining', icon: 'memory', labelKey: 'mining_dashboard' }]
             : []),
           { path: '/wallet/assignment', icon: 'swap_horiz', labelKey: 'forging_assignment' },
         ],

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1363,7 +1363,14 @@ export class MobileWalletLayoutComponent implements OnInit {
       groups.push({
         id: 'mining',
         titleKey: 'mining',
-        items: [{ path: '/wallet/assignment', icon: 'swap_horiz', labelKey: 'forging_assignment' }],
+        items: [
+          // Mining dashboard in the menu whenever this build/mode actually
+          // mines (hybrid mobile) — same destination as the bottom tab.
+          ...(this.appMode.miningEnabled()
+            ? [{ path: '/miner/dashboard', icon: 'memory', labelKey: 'mining_dashboard' }]
+            : []),
+          { path: '/wallet/assignment', icon: 'swap_horiz', labelKey: 'forging_assignment' },
+        ],
       });
     }
 

--- a/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
+++ b/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
@@ -71,6 +71,13 @@ export const MOBILE_WALLET_ROUTES: Routes = [
           ),
       },
       {
+        path: 'history/:txid',
+        loadComponent: () =>
+          import(
+            '../../features/transactions/pages/transaction-detail/transaction-detail.component'
+          ).then(m => m.TransactionDetailComponent),
+      },
+      {
         // Unified responsive coins/balance-details page — the same component
         // the desktop /coins route uses (features/coins).
         path: 'coins',

--- a/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
+++ b/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
@@ -107,6 +107,17 @@ export const MOBILE_WALLET_ROUTES: Routes = [
           import('../../features/psbt/pages/psbt/psbt.component').then(m => m.PsbtComponent),
       },
       {
+        // Mining dashboard IN the wallet shell (drawer + toolbar) for the
+        // hybrid flavors — the bare /miner mining-layout stays for
+        // mining-only mode. Wallet-only has no mining commands.
+        path: 'mining',
+        canActivate: [notWalletOnlyGuard],
+        loadComponent: () =>
+          import('../../mining/pages/mining-dashboard/mining-dashboard.component').then(
+            m => m.MiningDashboardComponent
+          ),
+      },
+      {
         path: 'settings',
         loadComponent: () =>
           import('./pages/settings/wallet-settings.component').then(m => m.WalletSettingsComponent),

--- a/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
+++ b/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
@@ -73,9 +73,9 @@ export const MOBILE_WALLET_ROUTES: Routes = [
       {
         path: 'history/:txid',
         loadComponent: () =>
-          import(
-            '../../features/transactions/pages/transaction-detail/transaction-detail.component'
-          ).then(m => m.TransactionDetailComponent),
+          import('../../features/transactions/pages/transaction-detail/transaction-detail.component').then(
+            m => m.TransactionDetailComponent
+          ),
       },
       {
         // Unified responsive coins/balance-details page — the same component

--- a/web-wallet/src/app/features/peers/pages/peers/peers.component.ts
+++ b/web-wallet/src/app/features/peers/pages/peers/peers.component.ts
@@ -194,17 +194,21 @@ type PeerRow = PeerInfo & { versionClass: string };
         min-height: 100%;
       }
 
+      /* Gradient band on the shared balance-band token (app-wide header
+         height scheme). */
       .header {
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
-        padding: 16px 24px;
+        min-height: var(--menu-balance-h);
+        box-sizing: border-box;
+        padding: 0 24px;
         display: flex;
         justify-content: space-between;
         align-items: center;
 
         h1 {
           margin: 0;
-          font-size: 24px;
+          font-size: 20px;
           font-weight: 300;
         }
 

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -92,14 +92,6 @@ interface AddressInfo {
                   </mat-option>
                 }
               </mat-select>
-              <button
-                mat-icon-button
-                matSuffix
-                (click)="copyAddress(); $event.stopPropagation()"
-                [matTooltip]="'copy' | i18n"
-              >
-                <mat-icon>content_copy</mat-icon>
-              </button>
             </mat-form-field>
 
             <!-- 2. Amount / 3. Label (feed the URI/QR) -->
@@ -139,6 +131,18 @@ interface AddressInfo {
                   [colorDark]="'#1E3A5F'"
                   [colorLight]="'#FFFFFF'"
                 ></qrcode>
+              </div>
+
+              <div class="info-row">
+                <span class="info-label">{{ 'address' | i18n }}:</span>
+                <div
+                  class="info-value-row copyable"
+                  (click)="copyAddress()"
+                  [matTooltip]="'copy' | i18n"
+                >
+                  <span class="address-value">{{ selectedAddress() }}</span>
+                  <mat-icon class="copy-icon">content_copy</mat-icon>
+                </div>
               </div>
 
               <!-- 5. Payment URI -->
@@ -269,6 +273,9 @@ interface AddressInfo {
 
       .full-width {
         width: 100%;
+        /* The subscript wrapper is hidden (compact fields) — restore the
+           stack gap explicitly so fields don't glue together. */
+        margin-bottom: 12px;
       }
 
       .loading-inline {

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -8,6 +8,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSelectModule } from '@angular/material/select';
 import { QRCodeComponent } from 'angularx-qrcode';
 import { Subject } from 'rxjs';
 import { takeUntil, skip } from 'rxjs/operators';
@@ -18,6 +19,15 @@ import { buildPaymentUri } from '../../../../bitcoin/utils/payment-uri';
 import { NodeService } from '../../../../node/services/node.service';
 import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
 import { BackendRouterService } from '../../../../core/backend/backend-router.service';
+import { WalletRpcService } from '../../../../bitcoin/services/rpc/wallet-rpc.service';
+
+interface AddressInfo {
+  address: string;
+  purpose: string;
+  isUsed: boolean;
+  txCount: number;
+  label: string;
+}
 
 /**
  * ReceiveComponent - Compact, mobile-style receive page (same design at
@@ -37,6 +47,7 @@ import { BackendRouterService } from '../../../../core/backend/backend-router.se
     MatInputModule,
     MatProgressSpinnerModule,
     MatTooltipModule,
+    MatSelectModule,
     QRCodeComponent,
     I18nPipe,
   ],
@@ -63,8 +74,61 @@ import { BackendRouterService } from '../../../../core/backend/backend-router.se
               <mat-icon class="spend-only-icon">block</mat-icon>
               <span>{{ 'mwallet_receive_v30_blocked' | i18n }}</span>
             </div>
-          } @else if (currentAddress()) {
-            <!-- QR + copy rows for the current first-unused address -->
+          } @else if (selectedAddress()) {
+            <!-- 1. Address selector: latest virgin preselected; Core mode
+                 lists the full revealed history, remote lists what the seam
+                 knows (current + freshly generated). Copy via the suffix. -->
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>{{ 'select_address' | i18n }}</mat-label>
+              <mat-select
+                [ngModel]="selectedAddress()"
+                (ngModelChange)="selectedAddress.set($event)"
+              >
+                @for (addr of existingAddresses(); track addr.address) {
+                  <mat-option [value]="addr.address">
+                    <span class="address-option"
+                      >{{ addr.address }}{{ getAddressDisplayLabel(addr) }}</span
+                    >
+                  </mat-option>
+                }
+              </mat-select>
+              <button
+                mat-icon-button
+                matSuffix
+                (click)="copyAddress(); $event.stopPropagation()"
+                [matTooltip]="'copy' | i18n"
+              >
+                <mat-icon>content_copy</mat-icon>
+              </button>
+            </mat-form-field>
+
+            <!-- 2. Amount / 3. Label (feed the URI/QR) -->
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>{{ 'amount_optional' | i18n }}</mat-label>
+              <input
+                matInput
+                type="number"
+                [(ngModel)]="amount"
+                placeholder="0.00000000"
+                step="0.00000001"
+                min="0"
+                autocomplete="off"
+              />
+              <span matTextSuffix>BTCX</span>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>{{ 'label_optional' | i18n }}</mat-label>
+              <input
+                matInput
+                [(ngModel)]="label"
+                [placeholder]="'label_placeholder' | i18n"
+                maxlength="50"
+                autocomplete="off"
+              />
+            </mat-form-field>
+
+            <!-- 4. QR -->
             <div class="qr-section">
               <div class="qr-code-container">
                 <qrcode
@@ -77,18 +141,7 @@ import { BackendRouterService } from '../../../../core/backend/backend-router.se
                 ></qrcode>
               </div>
 
-              <div class="info-row">
-                <span class="info-label">{{ 'address' | i18n }}:</span>
-                <div
-                  class="info-value-row copyable"
-                  (click)="copyAddress()"
-                  [matTooltip]="'copy' | i18n"
-                >
-                  <span class="address-value">{{ currentAddress() }}</span>
-                  <mat-icon class="copy-icon">content_copy</mat-icon>
-                </div>
-              </div>
-
+              <!-- 5. Payment URI -->
               <div class="info-row">
                 <span class="info-label">{{ 'payment_uri' | i18n }}:</span>
                 <div
@@ -102,6 +155,7 @@ import { BackendRouterService } from '../../../../core/backend/backend-router.se
               </div>
             </div>
 
+            <!-- 6. Generate new address -->
             @if (singleAddress()) {
               <!-- Remote single-address (wpkh-WIF) wallet: ONE fixed address,
                    nothing to generate — the button collapses to a hint. -->
@@ -122,38 +176,6 @@ import { BackendRouterService } from '../../../../core/backend/backend-router.se
                 </button>
               </div>
             }
-
-            <!-- Optional amount + label (feed the URI/QR) — visually secondary -->
-            <div class="optional-fields">
-              <div class="form-section">
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'amount_optional' | i18n }}</mat-label>
-                  <input
-                    matInput
-                    type="number"
-                    [(ngModel)]="amount"
-                    placeholder="0.00000000"
-                    step="0.00000001"
-                    min="0"
-                    autocomplete="off"
-                  />
-                  <span matTextSuffix>BTCX</span>
-                </mat-form-field>
-              </div>
-
-              <div class="form-section">
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'label_optional' | i18n }}</mat-label>
-                  <input
-                    matInput
-                    [(ngModel)]="label"
-                    [placeholder]="'label_placeholder' | i18n"
-                    maxlength="50"
-                    autocomplete="off"
-                  />
-                </mat-form-field>
-              </div>
-            </div>
           } @else if (loadError()) {
             <!-- The old mobile receive's failed-state with retry. -->
             <div class="no-address">
@@ -287,6 +309,11 @@ import { BackendRouterService } from '../../../../core/backend/backend-router.se
       }
 
       /* QR Section */
+      .address-option {
+        font-family: monospace;
+        font-size: 12px;
+      }
+
       .qr-section {
         text-align: center;
         padding-top: 4px;
@@ -492,6 +519,11 @@ import { BackendRouterService } from '../../../../core/backend/backend-router.se
           margin-bottom: 8px;
         }
 
+        .address-option {
+          font-family: monospace;
+          font-size: 12px;
+        }
+
         .qr-section {
           padding-top: 2px;
         }
@@ -511,7 +543,15 @@ export class ReceiveComponent implements OnInit, OnDestroy {
   private readonly nodeService = inject(NodeService);
   private readonly btcxWallet = inject(BtcxWalletService);
   private readonly backendRouter = inject(BackendRouterService);
+  private readonly walletRpc = inject(WalletRpcService);
   private readonly destroy$ = new Subject<void>();
+
+  /**
+   * Whether the current backend can enumerate the wallet's revealed
+   * addresses (Core RPC). Remote/BDK lists only what the seam hands out
+   * (current first-unused + freshly generated this session).
+   */
+  readonly canEnumerate = computed(() => !this.backendRouter.isRemote());
 
   /**
    * Remote (Electrum) mode + a legacy v30 (coin-0') pocket = spend-only:
@@ -534,15 +574,16 @@ export class ReceiveComponent implements OnInit, OnDestroy {
   /** Address load failed (e.g. wallet runtime briefly closed) — offer retry. */
   readonly loadError = signal(false);
 
-  /** The shown receive address: latest virgin (first-unused) by default. */
-  readonly currentAddress = signal('');
+  /** The SELECTED address (latest virgin preselected; history selectable). */
+  readonly selectedAddress = signal('');
+  readonly existingAddresses = signal<AddressInfo[]>([]);
   readonly isGenerating = signal(false);
   amount: number | null = null;
   label = '';
 
   paymentUri(): string {
     return buildPaymentUri({
-      address: this.currentAddress(),
+      address: this.selectedAddress(),
       amount: this.amount,
       label: this.label,
     });
@@ -558,7 +599,8 @@ export class ReceiveComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(() => {
-        this.currentAddress.set('');
+        this.selectedAddress.set('');
+        this.existingAddresses.set([]);
         this.loadError.set(false);
         if (!this.spendOnly()) {
           this.loadReceiveAddress();
@@ -592,8 +634,9 @@ export class ReceiveComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Show the first VIRGIN (never-received) address via the backend seam —
-   * identical in Core and remote modes (`currentReceiveAddress`).
+   * Load the selector: the first VIRGIN (never-received) address is fetched
+   * via the seam and PRESELECTED; Core mode additionally enumerates the
+   * revealed history so older addresses stay reachable.
    */
   async loadReceiveAddress(): Promise<void> {
     if (this.spendOnly()) return;
@@ -603,12 +646,90 @@ export class ReceiveComponent implements OnInit, OnDestroy {
     this.loadError.set(false);
     try {
       const current = await this.backendRouter.wallet().currentReceiveAddress(walletName);
-      this.currentAddress.set(current);
+      if (this.canEnumerate()) {
+        await this.loadExistingAddressList(walletName, current);
+      } else {
+        this.existingAddresses.set(
+          current
+            ? [{ address: current, purpose: 'receive', isUsed: false, txCount: 0, label: '' }]
+            : []
+        );
+      }
+      this.selectedAddress.set(current);
     } catch (error) {
       console.error('Failed to load address:', error);
       // Only surface the retry state when nothing usable is on screen.
-      if (!this.currentAddress()) this.loadError.set(true);
+      if (!this.selectedAddress()) this.loadError.set(true);
     }
+  }
+
+  /**
+   * Build the Core existing-address list. isUsed reflects REAL on-chain
+   * usage (received sats / txids from listreceivedbyaddress); ensure
+   * guarantees the current first-unused is present so the selected value
+   * always has a matching option.
+   */
+  private async loadExistingAddressList(walletName: string, ensure?: string): Promise<void> {
+    const addressMap = await this.walletRpc.getAddressesByLabel(walletName, '');
+
+    const usage = new Map<string, { used: boolean; label: string }>();
+    try {
+      const received = await this.walletRpc.listReceivedByAddress(walletName, 0, true);
+      for (const r of received) {
+        usage.set(r.address, {
+          used: Math.round(r.amount * 1e8) > 0 || r.txids.length > 0,
+          label: r.label ?? '',
+        });
+      }
+    } catch {
+      // best-effort — used/label fall back to defaults below.
+    }
+
+    const addresses: AddressInfo[] = [];
+    for (const [address, info] of Object.entries(addressMap)) {
+      if (!this.isBech32Address(address)) continue;
+      const u = usage.get(address);
+      addresses.push({
+        address,
+        purpose: (info as { purpose?: string }).purpose || 'receive',
+        isUsed: u?.used ?? false,
+        txCount: 0,
+        label: u?.label ?? '',
+      });
+    }
+
+    if (ensure && !addresses.some(a => a.address === ensure)) {
+      addresses.unshift({
+        address: ensure,
+        purpose: 'receive',
+        isUsed: false,
+        txCount: 0,
+        label: '',
+      });
+    }
+
+    this.existingAddresses.set(addresses);
+  }
+
+  /** A bech32(m) address for the PoCX networks (not legacy/script). */
+  private isBech32Address(address: string): boolean {
+    const lower = address.toLowerCase();
+    return (
+      lower.startsWith('pocx1') ||
+      lower.startsWith('tpocx1') ||
+      lower.startsWith('rpocx1') ||
+      lower.startsWith('bc1') ||
+      lower.startsWith('tb1') ||
+      lower.startsWith('bcrt1')
+    );
+  }
+
+  /** Selector suffix: label + never-used hint, matching the old dropdown. */
+  getAddressDisplayLabel(addr: AddressInfo): string {
+    const parts: string[] = [];
+    if (addr.label) parts.push(addr.label);
+    if (addr.purpose === 'receive' && !addr.isUsed) parts.push('never used');
+    return parts.length > 0 ? ' (' + parts.join(' - ') + ')' : '';
   }
 
   async generateNewAddress(): Promise<void> {
@@ -621,7 +742,16 @@ export class ReceiveComponent implements OnInit, OnDestroy {
       const address = await this.backendRouter
         .wallet()
         .getNewAddress(walletName, this.label || '', 'bech32');
-      this.currentAddress.set(address);
+      if (this.canEnumerate()) {
+        // Core: refresh the list so the freshly revealed address shows.
+        await this.loadExistingAddressList(walletName, address);
+      } else {
+        this.existingAddresses.update(list => [
+          { address, purpose: 'receive', isUsed: false, txCount: 0, label: '' },
+          ...list,
+        ]);
+      }
+      this.selectedAddress.set(address);
     } catch (error) {
       console.error('Failed to generate address:', error);
       this.notification.error('error_generating_address');
@@ -631,7 +761,7 @@ export class ReceiveComponent implements OnInit, OnDestroy {
   }
 
   async copyAddress(): Promise<void> {
-    const address = this.currentAddress();
+    const address = this.selectedAddress();
     if (address) await this.clipboard.copyAddress(address);
   }
 

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -27,6 +27,8 @@ interface AddressInfo {
   isUsed: boolean;
   txCount: number;
   label: string;
+  /** Address of a retired legacy (v30 / coin-0) chain. */
+  isLegacy?: boolean;
 }
 
 /**
@@ -84,6 +86,11 @@ interface AddressInfo {
                 [ngModel]="selectedAddress()"
                 (ngModelChange)="selectedAddress.set($event)"
               >
+                <!-- Closed trigger shows ONLY the address — the (label /
+                     never used) suffix belongs to the open panel rows. -->
+                <mat-select-trigger>
+                  <span class="address-option">{{ selectedAddress() }}</span>
+                </mat-select-trigger>
                 @for (addr of existingAddresses(); track addr.address) {
                   <mat-option [value]="addr.address">
                     <span class="address-option"
@@ -684,7 +691,14 @@ export class ReceiveComponent implements OnInit, OnDestroy {
    * always has a matching option.
    */
   private async loadExistingAddressList(walletName: string, ensure?: string): Promise<void> {
-    const addressMap = await this.walletRpc.getAddressesByLabel(walletName, '');
+    let bookAddresses: string[] = [];
+    try {
+      const addressMap = await this.walletRpc.getAddressesByLabel(walletName, '');
+      bookAddresses = Object.keys(addressMap);
+    } catch {
+      // A freshly reimported wallet may have an EMPTY address book — Core
+      // errors on an unknown label. The descriptor path below still works.
+    }
 
     const usage = new Map<string, { used: boolean; label: string }>();
     try {
@@ -698,17 +712,77 @@ export class ReceiveComponent implements OnInit, OnDestroy {
     } catch {
       // best-effort — used/label fall back to defaults below.
     }
+    // listreceivedbyaddress is ADDRESS-BOOK-bound — on a reimported
+    // descriptor wallet the book is empty, so FUNDED addresses are the
+    // reliable usage signal (a mining wallet's whole history is here).
+    try {
+      const unspent = await this.walletRpc.listUnspent(walletName);
+      for (const u of unspent) {
+        if (!u.address) continue;
+        const entry = usage.get(u.address);
+        if (entry) entry.used = true;
+        else usage.set(u.address, { used: true, label: '' });
+      }
+    } catch {
+      // best-effort
+    }
+
+    // Seed from the wallet's own DESCRIPTORS, not just Core's address book:
+    // a reimported descriptor wallet knows its chains even though no
+    // addresses were ever handed out via getnewaddress here.
+    // - ACTIVE external chains (current coin type): derive the issued
+    //   range 0..next-1.
+    // - INACTIVE external chains (the legacy coin-0 sets a restore imports
+    //   watch-only): they issue nothing, so derive their imported range
+    //   (capped) and keep only addresses with REAL usage — the wallet's
+    //   past addresses.
+    const derived = new Set<string>(bookAddresses);
+    const legacy = new Set<string>();
+    try {
+      const { descriptors } = await this.walletRpc.listDescriptors(walletName);
+      for (const d of descriptors) {
+        if (d.internal) continue; // explicit change chains out
+        if (!d.desc.startsWith('wpkh(')) continue; // bech32 receive chains only
+        // Core tracks the issued range (next) even for INACTIVE imported
+        // legacy chains — those addresses were handed out at some point, so
+        // include them all. Beyond that, scan the (capped) imported range
+        // and keep only addresses with real usage (funded — the book is
+        // empty right after a reimport). NOTE: legacy imports carry no
+        // internal flag, so their change chain is scanned too — its used
+        // addresses are legitimate history.
+        const next = d.next ?? 0;
+        const start = d.range?.[0] ?? 0;
+        const end = Math.min(d.range?.[1] ?? next - 1, start + 299);
+        if (end < start && next <= 0) continue;
+        const scanEnd = Math.max(end, next - 1);
+        if (scanEnd < start) continue;
+        const addrs = await this.walletRpc.deriveAddresses(d.desc, [start, scanEnd]);
+        addrs.forEach((a, i) => {
+          const index = start + i;
+          // ACTIVE chain: every issued address (incl. the current virgin).
+          // INACTIVE legacy chains: USED addresses only — never offer a
+          // never-used legacy address for receiving (the retired chain).
+          if ((d.active && index < next) || usage.get(a)?.used) {
+            derived.add(a);
+            if (!d.active) legacy.add(a);
+          }
+        });
+      }
+    } catch {
+      // Pre-descriptor wallet — the address book is all there is.
+    }
 
     const addresses: AddressInfo[] = [];
-    for (const [address, info] of Object.entries(addressMap)) {
+    for (const address of derived) {
       if (!this.isBech32Address(address)) continue;
       const u = usage.get(address);
       addresses.push({
         address,
-        purpose: (info as { purpose?: string }).purpose || 'receive',
+        purpose: 'receive',
         isUsed: u?.used ?? false,
         txCount: 0,
         label: u?.label ?? '',
+        isLegacy: legacy.has(address),
       });
     }
 
@@ -742,6 +816,7 @@ export class ReceiveComponent implements OnInit, OnDestroy {
   getAddressDisplayLabel(addr: AddressInfo): string {
     const parts: string[] = [];
     if (addr.label) parts.push(addr.label);
+    if (addr.isLegacy) parts.push('v30');
     if (addr.purpose === 'receive' && !addr.isUsed) parts.push('never used');
     return parts.length > 0 ? ' (' + parts.join(' - ') + ')' : '';
   }

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -94,8 +94,9 @@ interface AddressInfo {
               </mat-select>
             </mat-form-field>
 
-            <!-- 2. Amount / 3. Label (feed the URI/QR) -->
-            <mat-form-field appearance="outline" class="full-width">
+            <!-- 2. Amount / 3. Label (feed the URI/QR) — desktop only; the
+                 phone tier hides them to keep the page on one screen. -->
+            <mat-form-field appearance="outline" class="full-width optional-field">
               <mat-label>{{ 'amount_optional' | i18n }}</mat-label>
               <input
                 matInput
@@ -109,7 +110,7 @@ interface AddressInfo {
               <span matTextSuffix>BTCX</span>
             </mat-form-field>
 
-            <mat-form-field appearance="outline" class="full-width">
+            <mat-form-field appearance="outline" class="full-width optional-field">
               <mat-label>{{ 'label_optional' | i18n }}</mat-label>
               <input
                 matInput
@@ -510,6 +511,12 @@ interface AddressInfo {
       @include bp.phone {
         .header {
           padding: 0 16px;
+        }
+
+        /* Phone: no amount/label — the page stays on one screen; the URI
+           falls back to the plain address. */
+        .optional-field {
+          display: none;
         }
 
         /* Compact phone rhythm: tighter page/card padding + section spacing. */

--- a/web-wallet/src/app/features/send/pages/send/send.component.ts
+++ b/web-wallet/src/app/features/send/pages/send/send.component.ts
@@ -766,24 +766,24 @@ const SANE_PRESET_MAX_SAT_VB = 200;
         }
       }
 
+      /* Exactly the forging-assignment fee-summary treatment: a plain
+         unboxed row — muted label left, tabular value right. */
       .fee-summary {
         display: flex;
         justify-content: space-between;
-        padding: 6px 10px;
-        background: #f5f7fa;
-        border-radius: 4px;
+        gap: 12px;
+        font-size: 12px;
+        margin-top: 10px;
         margin-bottom: 14px;
 
         .fee-label {
-          color: #666;
-          font-size: 13px;
+          color: rgba(0, 0, 0, 0.6);
+          flex-shrink: 0;
         }
 
         .fee-value {
-          font-family: monospace;
-          font-weight: 500;
-          font-size: 13px;
-          color: rgb(0, 35, 65);
+          text-align: right;
+          font-variant-numeric: tabular-nums;
         }
       }
 
@@ -996,9 +996,12 @@ const SANE_PRESET_MAX_SAT_VB = 200;
           border-bottom-color: #555 !important;
         }
 
-        .fee-summary,
         .summary-section {
           background: #333;
+        }
+
+        .fee-summary .fee-label {
+          color: rgba(255, 255, 255, 0.6);
         }
 
         .option-row {

--- a/web-wallet/src/app/features/send/pages/send/send.component.ts
+++ b/web-wallet/src/app/features/send/pages/send/send.component.ts
@@ -283,15 +283,6 @@ const SANE_PRESET_MAX_SAT_VB = 200;
                   </mat-form-field>
                 </div>
               }
-
-              <div class="fee-summary">
-                <span class="fee-label">{{ 'estimated_fee' | i18n }}:</span>
-                <span class="fee-value">
-                  {{ selectedFeeOption?.estimatedFee ?? 0 | number: '1.8-8' }}
-                  {{ currencySymbol() }} ({{ getEstimatedFeeSats() | number: '1.0-0' }}
-                  sats)
-                </span>
-              </div>
             </div>
 
             <!-- Options Section -->
@@ -766,27 +757,6 @@ const SANE_PRESET_MAX_SAT_VB = 200;
         }
       }
 
-      /* Exactly the forging-assignment fee-summary treatment: a plain
-         unboxed row — muted label left, tabular value right. */
-      .fee-summary {
-        display: flex;
-        justify-content: space-between;
-        gap: 12px;
-        font-size: 12px;
-        margin-top: 10px;
-        margin-bottom: 14px;
-
-        .fee-label {
-          color: rgba(0, 0, 0, 0.6);
-          flex-shrink: 0;
-        }
-
-        .fee-value {
-          text-align: right;
-          font-variant-numeric: tabular-nums;
-        }
-      }
-
       // Options section
       .options-section {
         .option-row {
@@ -998,10 +968,6 @@ const SANE_PRESET_MAX_SAT_VB = 200;
 
         .summary-section {
           background: #333;
-        }
-
-        .fee-summary .fee-label {
-          color: rgba(255, 255, 255, 0.6);
         }
 
         .option-row {

--- a/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
@@ -448,7 +448,9 @@ type OutputReference =
       .header {
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
         color: white;
-        padding: 16px 24px;
+        min-height: var(--menu-balance-h);
+        box-sizing: border-box;
+        padding: 0 24px;
         display: flex;
         align-items: center;
 
@@ -459,7 +461,7 @@ type OutputReference =
 
           h1 {
             margin: 0;
-            font-size: 24px;
+            font-size: 20px;
             font-weight: 300;
           }
         }

--- a/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
@@ -21,6 +21,7 @@ import {
   WalletTransaction,
 } from '../../../../bitcoin/services/rpc/wallet-rpc.service';
 import { BackendRouterService } from '../../../../core/backend/backend-router.service';
+import { BtcxWalletService } from '../../../../core/services/btcx-wallet.service';
 import {
   BlockchainRpcService,
   Transaction,
@@ -1016,6 +1017,7 @@ export class TransactionDetailComponent implements OnInit {
   private readonly walletService = inject(WalletService);
   private readonly walletRpc = inject(WalletRpcService);
   private readonly backendRouter = inject(BackendRouterService);
+  private readonly btcxWallet = inject(BtcxWalletService);
   private readonly blockchainRpc = inject(BlockchainRpcService);
   private readonly notification = inject(NotificationService);
   private readonly i18n = inject(I18nService);
@@ -1050,19 +1052,73 @@ export class TransactionDetailComponent implements OnInit {
       return;
     }
 
-    // Remote (Electrum) mode: gettransaction/getrawtransaction have no
-    // equivalent — render the essentials from the wallet's cached history.
+    // Remote (Electrum) mode: the synced BDK graph holds the complete tx —
+    // btcx_wallet_tx_detail serves it on demand, mapped into the SAME wallet
+    // + raw shapes Core's gettransaction/getrawtransaction fill, so the whole
+    // template (in/outputs, block info, raw hex, PoCX markers) just renders.
     if (this.backendRouter.isRemote()) {
       try {
-        const txs = await this.backendRouter.wallet().listTransactions(walletName, 999999, 0);
-        const cached = txs.find(t => t.txid === txid);
-        if (!cached) {
-          this.error.set('Transaction not found in wallet history');
-          return;
-        }
-        this.tx.set({ wallet: { ...cached, hex: '' }, raw: null });
+        const d = await this.btcxWallet.txDetail(txid);
+        const coinbase = d.inputs.some(i => i.coinbase);
+        const sign = d.direction === 'sent' ? -1 : 1;
+        const walletTx: WalletTransaction & { hex?: string } = {
+          txid: d.txid,
+          wtxid: d.wtxid,
+          category: d.direction === 'sent' ? 'send' : coinbase ? 'generate' : 'receive',
+          amount: (sign * d.amountSat) / 1e8,
+          fee: d.direction === 'sent' && d.feeSat !== null ? -d.feeSat / 1e8 : undefined,
+          confirmations: d.confirmations,
+          blockhash: d.blockHash ?? undefined,
+          blockheight: d.blockHeight ?? undefined,
+          blocktime: d.timestamp ?? undefined,
+          time: d.timestamp ?? 0,
+          timereceived: d.timestamp ?? 0,
+          bip125_replaceable: d.rbf ? 'yes' : 'no',
+          hex: d.rawHex,
+        };
+        const raw: Transaction = {
+          txid: d.txid,
+          hash: d.wtxid,
+          version: d.version,
+          size: d.size,
+          vsize: d.vsize,
+          weight: d.weight,
+          locktime: d.locktime,
+          hex: d.rawHex,
+          vin: d.inputs.map(i => ({
+            txid: i.txid,
+            vout: i.vout,
+            sequence: i.sequence,
+            coinbase: i.coinbase ? i.txid : undefined,
+            prevout:
+              i.prevValueSat !== null || i.prevAddress
+                ? {
+                    generated: false,
+                    height: 0,
+                    value: (i.prevValueSat ?? 0) / 1e8,
+                    scriptPubKey: {
+                      asm: '',
+                      hex: '',
+                      address: i.prevAddress ?? undefined,
+                      type: 'witness_v0_keyhash',
+                    },
+                  }
+                : undefined,
+          })),
+          vout: d.outputs.map(o => ({
+            value: o.valueSat / 1e8,
+            n: o.n,
+            scriptPubKey: {
+              asm: o.scriptAsm,
+              hex: o.scriptHex,
+              address: o.address ?? undefined,
+              type: o.opReturn ? 'nulldata' : o.address ? 'witness_v0_keyhash' : 'unknown',
+            },
+          })),
+        };
+        this.tx.set({ wallet: walletTx, raw });
         this.computeValues();
-        await this.detectPocxMarkers({ ...cached, hex: '' }, null);
+        await this.detectPocxMarkers(walletTx, raw);
       } catch (err) {
         this.error.set(err instanceof Error ? err.message : 'Failed to load transaction');
       } finally {

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -1028,7 +1028,7 @@ export class TransactionListComponent implements OnInit, OnDestroy {
     effect(() => {
       this.btcxWallet.lastSync();
       untracked(() => {
-        if (this.walletManager.activeWallet) void this.loadTransactions();
+        if (this.walletManager.activeWallet) void this.reloadIfChanged();
       });
     });
   }
@@ -1186,6 +1186,28 @@ export class TransactionListComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
+  /** Last tx probe {total, tip} — sync ticks skip identical reloads. */
+  private lastProbe: { total: number; tip: number } | null = null;
+
+  /** Sync tick: refetch only when the probe says the history moved. */
+  private async reloadIfChanged(): Promise<void> {
+    try {
+      const probe = await this.btcxWallet.txProbe();
+      if (
+        this.lastProbe &&
+        this.lastProbe.total === probe.total &&
+        this.lastProbe.tip === probe.tip &&
+        this.transactions().length > 0
+      ) {
+        return;
+      }
+      this.lastProbe = probe;
+    } catch {
+      // probe unavailable (Core mode / older backend) — plain reload
+    }
+    await this.loadTransactions();
+  }
+
   async loadTransactions(): Promise<void> {
     const walletName = this.walletManager.activeWallet;
     if (!walletName) return;
@@ -1200,9 +1222,8 @@ export class TransactionListComponent implements OnInit, OnDestroy {
       const count = this.loadLimit === 0 ? 999999 : this.loadLimit;
       const txs = await this.backendRouter.wallet().listTransactions(walletName, count, 0);
 
-      // Sort by time descending — copy first to avoid mutating the RPC response.
-      const sorted = [...txs].sort((a, b) => b.time - a.time);
-      this.transactions.set(sorted);
+      // Both backends return newest-first — no client re-sort.
+      this.transactions.set(txs);
     } catch (error) {
       console.error('Failed to load transactions:', error);
     } finally {

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -105,7 +105,7 @@ type TransactionFilter =
     I18nPipe,
   ],
   template: `
-    <div class="page-layout">
+    <div class="page-layout" [class.filters-open]="filtersOpen()">
       <!-- Header with gradient background -->
       <div class="header">
         <div class="header-left">
@@ -115,13 +115,24 @@ type TransactionFilter =
           <h1>{{ 'transactions' | i18n }}</h1>
         </div>
         <div class="header-right">
+          <!-- Phone-only: expand/collapse the filter row + load limit -->
+          <button
+            mat-icon-button
+            class="refresh-button filter-toggle"
+            [class.active]="filtersOpen()"
+            (click)="filtersOpen.set(!filtersOpen())"
+            [matTooltip]="'search' | i18n"
+          >
+            <mat-icon>filter_list</mat-icon>
+          </button>
+
           <!-- Export CSV (kept apart from the load-limit + refresh pair) -->
           <button
             mat-icon-button
             [disabled]="loading() || filteredTransactions().length === 0"
             (click)="exportCsv()"
             [matTooltip]="'export_csv' | i18n"
-            class="refresh-button"
+            class="refresh-button export-button"
           >
             <mat-icon>file_download</mat-icon>
           </button>
@@ -961,14 +972,43 @@ type TransactionFilter =
         }
       }
 
+      /* The funnel only exists at phone — desktop shows the filters inline. */
+      .filter-toggle {
+        display: none;
+      }
+
       @include bp.phone {
         .header {
           padding: 0 16px;
         }
 
-        /* The old mobile history had no filters and no load-limit select. */
+        .filter-toggle {
+          display: inline-flex;
+
+          &.active mat-icon {
+            color: #ffd54f;
+          }
+        }
+
+        /* Collapsed by default (the old mobile look); the funnel reveals the
+           filter row (wrapping) and the load-limit select in the header. */
         .filter-row,
         .limit-field {
+          display: none;
+        }
+
+        .filters-open .filter-row {
+          display: flex;
+          flex-wrap: wrap;
+        }
+
+        /* .page-layout carries .filters-open; the header is inside it. */
+        .filters-open .limit-field {
+          display: inline-flex;
+        }
+
+        /* Nobody exports CSV on a phone. */
+        .export-button {
           display: none;
         }
 
@@ -1045,6 +1085,8 @@ export class TransactionListComponent implements OnInit, OnDestroy {
   transactions = signal<WalletTransaction[]>([]);
   activeFilter = signal<TransactionFilter>('all');
   pageIndex = signal(0);
+  /** Phone: the filter row + load limit are collapsed behind the funnel. */
+  readonly filtersOpen = signal(false);
   /**
    * Fit-derived page size at EVERY width (the app-wide pattern): FitRows
    * measures how many rows fit the table/card viewport — no items-per-page

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -137,33 +137,37 @@ type TransactionFilter =
             <mat-icon>file_download</mat-icon>
           </button>
 
-          <!-- Refresh + load limit live in ONE menu (mobile-look rule):
-               Refresh on top, then the limit choices — picking a limit
-               reloads with it. -->
+          <!-- Load limit: its own icon + menu (refresh stays one tap). -->
           <button
             mat-icon-button
             [disabled]="loading()"
-            [matMenuTriggerFor]="refreshMenu"
-            [matTooltip]="'refresh' | i18n"
+            [matMenuTriggerFor]="limitMenu"
+            [matTooltip]="'load_limit' | i18n"
             class="refresh-button"
           >
-            <mat-icon>refresh</mat-icon>
+            <mat-icon>format_list_numbered</mat-icon>
           </button>
-          <mat-menu #refreshMenu="matMenu">
-            <button mat-menu-item (click)="loadTransactions()">
-              <mat-icon>refresh</mat-icon>
-              <span>{{ 'refresh' | i18n }}</span>
-            </button>
-            <mat-divider></mat-divider>
+          <mat-menu #limitMenu="matMenu">
             @for (option of loadLimitOptions; track option.value) {
               <button mat-menu-item (click)="setLoadLimit(option.value)">
                 <mat-icon>{{
                   loadLimit === option.value ? 'radio_button_checked' : 'radio_button_unchecked'
                 }}</mat-icon>
-                <span>{{ 'load_limit' | i18n }}: {{ option.label }}</span>
+                <span>{{ option.label }}</span>
               </button>
             }
           </mat-menu>
+
+          <!-- Refresh: plain one-tap -->
+          <button
+            mat-icon-button
+            [disabled]="loading()"
+            (click)="loadTransactions()"
+            [matTooltip]="'refresh' | i18n"
+            class="refresh-button"
+          >
+            <mat-icon>refresh</mat-icon>
+          </button>
         </div>
       </div>
 

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -137,26 +137,33 @@ type TransactionFilter =
             <mat-icon>file_download</mat-icon>
           </button>
 
-          <!-- Load Limit -->
-          <mat-form-field appearance="outline" class="limit-field">
-            <mat-label>{{ 'load_limit' | i18n }}</mat-label>
-            <mat-select [(value)]="loadLimit" (selectionChange)="onLoadLimitChange()">
-              @for (option of loadLimitOptions; track option.value) {
-                <mat-option [value]="option.value">{{ option.label }}</mat-option>
-              }
-            </mat-select>
-          </mat-form-field>
-
-          <!-- Refresh Button -->
+          <!-- Refresh + load limit live in ONE menu (mobile-look rule):
+               Refresh on top, then the limit choices — picking a limit
+               reloads with it. -->
           <button
             mat-icon-button
             [disabled]="loading()"
-            (click)="loadTransactions()"
+            [matMenuTriggerFor]="refreshMenu"
             [matTooltip]="'refresh' | i18n"
             class="refresh-button"
           >
             <mat-icon>refresh</mat-icon>
           </button>
+          <mat-menu #refreshMenu="matMenu">
+            <button mat-menu-item (click)="loadTransactions()">
+              <mat-icon>refresh</mat-icon>
+              <span>{{ 'refresh' | i18n }}</span>
+            </button>
+            <mat-divider></mat-divider>
+            @for (option of loadLimitOptions; track option.value) {
+              <button mat-menu-item (click)="setLoadLimit(option.value)">
+                <mat-icon>{{
+                  loadLimit === option.value ? 'radio_button_checked' : 'radio_button_unchecked'
+                }}</mat-icon>
+                <span>{{ 'load_limit' | i18n }}: {{ option.label }}</span>
+              </button>
+            }
+          </mat-menu>
         </div>
       </div>
 
@@ -488,55 +495,6 @@ type TransactionFilter =
         display: flex;
         align-items: center;
         gap: 12px;
-
-        .limit-field {
-          width: 140px;
-
-          ::ng-deep {
-            .mat-mdc-text-field-wrapper {
-              background: rgba(255, 255, 255, 0.1);
-              padding: 0 12px;
-            }
-
-            .mdc-notched-outline__leading,
-            .mdc-notched-outline__notch,
-            .mdc-notched-outline__trailing {
-              border-color: rgba(255, 255, 255, 0.3) !important;
-            }
-
-            .mat-mdc-form-field-flex {
-              height: 40px;
-              align-items: center;
-            }
-
-            .mat-mdc-form-field-infix {
-              padding: 0;
-              min-height: 40px;
-              display: flex;
-              align-items: center;
-            }
-
-            .mat-mdc-select-value,
-            .mat-mdc-select-arrow,
-            .mdc-floating-label {
-              color: white !important;
-            }
-
-            .mdc-floating-label {
-              top: 50% !important;
-              transform: translateY(-50%) !important;
-            }
-
-            .mdc-floating-label--float-above {
-              top: 0 !important;
-              transform: translateY(-50%) scale(0.75) !important;
-            }
-
-            .mat-mdc-form-field-subscript-wrapper {
-              display: none;
-            }
-          }
-        }
 
         .refresh-button {
           color: white;
@@ -990,21 +948,15 @@ type TransactionFilter =
           }
         }
 
-        /* Collapsed by default (the old mobile look); the funnel reveals the
-           filter row (wrapping) and the load-limit select in the header. */
-        .filter-row,
-        .limit-field {
+        /* Collapsed by default (the old mobile look); the funnel reveals
+           the filter row (wrapping). */
+        .filter-row {
           display: none;
         }
 
         .filters-open .filter-row {
           display: flex;
           flex-wrap: wrap;
-        }
-
-        /* .page-layout carries .filters-open; the header is inside it. */
-        .filters-open .limit-field {
-          display: inline-flex;
         }
 
         /* Nobody exports CSV on a phone. */
@@ -1252,6 +1204,12 @@ export class TransactionListComponent implements OnInit, OnDestroy {
     } finally {
       this.loading.set(false);
     }
+  }
+
+  /** Menu pick: adopt the limit and reload with it. */
+  setLoadLimit(value: number): void {
+    this.loadLimit = value;
+    this.onLoadLimitChange();
   }
 
   onLoadLimitChange(): void {

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -367,12 +367,10 @@ type TransactionFilter =
                                 <span>{{ 'view_address_in_explorer' | i18n }}</span>
                               </button>
                             }
-                            @if (!isRemote()) {
-                              <button mat-menu-item (click)="viewTransactionDetails(tx)">
-                                <mat-icon>info</mat-icon>
-                                <span>{{ 'transaction_details' | i18n }}</span>
-                              </button>
-                            }
+                            <button mat-menu-item (click)="viewTransactionDetails(tx)">
+                              <mat-icon>info</mat-icon>
+                              <span>{{ 'transaction_details' | i18n }}</span>
+                            </button>
                             @if (tx.address) {
                               <mat-divider></mat-divider>
                               <button mat-menu-item (click)="sendToAddress(tx.address)">
@@ -1384,9 +1382,6 @@ export class TransactionListComponent implements OnInit, OnDestroy {
 
   // Actions
   viewTransactionDetails(tx: WalletTransaction): void {
-    // Details are a Core-RPC feature (raw tx decode etc.) — no detail view in
-    // Electrum/remote mode.
-    if (this.isRemote()) return;
     this.router.navigate([this.appMode.pageRoute('/transactions'), tx.txid]);
   }
 

--- a/web-wallet/src/app/shared/components/mobile-nav/mobile-nav.component.ts
+++ b/web-wallet/src/app/shared/components/mobile-nav/mobile-nav.component.ts
@@ -29,7 +29,7 @@ import { AppModeService } from '../../../core/services/app-mode.service';
           <span class="nav-label">{{ 'mwallet_title' | i18n }}</span>
         </a>
         @if (appMode.isMobileMode()) {
-          <a routerLink="/miner" routerLinkActive="active" class="nav-item">
+          <a routerLink="/wallet/mining" routerLinkActive="active" class="nav-item">
             <mat-icon>hardware</mat-icon>
             <span class="nav-label">{{ 'mining' | i18n }}</span>
           </a>


### PR DESCRIPTION
Round 6:

1. **Receive** — Johnny's revised layout: address **selector** (latest virgin preselected; Core lists the full revealed history with used/never-used hints, remote lists current + generated; copy suffix) → amount → label → QR → payment URI → generate-new. Generating refreshes + selects.
2. **Assignment desktop** — section spacing matched to the send page (was too compressed); phone keeps the exact mobile rhythm.

Screenshot-verified at 1100px; receive verified compiling with the selector flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX