### PR TITLE
fix(mobile): live miner indicator + miner-context toolbar on mining pages

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1,6 +1,8 @@
-import { Component, computed, inject, signal, viewChild, OnInit } from '@angular/core';
+import { Component, computed, effect, inject, signal, viewChild, OnInit } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { DecimalPipe } from '@angular/common';
-import { Router, RouterModule } from '@angular/router';
+import { NavigationEnd, Router, RouterModule } from '@angular/router';
+import { filter, map } from 'rxjs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -297,18 +299,18 @@ interface NavGroup {
                 <div
                   class="status-indicator"
                   [matTooltip]="
-                    miningService.minerRunning()
+                    miningService.minerActive()
                       ? ('miner_running' | i18n)
                       : ('miner_stopped' | i18n)
                   "
                 >
-                  <mat-icon [class.miner-active]="miningService.minerRunning()">hardware</mat-icon>
+                  <mat-icon [class.miner-active]="miningService.minerActive()">hardware</mat-icon>
                 </div>
               }
             </div>
 
             <div class="toolbar-right">
-              @if (wallet.hasSeed()) {
+              @if (wallet.hasSeed() && !onMiningPage()) {
                 <!-- Wallet switcher chip (desktop toolbar's wallet selector) -->
                 <!-- Icon-only chip: the toolbar is too narrow for names —
                      the drawer header carries the full wallet · pocket
@@ -474,11 +476,13 @@ interface NavGroup {
                 <div class="toolbar-separator"></div>
               }
 
+              <!-- On the mining pages the gear is the MINER's settings
+                   (the setup wizard), like the mining-only shell. -->
               <button
                 mat-button
                 class="action-button icon-button"
-                [routerLink]="['/wallet/settings']"
-                [matTooltip]="'mwallet_settings_title' | i18n"
+                [routerLink]="onMiningPage() ? '/wallet/mining/setup' : '/wallet/settings'"
+                [matTooltip]="(onMiningPage() ? 'mining_setup' : 'mwallet_settings_title') | i18n"
               >
                 <mat-icon class="secondary-text">settings</mat-icon>
               </button>
@@ -1322,8 +1326,21 @@ export class MobileWalletLayoutComponent implements OnInit {
   private readonly appMode = inject(AppModeService);
   /** Mining exists in this shell (hybrid flavors) — wallet-only has none. */
   readonly miningAvailable = computed(() => this.appMode.miningEnabled());
-  private readonly notification = inject(NotificationService);
+
   private readonly router = inject(Router);
+
+  /** Current router url (NavigationEnd-driven). */
+  private readonly currentUrl = toSignal(
+    this.router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map(() => this.router.url)
+    ),
+    { initialValue: this.router.url }
+  );
+
+  /** Mining dashboard/setup: wallet chrome (chips) hides, gear goes to setup. */
+  readonly onMiningPage = computed(() => this.currentUrl().startsWith('/wallet/mining'));
+  private readonly notification = inject(NotificationService);
   private readonly dialog = inject(MatDialog);
   private readonly appUpdateService = inject(AppUpdateService);
 
@@ -1414,15 +1431,22 @@ export class MobileWalletLayoutComponent implements OnInit {
    */
   readonly chain = signal<BtcxChainInfo | null>(null);
 
+  constructor() {
+    // Hybrid flavors: hook up miner state + events so the toolbar's miner
+    // indicator is live without ever visiting the mining dashboard.
+    // Effect (not ngOnInit): launch-mode flags resolve ASYNC, so at init
+    // time miningAvailable() may still be false — this fires when it
+    // flips (initializeMining is idempotent).
+    effect(() => {
+      if (this.miningAvailable()) {
+        void this.miningService.initializeMining();
+      }
+    });
+  }
+
   ngOnInit(): void {
     // Lazy init: only mobile wallet routes touch the btcx wallet backend
     void this.wallet.initialize();
-    // Hybrid flavors: hook up miner state + events so the toolbar's miner
-    // indicator is live without ever visiting the mining dashboard
-    // (idempotent — the dashboard makes the same call).
-    if (this.miningAvailable()) {
-      void this.miningService.initializeMining();
-    }
   }
 
   /** Popover open: fresh server snapshots + tip header (last block time). */

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -136,10 +136,10 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
               <div
                 class="status-indicator"
                 [matTooltip]="
-                  miningService.minerRunning() ? ('miner_running' | i18n) : ('miner_stopped' | i18n)
+                  miningService.minerActive() ? ('miner_running' | i18n) : ('miner_stopped' | i18n)
                 "
               >
-                <mat-icon [class.active]="miningService.minerRunning()">hardware</mat-icon>
+                <mat-icon [class.active]="miningService.minerActive()">hardware</mat-icon>
               </div>
             }
 

--- a/web-wallet/src/app/mining/services/mining.service.ts
+++ b/web-wallet/src/app/mining/services/mining.service.ts
@@ -179,6 +179,19 @@ export class MiningService {
   // Miner state computed values
   readonly minerState = this._minerState.asReadonly();
   readonly minerRunning = computed(() => this._minerState().running);
+  /**
+   * Miner-is-active for INDICATORS: runtime running flag OR the backend's
+   * persisted mining status. The runtime flag only flips when THIS webview
+   * session called start/stop or hooked the events — after an Android
+   * activity recreate (webview reboot over a live foreground service) it
+   * starts false while the backend is still mining; the backend status
+   * covers that. miner:stopped triggers a refreshState() so the backend
+   * side never sticks.
+   */
+  readonly minerActive = computed(
+    () =>
+      this._minerState().running || (this._state()?.miningStatus.type ?? 'stopped') !== 'stopped'
+  );
   readonly minerStopping = computed(() => this._minerState().stopping);
   readonly minerCapacityTib = computed(() => this._minerState().capacityTib);
   readonly minerQueue = computed(() => this._minerState().queue);
@@ -455,13 +468,15 @@ export class MiningService {
       return;
     }
 
+    // Listeners always — mining can start behind this session's back
+    // (auto-start race, foreground service surviving a webview reload),
+    // and the stopped/progress events must land regardless.
+    await this.setupMinerEventListeners();
+
     // Check if miner is running (anything except 'stopped')
     const isRunning = state.miningStatus.type !== 'stopped';
     if (isRunning) {
-      console.log('MiningService: Miner already running, setting up listeners');
-      await this.setupMinerEventListeners();
-
-      // Update miner runtime state to reflect running status
+      console.log('MiningService: Miner already running');
       this._minerState.update(s => ({ ...s, running: true }));
     }
 
@@ -2341,6 +2356,8 @@ export class MiningService {
         stopping: false,
         queue: [],
       }));
+      // Resync the persisted status so minerActive drops with the runtime.
+      void this.refreshState();
       // Don't cleanup listeners - they stay active permanently
     });
     this._minerUnlisteners.push(stoppedUnlisten);


### PR DESCRIPTION
Round-9 follow-ups:

1. **Miner icon stayed grey while mining**: `minerRunning` is a session-runtime flag — it never learns about mining that started outside this webview session (Android activity recreate over a live foreground service; auto-start racing the async launch-mode flags, which could also skip the shell's init entirely). New `minerActive` computed blends the runtime flag with the backend's persisted mining status; `initializeMining()` always subscribes the miner events now, `miner:stopped` re-syncs the persisted state, and the wallet shell inits via an `effect()` that fires once the launch-mode flags actually resolve. Both toolbars (desktop + wallet shell) use it.
2. **Mining pages get the miner's toolbar context**: on `/wallet/mining*` the wallet and pocket chips hide and the settings gear navigates to the in-shell setup wizard instead of wallet settings — mirroring the mining-only shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX