### PR TITLE
fix(dashboard): recent-transactions fit flicker on mid widths

### DIFF
--- a/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/web-wallet/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -1084,6 +1084,27 @@ import { MiningService } from '../../../../mining/services';
           width: 100%;
           border-collapse: collapse;
           font-size: 13px;
+          /* FIXED layout: with auto layout the column widths depend on the
+             RENDERED ROWS, so the fit loop (rows -> widths -> wrapping ->
+             row height -> fit) oscillated on mid widths (pad landscape).
+             Fixed widths + ellipsis make row height width-independent. */
+          table-layout: fixed;
+
+          th.col-datetime {
+            width: 96px;
+          }
+          th.col-type {
+            width: 64px;
+          }
+          th.col-amount {
+            width: 140px;
+          }
+          th.col-status {
+            width: 88px;
+          }
+          th.col-actions {
+            width: 44px;
+          }
 
           thead {
             th {
@@ -1180,10 +1201,13 @@ import { MiningService } from '../../../../mining/services';
               }
 
               .address-text {
+                display: block;
                 font-family: monospace;
                 font-size: 11px;
                 color: rgb(0, 35, 65);
-                word-break: break-all;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
               }
             }
 
@@ -1199,11 +1223,14 @@ import { MiningService } from '../../../../mining/services';
 
             .col-txid {
               .txid-text {
+                display: block;
                 font-family: monospace;
                 font-size: 10px;
                 color: #1565c0;
                 cursor: pointer;
-                word-break: break-all;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
 
                 &:hover {
                   text-decoration: underline;


### PR DESCRIPTION
With table-layout: auto the column widths depend on the RENDERED rows:
adding the Nth row squeezed the txid column past its wrap point, every
row doubled in height, the fit dropped, the row left, the columns
relaxed, the fit rose — a content-driven oscillation (pad landscape,
1100+ widths) the fit directive's deadband cannot see. table-layout:
fixed with set column widths + nowrap/ellipsis on the address and txid
cells makes row height width-independent, breaking the loop
structurally. Verified: consecutive frame captures hash-identical.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX
