### PR TITLE
fix(android): per-flavor launcher label + drop toolbar app-name string

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -167,10 +167,20 @@ jobs:
           test -f "$STRINGS" || { echo "ERROR: $STRINGS not found (did tauri android init run?)"; exit 1; }
           grep -q '<string name="app_name">' "$STRINGS" || { echo "ERROR: app_name string not found in $STRINGS"; exit 1; }
           sed -i "s#<string name=\"app_name\">[^<]*</string>#<string name=\"app_name\">${PHX_APP_NAME}</string>#" "$STRINGS"
+          # The LAUNCHER label is the ACTIVITY's label — tauri's manifest points
+          # it at main_activity_title, so patching app_name alone leaves the
+          # visible name unchanged. Patch both.
+          sed -i "s#<string name=\"main_activity_title\">[^<]*</string>#<string name=\"main_activity_title\">${PHX_APP_NAME}</string>#" "$STRINGS"
           echo "Set launcher label to: ${PHX_APP_NAME}"
-          grep '<string name="app_name">' "$STRINGS"
-          # Re-assert the new label actually landed.
+          cat "$STRINGS"
+          # Re-assert the new label actually landed (app_name always; the
+          # activity title wherever the template defines it).
           grep -q "<string name=\"app_name\">${PHX_APP_NAME}</string>" "$STRINGS" || { echo "ERROR: app_name patch did not apply"; exit 1; }
+          if grep -q '<string name="main_activity_title">' "$STRINGS"; then
+            grep -q "<string name=\"main_activity_title\">${PHX_APP_NAME}</string>" "$STRINGS" || { echo "ERROR: main_activity_title patch did not apply"; exit 1; }
+          else
+            echo "WARNING: no main_activity_title in strings.xml - launcher label rides app_name"
+          fi
 
       - name: Build Android APK (ARM64 only) — ${{ matrix.flavor }}
         working-directory: web-wallet

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -195,10 +195,20 @@ jobs:
           test -f "$STRINGS" || { echo "ERROR: $STRINGS not found (did tauri android init run?)"; exit 1; }
           grep -q '<string name="app_name">' "$STRINGS" || { echo "ERROR: app_name string not found in $STRINGS"; exit 1; }
           sed -i "s#<string name=\"app_name\">[^<]*</string>#<string name=\"app_name\">${PHX_APP_NAME}</string>#" "$STRINGS"
+          # The LAUNCHER label is the ACTIVITY's label — tauri's manifest points
+          # it at main_activity_title, so patching app_name alone leaves the
+          # visible name unchanged. Patch both.
+          sed -i "s#<string name=\"main_activity_title\">[^<]*</string>#<string name=\"main_activity_title\">${PHX_APP_NAME}</string>#" "$STRINGS"
           echo "Set launcher label to: ${PHX_APP_NAME}"
-          grep '<string name="app_name">' "$STRINGS"
-          # Re-assert the new label actually landed.
+          cat "$STRINGS"
+          # Re-assert the new label actually landed (app_name always; the
+          # activity title wherever the template defines it).
           grep -q "<string name=\"app_name\">${PHX_APP_NAME}</string>" "$STRINGS" || { echo "ERROR: app_name patch did not apply"; exit 1; }
+          if grep -q '<string name="main_activity_title">' "$STRINGS"; then
+            grep -q "<string name=\"main_activity_title\">${PHX_APP_NAME}</string>" "$STRINGS" || { echo "ERROR: main_activity_title patch did not apply"; exit 1; }
+          else
+            echo "WARNING: no main_activity_title in strings.xml - launcher label rides app_name"
+          fi
 
       - name: Build Android APK (ARM64 only) — ${{ matrix.flavor }}
         working-directory: web-wallet

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -222,10 +222,6 @@ interface NavGroup {
 
               <div class="toolbar-separator"></div>
 
-              @if (!wallet.hasSeed()) {
-                <span class="app-name">{{ 'mwallet_title' | i18n }}</span>
-              }
-
               @if (wallet.network() !== 'mainnet') {
                 <span class="network-badge">{{ wallet.network() | i18n }}</span>
               }
@@ -800,15 +796,6 @@ interface NavGroup {
         min-width: 0;
       }
 
-      .app-name {
-        font-size: 16px;
-        font-weight: 500;
-        color: rgba(0, 0, 0, 0.87);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
       /* Wallet switcher chip — the desktop toolbar's .wallet-button, compact. */
       .wallet-chip {
         min-width: 0;
@@ -1250,10 +1237,6 @@ interface NavGroup {
         .wallet-toolbar {
           background-color: #424242 !important;
           color: white !important;
-        }
-
-        .app-name {
-          color: white;
         }
 
         .wallet-chip-content {


### PR DESCRIPTION
- The workflows patched only app_name in strings.xml, but tauri's
  generated manifest labels the launcher ACTIVITY with
  main_activity_title — so every flavor still displayed the productName
  ("Phoenix Wallet"). Patch both strings (test + release workflows);
  hybrid = "Phoenix Suite", wallet = "Phoenix Wallet", miner =
  "Phoenix Miner".
- Remove the toolbar app-name span ("Wallet", clipped to nonsense on
  narrow phones) from the wallet shell in all versions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX
