### PR TITLE
fix(fees): honor 0.1 sat/vB + live estimates + review fee rate (round 11)

### DIFF
--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "electrum-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
 dependencies = [
  "anyhow",
  "bdk_wallet",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "keys-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
 dependencies = [
  "anyhow",
  "bip39",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "params-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5319,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "seedstore"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
 dependencies = [
  "anyhow",
  "bip39",
@@ -7267,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "wallet-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
 dependencies = [
  "anyhow",
  "bdk_wallet",

--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "electrum-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
 dependencies = [
  "anyhow",
  "bdk_wallet",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "keys-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
 dependencies = [
  "anyhow",
  "bip39",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "params-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5319,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "seedstore"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
 dependencies = [
  "anyhow",
  "bip39",
@@ -7267,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "wallet-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=292fcc3e9d7853407099666271e5947bc08165d9#292fcc3e9d7853407099666271e5947bc08165d9"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=9d29326e945093a1f10fac0a79aee62d7f51c0f8#9d29326e945093a1f10fac0a79aee62d7f51c0f8"
 dependencies = [
  "anyhow",
  "bdk_wallet",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -100,11 +100,11 @@ pocx_aggregator = { version = "1.0.5", optional = true }
 
 
 # Nodeless BTCX wallet stack (shared btcx crates) — gated by the `wallet` feature
-params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
-keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
-seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
-electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
-wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "292fcc3e9d7853407099666271e5947bc08165d9", optional = true }
+params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
+keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
+seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
+electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
+wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
 bitcoin = { version = "0.32", features = ["serde", "rand-std"], optional = true }
 bdk_wallet = { version = "2", features = ["rusqlite"], optional = true }
 # bech32 with custom HRPs (pocx/tpocx/rpocx) â€” same version the btcx crates use

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -100,11 +100,11 @@ pocx_aggregator = { version = "1.0.5", optional = true }
 
 
 # Nodeless BTCX wallet stack (shared btcx crates) — gated by the `wallet` feature
-params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
-keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
-seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
-electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
-wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "9d29326e945093a1f10fac0a79aee62d7f51c0f8", optional = true }
+params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
+keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
+seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
+electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
+wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
 bitcoin = { version = "0.32", features = ["serde", "rand-std"], optional = true }
 bdk_wallet = { version = "2", features = ["rusqlite"], optional = true }
 # bech32 with custom HRPs (pocx/tpocx/rpocx) â€” same version the btcx crates use

--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -2205,7 +2205,7 @@ pub async fn btcx_wallet_fee_estimates(
         let chain = backend.chain();
         let vb = |kvb: Option<u64>| kvb.map(|rate| rate as f64 / 1000.0);
         Ok(BtcxFeeEstimates {
-            min_sat_per_vb: backend.params().min_feerate_sat_vb as f64,
+            min_sat_per_vb: backend.params().min_feerate_sat_kvb as f64 / 1000.0,
             fast: vb(chain.fee_estimate_kvb(1).map_err(|e| format!("{e:#}"))?),
             normal: vb(chain.fee_estimate_kvb(6).map_err(|e| format!("{e:#}"))?),
             slow: vb(chain.fee_estimate_kvb(144).map_err(|e| format!("{e:#}"))?),

--- a/web-wallet/src-tauri/src/btcx_wallet/psbt.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/psbt.rs
@@ -270,10 +270,39 @@ pub fn analyze(psbt_base64: &str) -> Result<PsbtAnalyzeDto, String> {
     };
 
     let fee_sat = psbt.fee().ok().map(|f| f.to_sat());
+    // Extractable → exact vsize. Otherwise ESTIMATE it: unsigned weight plus
+    // the standard satisfaction weight of every still-open input (P2WPKH
+    // ~108 WU, P2TR key-path ~66 WU) — so the review shows a fee rate
+    // before signing, not just after finalize.
     let estimated_vsize = if next == "extractor" {
         psbt.clone().extract_tx().ok().map(|tx| tx.vsize() as u64)
     } else {
-        None
+        let tx = &psbt.unsigned_tx;
+        let mut wu = tx.weight().to_wu();
+        let mut known = !tx.input.is_empty();
+        let mut any_witness = false;
+        for (i, inp) in psbt.inputs.iter().enumerate() {
+            if let Some(w) = &inp.final_script_witness {
+                any_witness = true;
+                wu += w.size() as u64;
+            } else {
+                match input_utxo(&psbt, i).map(|u| u.script_pubkey.clone()) {
+                    Some(spk) if spk.is_p2wpkh() => {
+                        any_witness = true;
+                        wu += 108;
+                    }
+                    Some(spk) if spk.is_p2tr() => {
+                        any_witness = true;
+                        wu += 66;
+                    }
+                    _ => known = false,
+                }
+            }
+        }
+        if any_witness {
+            wu += 2; // segwit marker + flag
+        }
+        known.then(|| wu.div_ceil(4))
     };
     let estimated_fee_rate_sat_vb = match (fee_sat, estimated_vsize) {
         (Some(fee), Some(vsize)) if vsize > 0 => Some(fee as f64 / vsize as f64),

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -18,8 +18,8 @@
         "height": 900,
         "resizable": true,
         "fullscreen": false,
-        "minWidth": 800,
-        "minHeight": 600
+        "minWidth": 320,
+        "minHeight": 480
       }
     ],
     "security": {

--- a/web-wallet/src-tauri/tauri.conf.json
+++ b/web-wallet/src-tauri/tauri.conf.json
@@ -18,8 +18,8 @@
         "height": 900,
         "resizable": true,
         "fullscreen": false,
-        "minWidth": 320,
-        "minHeight": 480
+        "minWidth": 800,
+        "minHeight": 600
       }
     ],
     "security": {

--- a/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
+++ b/web-wallet/src/app/features/psbt/components/psbt-compose/psbt-compose.component.ts
@@ -443,7 +443,14 @@ const UTXO_PAGE_SIZE = 10;
           @if (selectedFee?.custom) {
             <mat-form-field appearance="outline" class="custom-fee-field">
               <mat-label>{{ 'fee_rate' | i18n }} (sat/vB)</mat-label>
-              <input matInput type="number" min="0.1" step="0.001" [(ngModel)]="customFeeRate" />
+              <input
+                matInput
+                type="number"
+                min="0.1"
+                step="0.001"
+                [(ngModel)]="customFeeRate"
+                (ngModelChange)="feeVersion.set(feeVersion() + 1)"
+              />
             </mat-form-field>
           }
         </div>
@@ -1398,7 +1405,7 @@ export class PsbtComposeComponent implements OnInit {
   selectedFee: FeeChip | null = null;
   customFeeRate: number | null = 1;
   /** Bumped on fee selection/edit so computed summaries recalculate */
-  private readonly feeVersion = signal(0);
+  readonly feeVersion = signal(0);
 
   filteredUtxos = computed(() => {
     const text = this.utxoFilterText().trim().toLowerCase();
@@ -1482,7 +1489,9 @@ export class PsbtComposeComponent implements OnInit {
     const rate = this.effectiveFeeRate();
     if (rate === null || rate <= 0) return null;
     const nIn = this.manualCoins() ? Math.max(1, this.selectedOutpoints().size) : 1;
-    const nOut = this.outputs().length + 1 + (this.showData() ? 1 : 0);
+    // MAX (subtract-fee) drains — there is no change output to pay for.
+    const change = this.subtractFeeIndex() !== null ? 0 : 1;
+    const nOut = this.outputs().length + change + (this.showData() ? 1 : 0);
     const vsize = 11 + nIn * 68 + nOut * 31;
     return (rate * vsize) / 1e8;
   });

--- a/web-wallet/src/app/features/send/pages/send/send.component.ts
+++ b/web-wallet/src/app/features/send/pages/send/send.component.ts
@@ -1276,8 +1276,10 @@ export class SendComponent implements OnInit, OnDestroy {
 
     if (feeRate === null) return;
 
-    // Estimate transaction size (P2WPKH with change output: ~170 vbytes for 1-in-2-out)
-    const estimatedVBytes = 170;
+    // Estimated size for the typical 1-in-2-out P2WPKH send: 11 + 68 + 2*31
+    // = 141 vB — the same formula the Transaction Builder uses, so the two
+    // screens quote the same fee for the same rate.
+    const estimatedVBytes = 141;
     const feeInSats = feeRate * estimatedVBytes;
     this.selectedFeeOption.estimatedFee = feeInSats / 100000000;
   }


### PR DESCRIPTION
Four Transaction Builder fee findings, per Johnny's ruling (0.1 sat/vB
supported everywhere — Core v30 relay floor; integer sat/kvB internal,
f64 only at human edges):

1. Custom 0.1 sat/vB silently paid 1 sat/vB: the btcx crate floored
   explicit rates at min_feerate_sat_vb (integer sat/vB, could not even
   express 0.1). Crate reworked to min_feerate_sat_kvb (100 = 0.1,
   btcx@9d29326); rev bumped; the fee-preset floor edge converts
   kvb/1000 for display.
2. The builder's estimated fee ignored the custom rate input — the
   estimate only recomputed on feeVersion bumps and the input never
   bumped it. Now it does.
3. Review showed "unknown" fee rate pre-finalize in remote mode:
   btcx_psbt_analyze only computed vsize on extractable PSBTs. It now
   ESTIMATES vsize for open inputs (P2WPKH ~108 WU, P2TR ~66 WU +
   marker/flag), so fee rate shows from the first review.
4. Send estimated 170 sat where the builder said 141 for the same tx:
   Send hardcoded 170 vB; aligned to the builder's 1-in-2-out P2WPKH
   formula (141 vB). The builder also stops estimating a change output
   in MAX/drain mode (real case: 110 vB, not 141).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX
