### PR TITLE
chore(ui): breakpoint sweep — all pages on the shared bp mixins

### DIFF
--- a/web-wallet/src/app/aggregator/components/summary-stats/summary-stats.component.ts
+++ b/web-wallet/src/app/aggregator/components/summary-stats/summary-stats.component.ts
@@ -103,6 +103,8 @@ import { I18nPipe, I18nService } from '../../../core/i18n';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .summary-cards {
         display: grid;
         grid-template-columns: repeat(4, 1fr);
@@ -111,13 +113,13 @@ import { I18nPipe, I18nService } from '../../../core/i18n';
         min-height: fit-content;
       }
 
-      @media (max-width: 1100px) {
+      @include bp.desktop-down {
         .summary-cards {
           grid-template-columns: repeat(2, 1fr);
         }
       }
 
-      @media (max-width: 600px) {
+      @include bp.phone {
         .summary-cards {
           grid-template-columns: 1fr;
         }

--- a/web-wallet/src/app/aggregator/pages/aggregator-dashboard/aggregator-dashboard.component.ts
+++ b/web-wallet/src/app/aggregator/pages/aggregator-dashboard/aggregator-dashboard.component.ts
@@ -60,6 +60,8 @@ import { I18nPipe } from '../../../core/i18n';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: flex;
         flex-direction: column;
@@ -94,7 +96,7 @@ import { I18nPipe } from '../../../core/i18n';
         min-height: 200px;
       }
 
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .detail-row {
           grid-template-columns: 1fr;
           gap: 12px;

--- a/web-wallet/src/app/features/auth/pages/wallet-select/wallet-select.component.ts
+++ b/web-wallet/src/app/features/auth/pages/wallet-select/wallet-select.component.ts
@@ -373,6 +373,8 @@ import { BtcxWalletService, BtcxCompartment } from '../../../../core/services/bt
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       /* Main Container - uses flex layout from app.component */
       :host {
         display: block;
@@ -835,7 +837,7 @@ import { BtcxWalletService, BtcxCompartment } from '../../../../core/services/bt
       }
 
       /* Responsive */
-      @media (max-width: 600px) {
+      @include bp.phone {
         .box-actions {
           flex-direction: column;
           align-items: stretch;

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1187,7 +1187,7 @@ interface NavGroup {
           height: 22px;
         }
 
-        @media (max-width: 600px) {
+        @include bp.phone {
           .lang-name-text {
             display: none;
           }

--- a/web-wallet/src/app/features/peers/pages/peers/peers.component.ts
+++ b/web-wallet/src/app/features/peers/pages/peers/peers.component.ts
@@ -185,6 +185,8 @@ type PeerRow = PeerInfo & { versionClass: string };
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: block;
         width: 100%;
@@ -524,7 +526,7 @@ type PeerRow = PeerInfo & { versionClass: string };
         }
       }
 
-      @media (max-width: 768px) {
+      @include bp.tablet-down {
         .header {
           padding: 12px 16px;
 

--- a/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
@@ -548,6 +548,8 @@ const UTXO_PAGE_SIZE = 10;
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: block;
       }
@@ -1276,7 +1278,7 @@ const UTXO_PAGE_SIZE = 10;
       }
 
       // Responsive
-      @media (max-width: 600px) {
+      @include bp.phone {
         .output-row {
           flex-wrap: wrap;
 

--- a/web-wallet/src/app/features/psbt/components/psbt-import-dialog/psbt-import-dialog.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-import-dialog/psbt-import-dialog.component.ts
@@ -82,6 +82,8 @@ export interface PsbtImportDialogData {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .title-icon {
         margin-right: 8px;
         vertical-align: middle;
@@ -93,7 +95,7 @@ export interface PsbtImportDialogData {
         max-width: 520px;
       }
 
-      @media (max-width: 600px) {
+      @include bp.phone {
         mat-dialog-content {
           min-width: unset;
         }

--- a/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
+++ b/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
@@ -739,7 +739,7 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
         }
       }
 
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .content.wide .stats {
           grid-template-columns: repeat(2, 1fr);
         }
@@ -1593,7 +1593,7 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
       }
 
       // ============ Responsive ============
-      @media (max-width: 600px) {
+      @include bp.phone {
         .content {
           padding: 16px;
         }

--- a/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
+++ b/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
@@ -1148,6 +1148,8 @@ function withListenPort(listenAddress: string, port: number): string {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .settings-page {
         min-height: 100vh;
         background: #eceff1;
@@ -1872,7 +1874,7 @@ function withListenPort(listenAddress: string, port: number): string {
       }
 
       /* Responsive */
-      @media (max-width: 600px) {
+      @include bp.phone {
         .settings-content {
           padding: 16px;
         }

--- a/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
@@ -439,6 +439,8 @@ type OutputReference =
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .page-layout {
         display: flex;
         flex-direction: column;
@@ -695,7 +697,7 @@ type OutputReference =
           gap: 16px;
           align-items: flex-start;
 
-          @media (max-width: 900px) {
+          @include bp.tablet-down {
             flex-direction: column;
 
             .io-arrow {

--- a/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
+++ b/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
@@ -136,6 +136,8 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .mining-layout {
         display: flex;
         flex-direction: column;
@@ -259,7 +261,7 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
           height: 24px;
         }
 
-        @media (max-width: 600px) {
+        @include bp.phone {
           .lang-name-text {
             display: none;
           }
@@ -302,7 +304,7 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
         }
       }
 
-      @media (max-width: 600px) {
+      @include bp.phone {
         .mining-toolbar {
           height: 56px;
         }

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -385,6 +385,8 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: block;
         position: relative;
@@ -557,7 +559,7 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
         }
 
         /* On screens < 1280px, show icon instead of text */
-        @media (max-width: 1279px) {
+        @include bp.desktop-down {
           .lang-name-text {
             display: none;
           }
@@ -669,7 +671,7 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
       }
 
       /* Responsive */
-      @media (max-width: 600px) {
+      @include bp.phone {
         .toolbar {
           height: 56px;
         }

--- a/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
+++ b/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
@@ -586,6 +586,8 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: flex;
         flex-direction: column;
@@ -633,7 +635,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Mobile/small screens: ensure content has intrinsic height for scrolling */
-      @media (max-height: 700px) {
+      @include bp.short {
         .main-content {
           display: block; /* Switch from flex to block for proper scroll behavior */
           padding: 16px;
@@ -649,7 +651,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Mobile width: switch to block layout for proper stacking */
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .main-content {
           display: block;
           padding: 12px;
@@ -673,13 +675,13 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
         min-height: fit-content; /* Ensure cards don't collapse */
       }
 
-      @media (max-width: 1100px) {
+      @include bp.desktop-down {
         .summary-cards {
           grid-template-columns: repeat(2, 1fr);
         }
       }
 
-      @media (max-width: 600px) {
+      @include bp.phone {
         .summary-cards {
           grid-template-columns: 1fr;
         }
@@ -1222,7 +1224,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
         min-height: 150px;
       }
 
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .detail-row {
           grid-template-columns: 1fr;
           gap: 12px;
@@ -1255,7 +1257,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Small screens: use fixed heights instead of flex ratios */
-      @media (max-height: 700px) {
+      @include bp.short {
         .detail-row {
           flex: none;
           min-height: auto;
@@ -1494,7 +1496,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Small screens: fixed height for activity */
-      @media (max-height: 700px) {
+      @include bp.short {
         .activity-section {
           flex: none;
           height: 150px;
@@ -1503,7 +1505,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Mobile: ensure activity section doesn't overlap */
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .activity-section {
           flex: none;
           min-height: 140px;

--- a/web-wallet/src/app/shared/components/address-coins-list/address-coins-list.component.ts
+++ b/web-wallet/src/app/shared/components/address-coins-list/address-coins-list.component.ts
@@ -165,6 +165,8 @@ export function aggregateCoins(coins: WalletCoin[]): AddressBalance[] {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       /* Flex-fill the bounded parent (the wrapper's .coins-card) so the row
          viewport height is viewport-derived — giving FitRowsDirective a real
          height to measure under BOTH shells. */
@@ -330,7 +332,7 @@ export function aggregateCoins(coins: WalletCoin[]): AddressBalance[] {
       /* Responsive — reflow each table row to a stacked card below 600px
          (tablet portrait, phone). The address wraps at full width; the three
          stat cells collapse onto one meta line under it. */
-      @media (max-width: 600px) {
+      @include bp.phone {
         .table-header {
           display: none;
         }

--- a/web-wallet/src/app/shared/components/mnemonic-display/mnemonic-display.component.ts
+++ b/web-wallet/src/app/shared/components/mnemonic-display/mnemonic-display.component.ts
@@ -33,6 +33,8 @@ import { I18nPipe } from '../../../core/i18n';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .mnemonic-display {
         display: grid;
         grid-template-columns: repeat(4, 1fr);
@@ -66,7 +68,7 @@ import { I18nPipe } from '../../../core/i18n';
         margin-bottom: 16px;
       }
 
-      @media (max-width: 599px) {
+      @include bp.phone {
         .mnemonic-display {
           grid-template-columns: repeat(3, 1fr);
         }

--- a/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
+++ b/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
@@ -98,6 +98,8 @@ export interface MnemonicEntryState {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .word-length-selector {
         display: flex;
         gap: 8px;
@@ -192,7 +194,7 @@ export interface MnemonicEntryState {
         }
       }
 
-      @media (max-width: 599px) {
+      @include bp.phone {
         .mnemonic-input-grid {
           grid-template-columns: repeat(3, 1fr);
 

--- a/web-wallet/src/app/shared/components/page-layout/page-layout.component.ts
+++ b/web-wallet/src/app/shared/components/page-layout/page-layout.component.ts
@@ -85,6 +85,8 @@ export interface BreadcrumbItem {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .page-layout {
         min-height: 100vh;
         display: flex;
@@ -187,7 +189,7 @@ export interface BreadcrumbItem {
         }
       }
 
-      @media (max-width: 599px) {
+      @include bp.phone {
         .page-header-section {
           padding: 16px;
           min-height: 120px;

--- a/web-wallet/src/app/shared/components/step-header/step-header.component.ts
+++ b/web-wallet/src/app/shared/components/step-header/step-header.component.ts
@@ -35,6 +35,8 @@ import { Component, Input } from '@angular/core';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .step-header {
         padding: 16px 24px;
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
@@ -45,7 +47,7 @@ import { Component, Input } from '@angular/core';
         border-radius: 4px 4px 0 0;
       }
 
-      @media (max-width: 599px) {
+      @include bp.phone {
         .step-header {
           flex-direction: column;
           gap: 12px;

--- a/web-wallet/src/styles.scss
+++ b/web-wallet/src/styles.scss
@@ -1,6 +1,7 @@
 // Phoenix Wallet - Global Styles
 
 // Import custom theme (using @use to avoid deprecation warnings)
+@use 'breakpoints' as bp;
 @use 'styles/theme';
 @use 'styles/utilities';
 
@@ -50,7 +51,7 @@ body {
 }
 
 // Lowest breakpoint: both shared bands shrink by width.
-@media (max-width: 600px) {
+@include bp.phone {
   :root {
     --toolbar-h: 56px;
     --menu-balance-h: 68px;
@@ -419,7 +420,7 @@ a {
 // Responsive Utilities
 // ============================================================
 
-@media (max-width: 599px) {
+@include bp.phone {
   .hide-mobile {
     display: none !important;
   }
@@ -429,7 +430,7 @@ a {
   }
 }
 
-@media (min-width: 600px) {
+@media (min-width: (bp.$phone + 1)) {
   .hide-desktop {
     display: none !important;
   }
@@ -462,7 +463,7 @@ a {
   overflow-y: auto !important;
 }
 
-@media (max-width: 600px) {
+@include bp.phone {
   .lang-dropdown-menu {
     max-height: calc(100vh - 72px) !important; // smaller toolbar on mobile
   }


### PR DESCRIPTION
Mechanical cleanup pass: every hand-typed standard-tier media query (600/900/1100 width + 700 height) across 18 components and the global stylesheet now uses the `_breakpoints.scss` mixins (`bp.phone` / `bp.tablet-down` / `bp.desktop-down` / `bp.short`).

Stray values folded into the standard set:
- `599px` (4 components + global) → `bp.phone`
- `768px` (peers) → `bp.tablet-down`
- `1279px` (toolbar) → `bp.desktop-down`
- global `hide-mobile`/`hide-desktop` boundary now derives from `bp.$phone` (≤600 / ≥601, still complementary)

Kept literal on purpose: the sub-phone mnemonic grid column steps (480px/400px in mnemonic-entry/display) — documented finer granularity below the phone tier.

No template or logic changes; compile-verified in the dev session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX