### PR TITLE
fix(mobile): Android round-8 — tx header icons, miner toolbar indicator, builder wrap

### DIFF
--- a/web-wallet/src/app/aggregator/components/summary-stats/summary-stats.component.ts
+++ b/web-wallet/src/app/aggregator/components/summary-stats/summary-stats.component.ts
@@ -103,6 +103,8 @@ import { I18nPipe, I18nService } from '../../../core/i18n';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .summary-cards {
         display: grid;
         grid-template-columns: repeat(4, 1fr);
@@ -111,13 +113,13 @@ import { I18nPipe, I18nService } from '../../../core/i18n';
         min-height: fit-content;
       }
 
-      @media (max-width: 1100px) {
+      @include bp.desktop-down {
         .summary-cards {
           grid-template-columns: repeat(2, 1fr);
         }
       }
 
-      @media (max-width: 600px) {
+      @include bp.phone {
         .summary-cards {
           grid-template-columns: 1fr;
         }

--- a/web-wallet/src/app/aggregator/pages/aggregator-dashboard/aggregator-dashboard.component.ts
+++ b/web-wallet/src/app/aggregator/pages/aggregator-dashboard/aggregator-dashboard.component.ts
@@ -60,6 +60,8 @@ import { I18nPipe } from '../../../core/i18n';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: flex;
         flex-direction: column;
@@ -94,7 +96,7 @@ import { I18nPipe } from '../../../core/i18n';
         min-height: 200px;
       }
 
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .detail-row {
           grid-template-columns: 1fr;
           gap: 12px;

--- a/web-wallet/src/app/features/auth/pages/wallet-select/wallet-select.component.ts
+++ b/web-wallet/src/app/features/auth/pages/wallet-select/wallet-select.component.ts
@@ -373,6 +373,8 @@ import { BtcxWalletService, BtcxCompartment } from '../../../../core/services/bt
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       /* Main Container - uses flex layout from app.component */
       :host {
         display: block;
@@ -835,7 +837,7 @@ import { BtcxWalletService, BtcxCompartment } from '../../../../core/services/bt
       }
 
       /* Responsive */
-      @media (max-width: 600px) {
+      @include bp.phone {
         .box-actions {
           flex-direction: column;
           align-items: stretch;

--- a/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -531,7 +531,7 @@ import { MiningService } from '../../../../mining/services';
             <mat-card-content>
               <h3>{{ 'mwallet_mine_hint_title' | i18n }}</h3>
               <p class="hint-text">{{ 'mwallet_mine_hint_text' | i18n }}</p>
-              <button mat-stroked-button routerLink="/miner/setup">
+              <button mat-stroked-button routerLink="/wallet/mining/setup">
                 <mat-icon>hardware</mat-icon>
                 {{ 'mwallet_mine_setup' | i18n }}
               </button>

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -20,6 +20,7 @@ import {
   BtcxChainInfo,
 } from '../../../core/services/btcx-wallet.service';
 import { ElectrumStatusService } from '../../../core/services/electrum-status.service';
+import { MiningService } from '../../../mining/services/mining.service';
 import { AppModeService } from '../../../core/services/app-mode.service';
 import { ViewportService } from '../../../core/services/viewport.service';
 import { AppUpdateService } from '../../../core/services/app-update.service';
@@ -287,6 +288,19 @@ interface NavGroup {
                 </div>
               </mat-menu>
             </div>
+
+            <!-- Miner indicator (the desktop toolbar's hardware icon; the
+                 plotter icon is deliberately omitted — no toolbar space) -->
+            @if (miningAvailable() && miningService.isConfigured()) {
+              <div
+                class="status-indicator"
+                [matTooltip]="
+                  miningService.minerRunning() ? ('miner_running' | i18n) : ('miner_stopped' | i18n)
+                "
+              >
+                <mat-icon [class.miner-active]="miningService.minerRunning()">hardware</mat-icon>
+              </div>
+            }
 
             <div class="toolbar-right">
               @if (wallet.hasSeed()) {
@@ -1268,6 +1282,10 @@ interface NavGroup {
           &.electrum-connecting {
             color: rgba(255, 255, 255, 0.45);
           }
+
+          &.miner-active {
+            color: #4caf50;
+          }
         }
       }
 
@@ -1293,7 +1311,10 @@ export class MobileWalletLayoutComponent implements OnInit {
   readonly wallet = inject(BtcxWalletService);
   readonly electrumStatus = inject(ElectrumStatusService);
   readonly viewport = inject(ViewportService);
+  readonly miningService = inject(MiningService);
   private readonly appMode = inject(AppModeService);
+  /** Mining exists in this shell (hybrid flavors) — wallet-only has none. */
+  readonly miningAvailable = computed(() => this.appMode.miningEnabled());
   private readonly notification = inject(NotificationService);
   private readonly router = inject(Router);
   private readonly dialog = inject(MatDialog);

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1187,7 +1187,7 @@ interface NavGroup {
           height: 22px;
         }
 
-        @media (max-width: 600px) {
+        @include bp.phone {
           .lang-name-text {
             display: none;
           }

--- a/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
+++ b/web-wallet/src/app/features/mobile-wallet/mobile-wallet.routes.ts
@@ -125,6 +125,17 @@ export const MOBILE_WALLET_ROUTES: Routes = [
           ),
       },
       {
+        // Setup wizard IN the wallet shell — same treatment as the dashboard
+        // above, so Setup never teleports hybrid users to the bare miner
+        // shell (mining-only keeps /miner/setup).
+        path: 'mining/setup',
+        canActivate: [notWalletOnlyGuard],
+        loadComponent: () =>
+          import('../../mining/pages/setup-wizard/setup-wizard.component').then(
+            m => m.SetupWizardComponent
+          ),
+      },
+      {
         path: 'settings',
         loadComponent: () =>
           import('./pages/settings/wallet-settings.component').then(m => m.WalletSettingsComponent),

--- a/web-wallet/src/app/features/peers/pages/peers/peers.component.ts
+++ b/web-wallet/src/app/features/peers/pages/peers/peers.component.ts
@@ -185,6 +185,8 @@ type PeerRow = PeerInfo & { versionClass: string };
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: block;
         width: 100%;
@@ -524,7 +526,7 @@ type PeerRow = PeerInfo & { versionClass: string };
         }
       }
 
-      @media (max-width: 768px) {
+      @include bp.tablet-down {
         .header {
           padding: 12px 16px;
 

--- a/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
@@ -223,6 +223,9 @@ const UTXO_PAGE_SIZE = 10;
               >
                 <mat-icon>contacts</mat-icon>
               </button>
+              <!-- Phone: wrap AFTER the contacts button (address + contacts
+                   on line one, amount + max + remove on line two) -->
+              <div class="row-break"></div>
               <mat-form-field appearance="outline" class="amount-field">
                 <mat-label>{{ 'amount' | i18n }}</mat-label>
                 <input
@@ -830,6 +833,11 @@ const UTXO_PAGE_SIZE = 10;
           min-width: 0;
         }
 
+        /* Forced wrap point (phone only). */
+        .row-break {
+          display: none;
+        }
+
         .amount-field {
           width: 210px;
           flex-shrink: 0;
@@ -1282,9 +1290,10 @@ const UTXO_PAGE_SIZE = 10;
         .output-row {
           flex-wrap: wrap;
 
-          .addr-field {
-            width: 100%;
-            flex: unset;
+          .row-break {
+            display: block;
+            flex-basis: 100%;
+            height: 0;
           }
 
           .amount-field {

--- a/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
@@ -548,6 +548,8 @@ const UTXO_PAGE_SIZE = 10;
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: block;
       }
@@ -1276,7 +1278,7 @@ const UTXO_PAGE_SIZE = 10;
       }
 
       // Responsive
-      @media (max-width: 600px) {
+      @include bp.phone {
         .output-row {
           flex-wrap: wrap;
 

--- a/web-wallet/src/app/features/psbt/components/psbt-import-dialog/psbt-import-dialog.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-import-dialog/psbt-import-dialog.component.ts
@@ -82,6 +82,8 @@ export interface PsbtImportDialogData {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .title-icon {
         margin-right: 8px;
         vertical-align: middle;
@@ -93,7 +95,7 @@ export interface PsbtImportDialogData {
         max-width: 520px;
       }
 
-      @media (max-width: 600px) {
+      @include bp.phone {
         mat-dialog-content {
           min-width: unset;
         }

--- a/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
+++ b/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
@@ -739,7 +739,7 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
         }
       }
 
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .content.wide .stats {
           grid-template-columns: repeat(2, 1fr);
         }
@@ -1593,7 +1593,7 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
       }
 
       // ============ Responsive ============
-      @media (max-width: 600px) {
+      @include bp.phone {
         .content {
           padding: 16px;
         }

--- a/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
+++ b/web-wallet/src/app/features/settings/pages/settings/settings.component.ts
@@ -1148,6 +1148,8 @@ function withListenPort(listenAddress: string, port: number): string {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .settings-page {
         min-height: 100vh;
         background: #eceff1;
@@ -1872,7 +1874,7 @@ function withListenPort(listenAddress: string, port: number): string {
       }
 
       /* Responsive */
-      @media (max-width: 600px) {
+      @include bp.phone {
         .settings-content {
           padding: 16px;
         }

--- a/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
@@ -439,6 +439,8 @@ type OutputReference =
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .page-layout {
         display: flex;
         flex-direction: column;
@@ -695,7 +697,7 @@ type OutputReference =
           gap: 16px;
           align-items: flex-start;
 
-          @media (max-width: 900px) {
+          @include bp.tablet-down {
             flex-direction: column;
 
             .io-arrow {

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -137,13 +137,15 @@ type TransactionFilter =
             <mat-icon>file_download</mat-icon>
           </button>
 
-          <!-- Load limit: its own icon + menu (refresh stays one tap). -->
+          <!-- Load limit: its own icon + menu (refresh stays one tap). On
+               phone it lives in the funnel-revealed filter row instead so the
+               header keeps to two icons and never wraps. -->
           <button
             mat-icon-button
             [disabled]="loading()"
             [matMenuTriggerFor]="limitMenu"
             [matTooltip]="'load_limit' | i18n"
-            class="refresh-button"
+            class="refresh-button limit-button"
           >
             <mat-icon>format_list_numbered</mat-icon>
           </button>
@@ -231,6 +233,17 @@ type TransactionFilter =
         <!-- Reset Button -->
         <button mat-stroked-button class="reset-button" (click)="resetFilters()">
           {{ 'reset' | i18n }}
+        </button>
+
+        <!-- Phone-only load-limit trigger (same menu as the header icon) -->
+        <button
+          mat-icon-button
+          [disabled]="loading()"
+          [matMenuTriggerFor]="limitMenu"
+          [matTooltip]="'load_limit' | i18n"
+          class="limit-inline"
+        >
+          <mat-icon>format_list_numbered</mat-icon>
         </button>
       </div>
 
@@ -937,6 +950,12 @@ type TransactionFilter =
         display: none;
       }
 
+      /* The in-row load-limit trigger only exists at phone — desktop keeps
+         it in the header. */
+      .limit-inline {
+        display: none;
+      }
+
       @include bp.phone {
         .header {
           padding: 0 16px;
@@ -946,7 +965,7 @@ type TransactionFilter =
           display: inline-flex;
 
           &.active mat-icon {
-            color: #ffd54f;
+            color: #4caf50;
           }
         }
 
@@ -964,6 +983,20 @@ type TransactionFilter =
         /* Nobody exports CSV on a phone. */
         .export-button {
           display: none;
+        }
+
+        /* Two icons max in the header (funnel + refresh) so it never wraps
+           on narrow phones — the load limit moves into the filter row. */
+        .header-right {
+          gap: 0;
+
+          .limit-button {
+            display: none;
+          }
+        }
+
+        .filters-open .limit-inline {
+          display: inline-flex;
         }
 
         .transactions-card {

--- a/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
+++ b/web-wallet/src/app/layout/mining-layout/mining-layout.component.ts
@@ -136,6 +136,8 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .mining-layout {
         display: flex;
         flex-direction: column;
@@ -259,7 +261,7 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
           height: 24px;
         }
 
-        @media (max-width: 600px) {
+        @include bp.phone {
           .lang-name-text {
             display: none;
           }
@@ -302,7 +304,7 @@ import { MobileNavComponent } from '../../shared/components/mobile-nav/mobile-na
         }
       }
 
-      @media (max-width: 600px) {
+      @include bp.phone {
         .mining-toolbar {
           height: 56px;
         }

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -726,6 +726,12 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
           .dropdown-arrow {
             display: none;
           }
+
+          /* Icon-only: match the other toolbar icons' grey — the loaded
+             state's near-black emphasis reads wrong without the text. */
+          .wallet-icon.has-wallet {
+            color: rgba(0, 0, 0, 0.54);
+          }
         }
       }
     `,

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -164,8 +164,10 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
               </div>
             }
 
-            <!-- Clock-drift Indicator (visible when monitoring is enabled) -->
-            @if (clockDrift.enabled()) {
+            <!-- Clock-drift Indicator (visible when monitoring is enabled).
+                 RPC modes only: drift matters for local-node forging;
+                 remote mode neither forges locally nor serves time. -->
+            @if (clockDrift.enabled() && !nodeService.isRemote()) {
               <div
                 class="status-indicator clock-drift-indicator"
                 [class.clickable]="true"

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -385,6 +385,8 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: block;
         position: relative;
@@ -557,7 +559,7 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
         }
 
         /* On screens < 1280px, show icon instead of text */
-        @media (max-width: 1279px) {
+        @include bp.desktop-down {
           .lang-name-text {
             display: none;
           }
@@ -669,7 +671,7 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
       }
 
       /* Responsive */
-      @media (max-width: 600px) {
+      @include bp.phone {
         .toolbar {
           height: 56px;
         }

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -715,6 +715,18 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
           padding: 0.1rem 0.4rem;
           left: calc(50% - 35px);
         }
+
+        /* Wallet + pocket selectors collapse to icon-only chips (the wallet
+           shell's icon-chip look) — the dropdown menus carry the names. */
+        .wallet-button {
+          min-width: 48px;
+          padding: 0 4px;
+
+          .wallet-name,
+          .dropdown-arrow {
+            display: none;
+          }
+        }
       }
     `,
   ],

--- a/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
+++ b/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
@@ -586,6 +586,8 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       :host {
         display: flex;
         flex-direction: column;
@@ -633,7 +635,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Mobile/small screens: ensure content has intrinsic height for scrolling */
-      @media (max-height: 700px) {
+      @include bp.short {
         .main-content {
           display: block; /* Switch from flex to block for proper scroll behavior */
           padding: 16px;
@@ -649,7 +651,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Mobile width: switch to block layout for proper stacking */
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .main-content {
           display: block;
           padding: 12px;
@@ -673,13 +675,13 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
         min-height: fit-content; /* Ensure cards don't collapse */
       }
 
-      @media (max-width: 1100px) {
+      @include bp.desktop-down {
         .summary-cards {
           grid-template-columns: repeat(2, 1fr);
         }
       }
 
-      @media (max-width: 600px) {
+      @include bp.phone {
         .summary-cards {
           grid-template-columns: 1fr;
         }
@@ -1222,7 +1224,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
         min-height: 150px;
       }
 
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .detail-row {
           grid-template-columns: 1fr;
           gap: 12px;
@@ -1255,7 +1257,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Small screens: use fixed heights instead of flex ratios */
-      @media (max-height: 700px) {
+      @include bp.short {
         .detail-row {
           flex: none;
           min-height: auto;
@@ -1494,7 +1496,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Small screens: fixed height for activity */
-      @media (max-height: 700px) {
+      @include bp.short {
         .activity-section {
           flex: none;
           height: 150px;
@@ -1503,7 +1505,7 @@ import { OrphanResolutionDialogComponent } from '../../components/orphan-resolut
       }
 
       /* Mobile: ensure activity section doesn't overlap */
-      @media (max-width: 900px) {
+      @include bp.tablet-down {
         .activity-section {
           flex: none;
           min-height: 140px;

--- a/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
+++ b/web-wallet/src/app/mining/pages/mining-dashboard/mining-dashboard.component.ts
@@ -1708,7 +1708,11 @@ export class MiningDashboardComponent implements OnInit, OnDestroy {
    * navigation was silently cancel-redirected back to the dashboard).
    */
   readonly setupRoute = computed(() =>
-    this.appMode.isMiningOnly() || this.appMode.isMobileMode() ? '/miner/setup' : '/mining/setup'
+    this.appMode.isMiningOnly()
+      ? '/miner/setup'
+      : this.appMode.isMobileMode()
+        ? '/wallet/mining/setup'
+        : '/mining/setup'
   );
 
   // Use service signals directly so component state stays in lock-step with

--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -3277,10 +3277,22 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Where this wizard lives / exits to — the shell the user came from
+   * (mirrors the dashboard's setupRoute so Setup never swaps shells).
+   */
+  private get shellRoutes(): { setup: string; dashboard: string } {
+    if (this.appMode.isMiningOnly())
+      return { setup: '/miner/setup', dashboard: '/miner/dashboard' };
+    if (this.appMode.isMobileMode())
+      return { setup: '/wallet/mining/setup', dashboard: '/wallet/mining' };
+    return { setup: '/mining/setup', dashboard: '/mining' };
+  }
+
   /** Route to wallet onboarding; returnTo brings the user back to this step. */
   goToCreateWallet(): void {
     void this.router.navigate(['/wallet/create'], {
-      queryParams: { returnTo: '/miner/setup?step=1&fromWallet=1' },
+      queryParams: { returnTo: this.shellRoutes.setup + '?step=1&fromWallet=1' },
     });
   }
 
@@ -3413,7 +3425,7 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
   }
 
   cancel(): void {
-    this.router.navigate(['/mining']);
+    this.router.navigate([this.shellRoutes.dashboard]);
   }
 
   toggleAdvanced(step: string): void {
@@ -4379,7 +4391,7 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
 
       // Navigate to dashboard - user can start mining/plotting from there
       // Mining requires plot files to exist first
-      await this.router.navigate(['/mining']);
+      await this.router.navigate([this.shellRoutes.dashboard]);
     } catch (error) {
       console.error('Failed to save configuration:', error);
       this.snackBar.open(

--- a/web-wallet/src/app/shared/components/address-coins-list/address-coins-list.component.ts
+++ b/web-wallet/src/app/shared/components/address-coins-list/address-coins-list.component.ts
@@ -165,6 +165,8 @@ export function aggregateCoins(coins: WalletCoin[]): AddressBalance[] {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       /* Flex-fill the bounded parent (the wrapper's .coins-card) so the row
          viewport height is viewport-derived — giving FitRowsDirective a real
          height to measure under BOTH shells. */
@@ -330,7 +332,7 @@ export function aggregateCoins(coins: WalletCoin[]): AddressBalance[] {
       /* Responsive — reflow each table row to a stacked card below 600px
          (tablet portrait, phone). The address wraps at full width; the three
          stat cells collapse onto one meta line under it. */
-      @media (max-width: 600px) {
+      @include bp.phone {
         .table-header {
           display: none;
         }

--- a/web-wallet/src/app/shared/components/mnemonic-display/mnemonic-display.component.ts
+++ b/web-wallet/src/app/shared/components/mnemonic-display/mnemonic-display.component.ts
@@ -33,6 +33,8 @@ import { I18nPipe } from '../../../core/i18n';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .mnemonic-display {
         display: grid;
         grid-template-columns: repeat(4, 1fr);
@@ -66,7 +68,7 @@ import { I18nPipe } from '../../../core/i18n';
         margin-bottom: 16px;
       }
 
-      @media (max-width: 599px) {
+      @include bp.phone {
         .mnemonic-display {
           grid-template-columns: repeat(3, 1fr);
         }

--- a/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
+++ b/web-wallet/src/app/shared/components/mnemonic-entry/mnemonic-entry.component.ts
@@ -98,6 +98,8 @@ export interface MnemonicEntryState {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .word-length-selector {
         display: flex;
         gap: 8px;
@@ -192,7 +194,7 @@ export interface MnemonicEntryState {
         }
       }
 
-      @media (max-width: 599px) {
+      @include bp.phone {
         .mnemonic-input-grid {
           grid-template-columns: repeat(3, 1fr);
 

--- a/web-wallet/src/app/shared/components/page-layout/page-layout.component.ts
+++ b/web-wallet/src/app/shared/components/page-layout/page-layout.component.ts
@@ -85,6 +85,8 @@ export interface BreadcrumbItem {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .page-layout {
         min-height: 100vh;
         display: flex;
@@ -187,7 +189,7 @@ export interface BreadcrumbItem {
         }
       }
 
-      @media (max-width: 599px) {
+      @include bp.phone {
         .page-header-section {
           padding: 16px;
           min-height: 120px;

--- a/web-wallet/src/app/shared/components/step-header/step-header.component.ts
+++ b/web-wallet/src/app/shared/components/step-header/step-header.component.ts
@@ -35,6 +35,8 @@ import { Component, Input } from '@angular/core';
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       .step-header {
         padding: 16px 24px;
         background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
@@ -45,7 +47,7 @@ import { Component, Input } from '@angular/core';
         border-radius: 4px 4px 0 0;
       }
 
-      @media (max-width: 599px) {
+      @include bp.phone {
         .step-header {
           flex-direction: column;
           gap: 12px;

--- a/web-wallet/src/styles.scss
+++ b/web-wallet/src/styles.scss
@@ -1,6 +1,7 @@
 // Phoenix Wallet - Global Styles
 
 // Import custom theme (using @use to avoid deprecation warnings)
+@use 'breakpoints' as bp;
 @use 'styles/theme';
 @use 'styles/utilities';
 
@@ -50,7 +51,7 @@ body {
 }
 
 // Lowest breakpoint: both shared bands shrink by width.
-@media (max-width: 600px) {
+@include bp.phone {
   :root {
     --toolbar-h: 56px;
     --menu-balance-h: 68px;
@@ -419,7 +420,7 @@ a {
 // Responsive Utilities
 // ============================================================
 
-@media (max-width: 599px) {
+@include bp.phone {
   .hide-mobile {
     display: none !important;
   }
@@ -429,7 +430,7 @@ a {
   }
 }
 
-@media (min-width: 600px) {
+@media (min-width: (bp.$phone + 1)) {
   .hide-desktop {
     display: none !important;
   }
@@ -462,7 +463,7 @@ a {
   overflow-y: auto !important;
 }
 
-@media (max-width: 600px) {
+@include bp.phone {
   .lang-dropdown-menu {
     max-height: calc(100vh - 72px) !important; // smaller toolbar on mobile
   }


### PR DESCRIPTION
Hybrid-APK review round 8:

- **Transactions header breaks on phone (too many icons)**: the load-limit icon now lives inside the funnel-revealed filter row (same `mat-menu`, second trigger); the header keeps exactly two icons (funnel + refresh, gap 0) and no longer wraps at 360-400px. Funnel-active color switched from amber to the toolbar green (#4caf50).
- **Mining shares the wallet-shell top row**: added the desktop toolbar's miner indicator (hardware icon, green when `minerRunning()`, tooltip) to the wallet-shell toolbar, gated on `miningEnabled() && isConfigured()`. Plotter icon deliberately omitted — limited space.
- **Transaction Builder wrap point**: on phone the output row now breaks *after* the contacts button (explicit flex `row-break`), so line one = address + contact picker, line two = amount + max + remove.

Screenshot-verified at 390px in the dev session (transactions header/filter row and builder wrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX