### PR TITLE
fix(build): 2.4.0 release repair — wallet-feature gate + CI greens

### DIFF
--- a/web-wallet/package-lock.json
+++ b/web-wallet/package-lock.json
@@ -3325,24 +3325,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3383,9 +3365,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3395,7 +3377,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -3421,24 +3403,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
@@ -3472,9 +3436,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8233,16 +8197,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -8754,13 +8718,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -9696,9 +9653,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9707,8 +9664,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -9849,24 +9806,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
@@ -10549,24 +10488,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.5",
@@ -11663,24 +11584,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/karma-coverage/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma-coverage/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/karma-coverage/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
@@ -11776,13 +11679,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/karma/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/karma/node_modules/body-parser": {
       "version": "1.20.6",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
@@ -11806,17 +11702,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/karma/node_modules/chokidar": {

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -80,6 +80,7 @@
     "typescript-eslint": "^8.61.1"
   },
   "overrides": {
+    "brace-expansion": "^5.0.8",
     "serialize-javascript": "^7.0.3",
     "@babel/core": "^7.29.7",
     "esbuild": "^0.28.1",

--- a/web-wallet/src-tauri/src/btcx_wallet/commands.rs
+++ b/web-wallet/src-tauri/src/btcx_wallet/commands.rs
@@ -1729,7 +1729,9 @@ pub fn first_address_impl(state: &SharedBtcxWalletState) -> Result<String, Strin
             .wallet
             .persist(&mut entry.conn)
             .map_err(|e| format!("persisting wallet: {e}"))?;
-        let info = entry.wallet.peek_address(bdk_wallet::KeychainKind::External, 0);
+        let info = entry
+            .wallet
+            .peek_address(bdk_wallet::KeychainKind::External, 0);
         super::psbt::spk_to_address(network, &info.address.script_pubkey())
             .ok_or_else(|| "Unsupported address script".to_string())
     })?;

--- a/web-wallet/src-tauri/src/lib.rs
+++ b/web-wallet/src-tauri/src/lib.rs
@@ -1117,6 +1117,7 @@ pub fn run() {
             btcx_wallet::commands::btcx_wallet_new_address,
             #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_current_address,
+            #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_first_address,
             #[cfg(feature = "wallet")]
             btcx_wallet::commands::btcx_wallet_balance,

--- a/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
+++ b/web-wallet/src/app/features/mobile-wallet/layout/mobile-wallet-layout.component.ts
@@ -322,7 +322,7 @@ interface NavGroup {
                     importLink="/wallet/import"
                     (selectGroup)="switchToGroup($event)"
                     (requestClose)="walletMenuTrigger.closeMenu()"
-                  /></mat-menu>
+                /></mat-menu>
 
                 <!-- Pocket chip (icon-only): the active wallet's
                      compartments, greyed out while nothing is open or

--- a/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
+++ b/web-wallet/src/app/features/psbt/pages/psbt/psbt.component.ts
@@ -2441,5 +2441,4 @@ export class PsbtComponent implements OnInit {
   shortId(id: string): string {
     return `${id.slice(0, 8)}…${id.slice(-4)}`;
   }
-
 }

--- a/web-wallet/src/app/features/send/pages/send/send.component.ts
+++ b/web-wallet/src/app/features/send/pages/send/send.component.ts
@@ -339,7 +339,6 @@ const SANE_PRESET_MAX_SAT_VB = 200;
                   <span>{{ 'insufficient_balance' | i18n }}</span>
                 </div>
               }
-
             </div>
 
             <!-- Error Display -->

--- a/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-detail/transaction-detail.component.ts
@@ -1458,7 +1458,8 @@ export class TransactionDetailComponent implements OnInit {
       // Navigate to the new transaction
       this.loadTransaction(newTxid);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error) || this.i18n.get('bump_fee_error');
+      const message =
+        error instanceof Error ? error.message : String(error) || this.i18n.get('bump_fee_error');
       this.notification.error(message);
     }
   }

--- a/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
+++ b/web-wallet/src/app/features/transactions/pages/transaction-list/transaction-list.component.ts
@@ -1509,7 +1509,8 @@ export class TransactionListComponent implements OnInit, OnDestroy {
       // Also refresh wallet service for balance updates
       this.walletService.refresh();
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error) || this.i18n.get('bump_fee_error');
+      const message =
+        error instanceof Error ? error.message : String(error) || this.i18n.get('bump_fee_error');
       this.notification.error(message);
     }
   }
@@ -1554,7 +1555,8 @@ export class TransactionListComponent implements OnInit, OnDestroy {
       this.loadTransactions();
       this.walletService.refresh();
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error) || this.i18n.get('cpfp_error');
+      const message =
+        error instanceof Error ? error.message : String(error) || this.i18n.get('cpfp_error');
       this.notification.error(message);
     }
   }

--- a/web-wallet/src/app/features/wallet-setup/restore-wallet-flow.component.ts
+++ b/web-wallet/src/app/features/wallet-setup/restore-wallet-flow.component.ts
@@ -1,4 +1,13 @@
-import { Component, OnInit, ViewChild, computed, inject, input, output, signal } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -185,7 +194,9 @@ import {
               <button
                 mat-raised-button
                 color="primary"
-                [disabled]="!mnemonicValid() || nameSection.hasError() || !protect.valid() || restoring()"
+                [disabled]="
+                  !mnemonicValid() || nameSection.hasError() || !protect.valid() || restoring()
+                "
                 (click)="restore()"
               >
                 @if (restoring()) {

--- a/web-wallet/src/app/layout/toolbar/toolbar.component.ts
+++ b/web-wallet/src/app/layout/toolbar/toolbar.component.ts
@@ -253,96 +253,96 @@ import { ElectrumServerListComponent } from '../../shared/components/electrum-se
                   (requestClose)="walletMenuTrigger.closeMenu()"
                 />
               } @else {
-              <button mat-menu-item (click)="manageWallets()" class="manage-wallets-item">
-                <mat-icon>settings</mat-icon>
-                <span>{{ 'manage_wallets' | i18n }}</span>
-              </button>
-              <mat-divider></mat-divider>
-              @for (wallet of wallets(); track wallet.name) {
-                <button
-                  mat-menu-item
-                  class="wallet-row"
-                  [class.wallet-loaded]="wallet.isLoaded"
-                  [class.wallet-unloaded]="!wallet.isLoaded"
-                  (click)="selectWallet(wallet)"
-                  [disabled]="isWalletLoading(wallet.name)"
-                >
-                  <div class="wallet-row-content">
-                    <!-- Column 1: Wallet icon -->
-                    <mat-icon class="wallet-row-icon">account_balance_wallet</mat-icon>
-                    <!-- Column 2: Wallet name (+ multisig glyph) -->
-                    <span class="wallet-row-name">{{ wallet.name || '(default)' }}</span>
-                    @if (wallet.multisig) {
-                      <mat-icon
-                        class="wallet-row-multisig"
-                        [matTooltip]="
-                          'msig_wallet_tooltip'
-                            | i18n
-                              : {
-                                  required: wallet.multisig.requiredSigs,
-                                  total: wallet.multisig.totalKeys,
-                                }
-                        "
-                        >group</mat-icon
-                      >
-                    }
-                    <!-- Column 3: Watch-only indicator (only for loaded watch-only wallets) -->
-                    @if (wallet.isLoaded && wallet.isWatchOnly) {
-                      <mat-icon class="wallet-row-watch" matTooltip="{{ 'watch_only' | i18n }}"
-                        >visibility</mat-icon
-                      >
-                    } @else {
-                      <span class="wallet-row-watch-placeholder"></span>
-                    }
-                    <!-- Column 4: Lock status. Not gated on isLoaded: a
+                <button mat-menu-item (click)="manageWallets()" class="manage-wallets-item">
+                  <mat-icon>settings</mat-icon>
+                  <span>{{ 'manage_wallets' | i18n }}</span>
+                </button>
+                <mat-divider></mat-divider>
+                @for (wallet of wallets(); track wallet.name) {
+                  <button
+                    mat-menu-item
+                    class="wallet-row"
+                    [class.wallet-loaded]="wallet.isLoaded"
+                    [class.wallet-unloaded]="!wallet.isLoaded"
+                    (click)="selectWallet(wallet)"
+                    [disabled]="isWalletLoading(wallet.name)"
+                  >
+                    <div class="wallet-row-content">
+                      <!-- Column 1: Wallet icon -->
+                      <mat-icon class="wallet-row-icon">account_balance_wallet</mat-icon>
+                      <!-- Column 2: Wallet name (+ multisig glyph) -->
+                      <span class="wallet-row-name">{{ wallet.name || '(default)' }}</span>
+                      @if (wallet.multisig) {
+                        <mat-icon
+                          class="wallet-row-multisig"
+                          [matTooltip]="
+                            'msig_wallet_tooltip'
+                              | i18n
+                                : {
+                                    required: wallet.multisig.requiredSigs,
+                                    total: wallet.multisig.totalKeys,
+                                  }
+                          "
+                          >group</mat-icon
+                        >
+                      }
+                      <!-- Column 3: Watch-only indicator (only for loaded watch-only wallets) -->
+                      @if (wallet.isLoaded && wallet.isWatchOnly) {
+                        <mat-icon class="wallet-row-watch" matTooltip="{{ 'watch_only' | i18n }}"
+                          >visibility</mat-icon
+                        >
+                      } @else {
+                        <span class="wallet-row-watch-placeholder"></span>
+                      }
+                      <!-- Column 4: Lock status. Not gated on isLoaded: a
                          LOCKED btcx wallet is by definition unloaded and
                          needs the padlock as its unlock affordance. -->
-                    @if (
-                      (wallet.isLoaded || isWalletLocked(wallet)) &&
-                      !wallet.isWatchOnly &&
-                      wallet.isEncrypted
-                    ) {
-                      @if (isWalletLocked(wallet)) {
+                      @if (
+                        (wallet.isLoaded || isWalletLocked(wallet)) &&
+                        !wallet.isWatchOnly &&
+                        wallet.isEncrypted
+                      ) {
+                        @if (isWalletLocked(wallet)) {
+                          <mat-icon
+                            class="wallet-row-lock wallet-row-lock-action wallet-lock-encrypted-locked"
+                            (click)="onUnlockClick(wallet, $event)"
+                            [matTooltip]="'unlock_wallet_for_session_tooltip' | i18n"
+                            >lock</mat-icon
+                          >
+                        } @else {
+                          <mat-icon
+                            class="wallet-row-lock wallet-row-lock-action wallet-lock-encrypted-unlocked"
+                            (click)="onLockClick(wallet, $event)"
+                            [matTooltip]="'lock_wallet_tooltip' | i18n"
+                            >lock_open</mat-icon
+                          >
+                        }
+                      } @else if (!wallet.isWatchOnly) {
+                        <span class="wallet-row-lock-placeholder"></span>
+                      }
+                      <!-- Column 5: Load (unloaded) / Eject (loaded) action -->
+                      @if (wallet.isLoaded) {
                         <mat-icon
-                          class="wallet-row-lock wallet-row-lock-action wallet-lock-encrypted-locked"
-                          (click)="onUnlockClick(wallet, $event)"
-                          [matTooltip]="'unlock_wallet_for_session_tooltip' | i18n"
-                          >lock</mat-icon
+                          class="wallet-row-eject"
+                          (click)="ejectWallet(wallet, $event)"
+                          matTooltip="{{ 'unload_wallet' | i18n }}"
+                          >eject</mat-icon
                         >
                       } @else {
                         <mat-icon
-                          class="wallet-row-lock wallet-row-lock-action wallet-lock-encrypted-unlocked"
-                          (click)="onLockClick(wallet, $event)"
-                          [matTooltip]="'lock_wallet_tooltip' | i18n"
-                          >lock_open</mat-icon
+                          class="wallet-row-load"
+                          (click)="onLoadClick(wallet, $event)"
+                          matTooltip="{{ 'load_wallet' | i18n }}"
+                          >play_arrow</mat-icon
                         >
                       }
-                    } @else if (!wallet.isWatchOnly) {
-                      <span class="wallet-row-lock-placeholder"></span>
-                    }
-                    <!-- Column 5: Load (unloaded) / Eject (loaded) action -->
-                    @if (wallet.isLoaded) {
-                      <mat-icon
-                        class="wallet-row-eject"
-                        (click)="ejectWallet(wallet, $event)"
-                        matTooltip="{{ 'unload_wallet' | i18n }}"
-                        >eject</mat-icon
-                      >
-                    } @else {
-                      <mat-icon
-                        class="wallet-row-load"
-                        (click)="onLoadClick(wallet, $event)"
-                        matTooltip="{{ 'load_wallet' | i18n }}"
-                        >play_arrow</mat-icon
-                      >
-                    }
-                    <!-- Loading spinner -->
-                    @if (isWalletLoading(wallet.name)) {
-                      <mat-spinner diameter="16" class="wallet-row-spinner"></mat-spinner>
-                    }
-                  </div>
-                </button>
-              }
+                      <!-- Loading spinner -->
+                      @if (isWalletLoading(wallet.name)) {
+                        <mat-spinner diameter="16" class="wallet-row-spinner"></mat-spinner>
+                      }
+                    </div>
+                  </button>
+                }
               }
             </mat-menu>
 

--- a/web-wallet/src/app/shared/components/verify-words/verify-words.component.ts
+++ b/web-wallet/src/app/shared/components/verify-words/verify-words.component.ts
@@ -132,9 +132,7 @@ export class VerifyWordsComponent {
 
   /** True once every requested word is typed correctly. */
   passed(): boolean {
-    return (
-      this.verifyIndices.length > 0 && this.verifyIndices.every((_, i) => this.wordCorrect(i))
-    );
+    return this.verifyIndices.length > 0 && this.verifyIndices.every((_, i) => this.wordCorrect(i));
   }
 
   updateSuggestions(index: number, value: string): void {

--- a/web-wallet/src/app/shared/components/wallet-group-menu/wallet-group-menu.component.ts
+++ b/web-wallet/src/app/shared/components/wallet-group-menu/wallet-group-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, output, signal } from '@angular/core';
+import { Component, inject, input, output, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';


### PR DESCRIPTION
Repairs the v2.4.0 release builds: the new `btcx_wallet_first_address` registration was missing its `#[cfg(feature = "wallet")]`, breaking every wallet-less build (mining APK flavor, macOS miner launcher → both macOS release jobs). Plus the three CI gates: rustfmt over the 2.4.0 Rust changes, one unused import (ESLint), and a `brace-expansion ^5.0.8` override for the fresh high advisory (GHSA-mh99-v99m-4gvg).

Verified locally: mining-only cargo build, fmt --check, lint, `npm audit --audit-level=high` exit 0, web build + unit tests green.

After merge: v2.4.0 tag will be re-cut on master and the draft release rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hXCcbdPZEZVf9baPrp5RX