### PR TITLE
feat(receive): enumerate revealed addresses in Electrum mode

### DIFF
--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -1924,6 +1924,65 @@ pub struct BtcxTxProbe {
     pub tip: u32,
 }
 
+/// One revealed external (receive) address of the open wallet.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BtcxWalletAddressDto {
+    pub address: String,
+    pub index: u32,
+    /// Some transaction in the wallet's history pays this address.
+    pub used: bool,
+    /// Currently holds an unspent output.
+    pub funded: bool,
+}
+
+/// Every revealed external address with used/funded flags — the remote
+/// counterpart of the Core receive page's address enumeration. Pure local
+/// read (keychain index + synced tx graph), no server traffic.
+#[tauri::command]
+pub fn btcx_wallet_addresses(
+    state: State<'_, SharedBtcxWalletState>,
+) -> Result<Vec<BtcxWalletAddressDto>, String> {
+    use bdk_wallet::KeychainKind;
+    let network = state.get_config().network;
+    state.with_entry(|entry| {
+        let last = entry.wallet.derivation_index(KeychainKind::External);
+        // Non-wildcard (single-address WIF) descriptors reveal no index —
+        // peek(0) still yields the one fixed address.
+        let upto = last.unwrap_or(0);
+        // One pass over the history: every output script that ever received.
+        let mut received: std::collections::HashSet<bitcoin::ScriptBuf> =
+            std::collections::HashSet::new();
+        for wtx in entry.wallet.transactions() {
+            for out in &wtx.tx_node.tx.output {
+                received.insert(out.script_pubkey.clone());
+            }
+        }
+        let funded: std::collections::HashSet<bitcoin::ScriptBuf> = entry
+            .wallet
+            .list_unspent()
+            .map(|u| u.txout.script_pubkey.clone())
+            .collect();
+        let list = (0..=upto)
+            .map(|i| {
+                let spk = entry
+                    .wallet
+                    .peek_address(KeychainKind::External, i)
+                    .address
+                    .script_pubkey();
+                BtcxWalletAddressDto {
+                    address: super::psbt::spk_to_address(network, &spk).unwrap_or_default(),
+                    index: i,
+                    used: received.contains(&spk),
+                    funded: funded.contains(&spk),
+                }
+            })
+            .filter(|a| !a.address.is_empty())
+            .collect();
+        Ok(list)
+    })
+}
+
 #[tauri::command]
 pub fn btcx_wallet_tx_probe(
     state: State<'_, SharedBtcxWalletState>,

--- a/web-wallet/src-tauri/src/lib.rs
+++ b/web-wallet/src-tauri/src/lib.rs
@@ -1122,6 +1122,8 @@ pub fn run() {
             #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_transactions,
             #[cfg(feature = "wallet")]
+            btcx_wallet::commands::btcx_wallet_addresses,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_tx_probe,
             #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_tx_detail,

--- a/web-wallet/src/app/core/services/btcx-wallet.service.ts
+++ b/web-wallet/src/app/core/services/btcx-wallet.service.ts
@@ -1044,6 +1044,12 @@ export class BtcxWalletService {
    * `limit: 0` is a cheap count-only query (no items, no per-item work).
    * Both absent = the full history. Throws on failure.
    */
+  /** Every revealed external address with used/funded flags — the remote
+   *  receive page's address enumeration. Pure local read. */
+  async addresses(): Promise<{ address: string; index: number; used: boolean; funded: boolean }[]> {
+    return invoke('btcx_wallet_addresses');
+  }
+
   /** Near-free change probe: history size + tip. Callers compare with the
    *  last probe and skip refetching the list when nothing moved. */
   async txProbe(): Promise<{ total: number; tip: number }> {

--- a/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
+++ b/web-wallet/src/app/features/receive/pages/receive/receive.component.ts
@@ -670,11 +670,29 @@ export class ReceiveComponent implements OnInit, OnDestroy {
       if (this.canEnumerate()) {
         await this.loadExistingAddressList(walletName, current);
       } else {
-        this.existingAddresses.set(
-          current
-            ? [{ address: current, purpose: 'receive', isUsed: false, txCount: 0, label: '' }]
-            : []
-        );
+        // Remote/BDK: enumerate every revealed external address locally
+        // (used/funded flags from the synced graph) — newest first, same
+        // as the Core list; the current first-unused is always present.
+        const revealed = await this.btcxWallet.addresses();
+        const list = revealed
+          .sort((a, b) => b.index - a.index)
+          .map(a => ({
+            address: a.address,
+            purpose: 'receive',
+            isUsed: a.used || a.funded,
+            txCount: 0,
+            label: '',
+          }));
+        if (current && !list.some(a => a.address === current)) {
+          list.unshift({
+            address: current,
+            purpose: 'receive',
+            isUsed: false,
+            txCount: 0,
+            label: '',
+          });
+        }
+        this.existingAddresses.set(list);
       }
       this.selectedAddress.set(current);
     } catch (error) {


### PR DESCRIPTION
The receive selector in remote mode only showed the current first-unused
address — the enumeration path was Core-RPC-only (canEnumerate gate)
because no btcx equivalent existed. New btcx_wallet_addresses serves
every revealed external address with used/funded flags from the local
keychain index + synced tx graph (zero server traffic; single-address
WIF wallets yield their one entry). The remote branch consumes it
newest-first with the same (never used) tagging as Core, current
first-unused always present and preselected.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX
