### PR TITLE
chore(deps): repin btcx to the merged master SHA (f9c51fc)

### DIFF
--- a/web-wallet/src-tauri/Cargo.lock
+++ b/web-wallet/src-tauri/Cargo.lock
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "electrum-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972#f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972"
 dependencies = [
  "anyhow",
  "bdk_wallet",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "keys-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972#f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972"
 dependencies = [
  "anyhow",
  "bip39",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "params-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972#f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5319,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "seedstore"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972#f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972"
 dependencies = [
  "anyhow",
  "bip39",
@@ -7267,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "wallet-btcx"
 version = "0.1.0"
-source = "git+https://github.com/PoC-Consortium/btcx?rev=b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e#b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e"
+source = "git+https://github.com/PoC-Consortium/btcx?rev=f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972#f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972"
 dependencies = [
  "anyhow",
  "bdk_wallet",

--- a/web-wallet/src-tauri/Cargo.toml
+++ b/web-wallet/src-tauri/Cargo.toml
@@ -100,11 +100,11 @@ pocx_aggregator = { version = "1.0.5", optional = true }
 
 
 # Nodeless BTCX wallet stack (shared btcx crates) — gated by the `wallet` feature
-params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
-keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
-seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
-electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
-wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "b45d6bd5fbd6bb39fec5eb1898fe1ff14c41de9e", optional = true }
+params-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972", optional = true }
+keys-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972", optional = true }
+seedstore = { git = "https://github.com/PoC-Consortium/btcx", rev = "f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972", optional = true }
+electrum-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972", optional = true }
+wallet-btcx = { git = "https://github.com/PoC-Consortium/btcx", rev = "f9c51fcf5a0b2209099a4fb9ac51f406a4f3c972", optional = true }
 bitcoin = { version = "0.32", features = ["serde", "rand-std"], optional = true }
 bdk_wallet = { version = "2", features = ["rusqlite"], optional = true }
 # bech32 with custom HRPs (pocx/tpocx/rpocx) â€” same version the btcx crates use


### PR DESCRIPTION
b45d6bd was a branch commit — orphaned after the squash-merge deleted
the branch; pin the reachable master commit (identical content).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX
