### PR TITLE
fix(psbt): phone layouts + finalized-PSBT broadcast + auto-finalize everywhere

### DIFF
--- a/handbook/chapters/ch08-sending.md
+++ b/handbook/chapters/ch08-sending.md
@@ -221,7 +221,7 @@ Once a PSBT exists, a step indicator across the top tracks it through its life: 
 
 *Sign on device* (hardware wallet) is shown but marked **coming soon**.
 
-**Finalize.** Once all required signatures are present (status *Signed*), **Finalize** seals the inputs. After finalizing, the transaction can no longer be edited.
+**Finalize.** Once all required signatures are present (status *Signed*), **Finalize** seals the inputs. After finalizing, the transaction can no longer be edited. When *your own* signature is the one that completes the transaction — the everyday single-signer case — signing seals it in the same action, and the flow jumps straight from Sign to Broadcast; the explicit Finalize stop exists for the multi-party flows, where signatures are collected and combined before sealing.
 
 **Broadcast.** The final step sends the finalized transaction to the network. There are two possible targets: your **local node** (*"bitcoind on this machine"*) when Phoenix runs a managed or external node, and a **remote Electrum server** (*"Broadcast through a remote server — no local node required"*) when a server is configured — the latter is how a nodeless wallet broadcasts without any local node (Chapter 26). On success, Phoenix shows a **Transaction broadcast** confirmation with the copyable txid and buttons to view your transactions or start another.
 

--- a/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
@@ -1287,6 +1287,27 @@ const UTXO_PAGE_SIZE = 10;
 
       // Responsive
       @include bp.phone {
+        /* Manual coin selection: the search field's Material minimum plus
+           the op button and amount box exceed a phone row - wrap, with the
+           search on its own line. */
+        .filter-row {
+          flex-wrap: wrap;
+
+          .grow-field {
+            flex: 1 1 100%;
+          }
+
+          .size-field {
+            flex: 1 1 auto;
+            width: auto;
+          }
+        }
+
+        .utxo-pager {
+          flex-wrap: wrap;
+          gap: 4px;
+        }
+
         .output-row {
           flex-wrap: wrap;
 

--- a/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
+++ b/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
@@ -1598,6 +1598,22 @@ type PsbtView = 'start' | 'compose' | 'doc' | 'success';
           padding: 16px;
         }
 
+        /* Six footer buttons never fit one row on a phone - wrap into a
+           2x3 grid (the spacer would break the grid, so it goes). */
+        .wizard-footer {
+          flex-wrap: wrap;
+
+          .spacer {
+            display: none;
+          }
+
+          button {
+            flex: 1 1 calc(33.33% - 7px);
+            min-width: 0;
+            padding: 0 4px;
+          }
+        }
+
         .actions button {
           flex: 1 1 auto;
         }
@@ -1974,6 +1990,11 @@ export class PsbtComponent implements OnInit {
           this.psbtService.saveDraft(draft);
         }
       }
+      // AFTER the draft bookkeeping (which resets finalHex for fresh
+      // imports): an already-final document gets its raw hex extracted so
+      // Broadcast is live without an explicit finalize step.
+      await this.ensureFinalHex(this.doc()!);
+      this.syncDraft();
       this.view.set('doc');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -2020,8 +2041,11 @@ export class PsbtComponent implements OnInit {
       }
       if (!(await this.ensureWalletUnlocked(walletName))) return;
       const sigsBefore = document.sigsCollected;
-      // finalize=false keeps sealing an explicit, separate step (the
-      // client-side signer leaves foreign inputs untouched too)
+      // finalize=true: when this signature COMPLETES the transaction it is
+      // sealed in the same action and the flow jumps straight to Broadcast —
+      // the same behavior the client-side (BDK) signer has always had, now
+      // unified across modes. Incomplete signings (multisig, foreign inputs)
+      // still stop at the explicit combine/finalize step.
       const result = this.isRemote()
         ? await this.btcxWallet.psbtProcess(document.base64)
         : await this.walletRpc.walletProcessPsbt(
@@ -2030,13 +2054,14 @@ export class PsbtComponent implements OnInit {
             true,
             'ALL',
             true,
-            false
+            true
           );
       // walletprocesspsbt also acts as an updater (adds derivation/UTXO
       // data), so a changed string does NOT prove a signature was added —
       // compare actual signature counts instead.
       const updated = await this.psbtService.buildDocument(result.psbt);
       this.doc.set(updated);
+      await this.ensureFinalHex(updated);
       this.syncDraft();
       if (updated.sigsCollected > sigsBefore || result.complete) {
         this.notification.success(this.i18n.get('psbt_signed'));
@@ -2161,6 +2186,27 @@ export class PsbtComponent implements OnInit {
       this.docError.set(error instanceof Error ? error.message : String(error));
     } finally {
       this.finalizing.set(false);
+    }
+  }
+
+  /**
+   * A document can arrive ALREADY finalized without finalize() ever running
+   * here — the client-side (BDK) signer seals the PSBT as a side effect once
+   * the last signature lands, and an imported/draft PSBT may be final too.
+   * The broadcast button needs the raw hex, so extract it on demand.
+   */
+  private async ensureFinalHex(document: PsbtDocument): Promise<void> {
+    if (document.status !== 'finalized' || this.finalHex()) return;
+    try {
+      if (this.isRemote()) {
+        const result = await this.btcxWallet.psbtFinalize(document.base64);
+        if (result.complete && result.hex) this.finalHex.set(result.hex);
+      } else {
+        const extracted = await this.walletRpc.finalizePsbt(document.base64, true);
+        if (extracted.hex) this.finalHex.set(extracted.hex);
+      }
+    } catch (error) {
+      console.warn('ensureFinalHex failed:', error);
     }
   }
 


### PR DESCRIPTION
- Manual coin selection no longer overflows a phone: the filter row
  wraps (search on its own line - its Material minimum width was the
  culprit), and the UTXO pager wraps.
- The six wizard-footer buttons wrap into a 2x3 grid at phone width
  (spacer dropped there, 110px minimum lifted).
- A document that arrives ALREADY finalized (the BDK signer seals on
  the completing signature; imported/final drafts too) now gets its raw
  hex extracted on demand - Broadcast was permanently disabled in that
  state because only the explicit finalize action ever produced the hex.
- Unified finalize semantics (Johnny's ruling): Core walletprocesspsbt
  now also finalize=true, so a completing signature seals and jumps to
  Broadcast in every mode; the explicit Finalize stop remains for
  multi-party flows. Handbook ch08 updated to match.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX
