### PR TITLE
fix(mobile): miner-active green missing in light theme

### DIFF
--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -1075,6 +1075,10 @@ interface NavGroup {
           &.electrum-connecting {
             color: rgba(0, 0, 0, 0.38);
           }
+
+          &.miner-active {
+            color: #4caf50;
+          }
         }
 
         &.clickable {


### PR DESCRIPTION
The .miner-active color rule only existed inside the
:host-context(.dark-theme) block — in light theme the class applied
but nothing styled it, so the toolbar miner icon stayed grey while
mining. Mirror it in the base (light) status-indicator block, same as
the electrum state colors.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX
