### PR TITLE
fix(mobile): Android round-9 — toolbar miner icon, drawer balance, wizard stats, direct I/O default, notification settings

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -34,6 +34,7 @@ import {
 } from '../../../shared/components';
 import { isInvalidWalletName, isWalletNameTaken } from '../wallet-name';
 import { MobileNavComponent } from '../../../shared/components/mobile-nav/mobile-nav.component';
+import { FitTextDirective } from '../../../shared/directives';
 import { ElectrumServerListComponent } from '../../../shared/components/electrum-server-list/electrum-server-list.component';
 
 /** Width of ONE swipe-revealed action button in the wallet menu, px. */
@@ -101,6 +102,7 @@ interface NavGroup {
     MatTooltipModule,
     MobileNavComponent,
     ElectrumServerListComponent,
+    FitTextDirective,
     BtcxPipe,
     TimeAgoPipe,
     I18nPipe,
@@ -142,8 +144,8 @@ interface NavGroup {
         @if (wallet.hasSeed()) {
           <div class="drawer-wallet-info">
             <div class="drawer-wallet-name">{{ activeLabel() }}</div>
-            <div class="drawer-wallet-balance">
-              {{ (wallet.balance()?.totalSat ?? 0) / 100000000 | btcx }} BTCX
+            <div class="drawer-wallet-balance" appFitText [fitTextMinPx]="11">
+              {{ (wallet.balance()?.totalSat ?? 0) / 100000000 | btcx }}&nbsp;BTCX
             </div>
           </div>
         }
@@ -287,20 +289,23 @@ interface NavGroup {
                   }
                 </div>
               </mat-menu>
-            </div>
 
-            <!-- Miner indicator (the desktop toolbar's hardware icon; the
-                 plotter icon is deliberately omitted — no toolbar space) -->
-            @if (miningAvailable() && miningService.isConfigured()) {
-              <div
-                class="status-indicator"
-                [matTooltip]="
-                  miningService.minerRunning() ? ('miner_running' | i18n) : ('miner_stopped' | i18n)
-                "
-              >
-                <mat-icon [class.miner-active]="miningService.minerRunning()">hardware</mat-icon>
-              </div>
-            }
+              <!-- Miner indicator (the desktop toolbar's hardware icon,
+                   right next to the electrum bolt; the plotter icon is
+                   deliberately omitted — no toolbar space) -->
+              @if (miningAvailable() && miningService.isConfigured()) {
+                <div
+                  class="status-indicator"
+                  [matTooltip]="
+                    miningService.minerRunning()
+                      ? ('miner_running' | i18n)
+                      : ('miner_stopped' | i18n)
+                  "
+                >
+                  <mat-icon [class.miner-active]="miningService.minerRunning()">hardware</mat-icon>
+                </div>
+              }
+            </div>
 
             <div class="toolbar-right">
               @if (wallet.hasSeed()) {
@@ -665,6 +670,8 @@ interface NavGroup {
           font-size: 17px;
           font-weight: 500;
           font-variant-numeric: tabular-nums;
+          /* Never break between amount and unit — FitText shrinks instead. */
+          white-space: nowrap;
         }
       }
 
@@ -1410,6 +1417,12 @@ export class MobileWalletLayoutComponent implements OnInit {
   ngOnInit(): void {
     // Lazy init: only mobile wallet routes touch the btcx wallet backend
     void this.wallet.initialize();
+    // Hybrid flavors: hook up miner state + events so the toolbar's miner
+    // indicator is live without ever visiting the mining dashboard
+    // (idempotent — the dashboard makes the same call).
+    if (this.miningAvailable()) {
+      void this.miningService.initializeMining();
+    }
   }
 
   /** Popover open: fresh server snapshots + tip header (last block time). */

--- a/web-wallet/src/app/features/mobile-wallet/pages/settings/wallet-settings.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/pages/settings/wallet-settings.component.ts
@@ -1,17 +1,23 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
+import { Store } from '@ngrx/store';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { I18nPipe, I18nService } from '../../../../core/i18n';
 import { NotificationService } from '../../../../shared/services';
 import { BtcxWalletService, BtcxNetwork } from '../../../../core/services/btcx-wallet.service';
 import { ElectrumServersEditorComponent } from '../../../../shared/components/electrum-servers-editor/electrum-servers-editor.component';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 import { ElectronService } from '../../../../core/services/electron.service';
+import { SettingsActions } from '../../../../store/settings/settings.actions';
+import { selectNotifications } from '../../../../store/settings/settings.selectors';
+import type { NotificationSettings } from '../../../../store/settings/settings.state';
 
 /**
  * WalletSettingsComponent - mobile wallet settings.
@@ -33,6 +39,7 @@ import { ElectronService } from '../../../../core/services/electron.service';
     MatInputModule,
     MatSelectModule,
     MatProgressSpinnerModule,
+    MatSlideToggleModule,
     I18nPipe,
     ElectrumServersEditorComponent,
     PageHeaderComponent,
@@ -71,6 +78,56 @@ import { ElectronService } from '../../../../core/services/electron.service';
           [showTest]="true"
           (serversChange)="saveServers($event)"
         />
+      </div>
+
+      <!-- Notifications (the desktop settings tab, mobile-sized). Mining/
+           plotting status notifications are NOT listed — the Android
+           foreground service requires its persistent notification, so they
+           are always on. -->
+      <div class="card">
+        <h3>{{ 'notifications' | i18n }}</h3>
+        <div class="toggle-row master">
+          <span>{{
+            notifications().enabled
+              ? ('notifications_enabled' | i18n)
+              : ('notifications_disabled' | i18n)
+          }}</span>
+          <mat-slide-toggle
+            [checked]="notifications().enabled"
+            (change)="setNotification('enabled', $event.checked)"
+          />
+        </div>
+        @if (notifications().enabled) {
+          <div class="toggle-row">
+            <span>{{ 'incoming_payment' | i18n }}</span>
+            <mat-slide-toggle
+              [checked]="notifications().incomingPayment"
+              (change)="setNotification('incomingPayment', $event.checked)"
+            />
+          </div>
+          <div class="toggle-row">
+            <span>{{ 'payment_confirmed' | i18n }}</span>
+            <mat-slide-toggle
+              [checked]="notifications().paymentConfirmed"
+              (change)="setNotification('paymentConfirmed', $event.checked)"
+            />
+          </div>
+          <div class="toggle-row">
+            <span>{{ 'node_connected' | i18n }}</span>
+            <mat-slide-toggle
+              [checked]="notifications().nodeConnected"
+              (change)="setNotification('nodeConnected', $event.checked)"
+            />
+          </div>
+          <div class="toggle-row">
+            <span>{{ 'node_disconnected' | i18n }}</span>
+            <mat-slide-toggle
+              [checked]="notifications().nodeDisconnected"
+              (change)="setNotification('nodeDisconnected', $event.checked)"
+            />
+          </div>
+        }
+        <p class="hint-text">{{ 'notifications_mining_always_on' | i18n }}</p>
       </div>
 
       <!-- Lock (passphrase-encrypted seeds only) -->
@@ -192,11 +249,34 @@ import { ElectronService } from '../../../../core/services/electron.service';
           color: rgba(255, 255, 255, 0.6);
         }
       }
+
+      .toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 6px 0;
+        font-size: 14px;
+
+        &.master {
+          font-weight: 500;
+        }
+      }
     `,
   ],
 })
 export class WalletSettingsComponent implements OnInit {
   readonly wallet = inject(BtcxWalletService);
+  private readonly store = inject(Store);
+
+  /** Live notification settings (same store slice the desktop tab edits). */
+  readonly notifications = toSignal(this.store.select(selectNotifications), {
+    requireSync: true,
+  });
+
+  setNotification(key: keyof NotificationSettings, value: boolean): void {
+    this.store.dispatch(SettingsActions.updateNotifications({ notifications: { [key]: value } }));
+  }
+
   private readonly notification = inject(NotificationService);
   private readonly i18n = inject(I18nService);
   private readonly electron = inject(ElectronService);

--- a/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
+++ b/web-wallet/src/app/mining/pages/setup-wizard/setup-wizard.component.ts
@@ -1244,6 +1244,8 @@ interface ChainModalData {
   `,
   styles: [
     `
+      @use 'breakpoints' as bp;
+
       * {
         box-sizing: border-box;
       }
@@ -2702,6 +2704,29 @@ interface ChainModalData {
         text-align: right;
         padding-right: 8px;
       }
+
+      /* Phone: the drives summary is 4 monospace stats side by side —
+         desktop sizing overflows a 360-400px card. */
+      @include bp.phone {
+        .drives-summary {
+          justify-content: space-between;
+          gap: 8px;
+          padding: 8px 10px;
+        }
+
+        .drives-summary .summary-value {
+          font-size: 13px;
+        }
+
+        .drives-summary .summary-label {
+          font-size: 9px;
+          letter-spacing: 0.3px;
+        }
+
+        .drive-header .capacity-badge {
+          font-size: 11px;
+        }
+      }
     `,
   ],
 })
@@ -2952,8 +2977,8 @@ export class SetupWizardComponent implements OnInit, OnDestroy {
       // Custom address until the nodeless wallet state resolves
       // (initMobileWalletAddress may flip this to the wallet address)
       this.useCustomAddress.set(true);
-      this.directIo.set(false); // Direct I/O not reliable on Android
-      this.miningDirectIo.set(false); // Direct I/O not reliable on Android
+      // Direct I/O stays at the enabled default (same as desktop) —
+      // the old "not reliable on Android" blanket-off is obsolete.
     }
 
     // Check for step query parameter FIRST to avoid visual jump

--- a/web-wallet/src/assets/locales/en.json
+++ b/web-wallet/src/assets/locales/en.json
@@ -666,6 +666,7 @@
   "notifications": "Notifications",
   "notifications_disabled": "Notifications disabled",
   "notifications_enabled": "Notifications enabled",
+  "notifications_mining_always_on": "Mining and plotting status notifications are always on — the background service requires them.",
   "of_label": "of",
   "open_wallet": "Open Wallet",
   "options": "Options",


### PR DESCRIPTION
Hybrid-APK review round 9:

1. **Miner toolbar icon**: moved inside the left toolbar cluster (was between the flex clusters → rendered mid-bar) and now live from app start — the wallet shell calls `initializeMining()` on boot, so the icon reflects the running miner without ever opening the mining dashboard.
2. **Drawer balance**: `white-space: nowrap` + `FitTextDirective` (min 11px) — never breaks between amount and currency, shrinks like the balance card instead.
3. **Setup wizard plot-directories stats**: phone tier added (the wizard had no responsive rules at all) — summary values 13px, labels 9px, tight gaps, smaller capacity badge.
4. **Direct I/O**: removed the Android default-off override ("not reliable on Android") — plotter and mining direct I/O now default to enabled on all platforms, matching the desktop/Rust defaults.
5. **Mobile settings — Notifications card** (below Electrum servers, above the v30 funds check): master toggle + incoming payment / payment confirmed / connection lost / connection restored, dispatching to the existing settings store slice (`PocxNotificationService` already respects it). Mining/plotting status notifications are deliberately absent — the Android foreground service requires its notification, noted via hint text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX